### PR TITLE
tests fail in some cultures that have different date formats (en-AU, etc...)

### DIFF
--- a/test/WebJobs.Extensions.Tests/Timers/TimerInfoTests.cs
+++ b/test/WebJobs.Extensions.Tests/Timers/TimerInfoTests.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
+using System.Threading;
+
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Xunit;
 
@@ -9,6 +12,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 {
     public class TimerInfoTests
     {
+        public TimerInfoTests()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+        }
+
         [Fact]
         public void FormatNextOccurrences_ReturnsExpectedString()
         {


### PR DESCRIPTION
One more place that could have the same behavior in (https://github.com/Azure/azure-webjobs-sdk-extensions/issues/15)