### PR TITLE
docdb partition support

### DIFF
--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -69,8 +69,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.5\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.5.3\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -251,8 +251,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ExtensionsSample/Models/ItemDoc.cs
+++ b/src/ExtensionsSample/Models/ItemDoc.cs
@@ -10,6 +10,9 @@ namespace ExtensionsSample.Models
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        [JsonProperty("partition")]
+        public string Partition { get; set; }
+
         [JsonProperty("text")]
         public string Text { get; set; }
     }

--- a/src/ExtensionsSample/Samples/DocumentDBSamples.cs
+++ b/src/ExtensionsSample/Samples/DocumentDBSamples.cs
@@ -28,11 +28,10 @@ namespace ExtensionsSample.Samples
         //   ICollector<T>
         public static void InsertDocument(
             [TimerTrigger("00:01")] TimerInfo timer,
-            [DocumentDB("ItemDb", "ItemCollection")] out Item newItem)
+            [DocumentDB("ItemDb", "ItemCollection")] out ItemDoc newItem)
         {
-            newItem = new Item()
+            newItem = new ItemDoc()
             {
-                Id = Guid.NewGuid().ToString(),
                 Text = new Random().Next().ToString()
             };
         }

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebHooks.Receivers" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Receivers.GitHub" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.5" targetFramework="net45" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.5.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10271" targetFramework="net45" />

--- a/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBItemBindingContext.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBItemBindingContext.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    internal class DocumentDBItemBindingContext
+    {
+        public string Id { get; set; }
+        public string PartitionKey { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBOutputBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBOutputBindingProvider.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
@@ -20,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             _converterManager = converterManager;
         }
 
-        public Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
         {
             if (context == null)
             {
@@ -31,10 +34,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
             if (IsTypeValid(parameter.ParameterType))
             {
+                if (_context.CreateIfNotExists)
+                {
+                    await CreateIfNotExistAsync(_context.Service, _context.ResolvedDatabaseName,
+                        _context.ResolvedCollectionName, _context.ResolvedPartitionKey, _context.CollectionThroughput);
+                }
+
                 return CreateBinding(parameter, _context, _converterManager);
             }
 
-            return Task.FromResult<IBinding>(null);
+            return null;
         }
 
         internal static bool IsTypeValid(Type type)
@@ -46,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             return isValidOut || isValidCollector;
         }
 
-        internal static Task<IBinding> CreateBinding(ParameterInfo parameter, DocumentDBContext context, IConverterManager converterManager)
+        internal static IBinding CreateBinding(ParameterInfo parameter, DocumentDBContext context, IConverterManager converterManager)
         {
             IBinding binding = null;
             Type coreType = TypeUtility.GetCoreType(parameter.ParameterType);
@@ -66,7 +75,43 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
                 ExceptionDispatchInfo.Capture(ex).Throw();
             }
-            return Task.FromResult<IBinding>(binding);
+            return binding;
+        }
+
+        internal static async Task CreateIfNotExistAsync(IDocumentDBService service, string databaseName,
+         string documentCollectionName, string partitionKeyPath, int throughput)
+        {
+            Uri databaseUri = UriFactory.CreateDatabaseUri(databaseName);
+            Database database = new Database { Id = databaseName };
+
+            DocumentCollection documentCollection = new DocumentCollection
+            {
+                Id = documentCollectionName
+            };
+
+            if (!string.IsNullOrEmpty(partitionKeyPath))
+            {
+                documentCollection.PartitionKey.Paths.Add(partitionKeyPath);
+            }
+
+            // If there is any throughput specified, pass it on. DocumentClient will throw with a 
+            // descriptive message if the value does not meet the collection requirements.
+            RequestOptions collectionOptions = null;
+            if (throughput != 0)
+            {
+                collectionOptions = new RequestOptions
+                {
+                    OfferThroughput = throughput
+                };
+            }
+
+            // If we queried for the Database or Collection before creation, we may hit a race condition
+            // if multiple instances are running the same code. So let's just create and ignore a Conflict.
+            await DocumentDBUtility.ExecuteAndIgnoreStatusCodeAsync(HttpStatusCode.Conflict,
+                    () => service.CreateDatabaseAsync(database));
+
+            await DocumentDBUtility.ExecuteAndIgnoreStatusCodeAsync(HttpStatusCode.Conflict,
+                () => service.CreateDocumentCollectionAsync(databaseUri, documentCollection, collectionOptions));
         }
     }
 }

--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBAttribute.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBAttribute.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Azure.WebJobs
         public string CollectionName { get; private set; }
 
         /// <summary>
+        /// Optional.
+        /// Only applies to output bindings.
         /// If true, the database and collection will be automatically created if they do not exist.
         /// </summary>
         public bool CreateIfNotExists { get; set; }
@@ -64,8 +66,24 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>
         /// Optional. The Id of the document to retrieve from the collection.
-        /// May include binding parameters
+        /// May include binding parameters.
         /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// When specified on an output binding and <see cref="CreateIfNotExists"/> is true, defines the partition key 
+        /// path for the created collection.
+        /// When specified on an input binding, specifies the partition key value for the lookup.
+        /// May include binding parameters.
+        /// </summary>
+        public string PartitionKey { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// When specified on an output binding and <see cref="CreateIfNotExists"/> is true, defines the throughput of the created
+        /// collection.
+        /// </summary>
+        public int CollectionThroughput { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBContext.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBContext.cs
@@ -20,5 +20,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         public string ResolvedId { get; set; }
         public int MaxThrottleRetries { get; set; }
         public TraceWriter Trace { get; set; }
+        public string ResolvedPartitionKey { get; set; }
+        public bool CreateIfNotExists { get; set; }
+        public int CollectionThroughput { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.DocumentDB/Services/DocumentDBService.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Services/DocumentDBService.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             return _client;
         }
 
-        public async Task<DocumentCollection> CreateDocumentCollectionAsync(Uri databaseUri, DocumentCollection documentCollection)
+        public async Task<DocumentCollection> CreateDocumentCollectionAsync(Uri databaseUri, DocumentCollection documentCollection, RequestOptions options)
         {
-            ResourceResponse<DocumentCollection> response = await _client.CreateDocumentCollectionAsync(databaseUri, documentCollection);
+            ResourceResponse<DocumentCollection> response = await _client.CreateDocumentCollectionAsync(databaseUri, documentCollection, options);
             return response.Resource;
         }
 
@@ -49,9 +49,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             return response.Resource;
         }
 
-        public async Task<T> ReadDocumentAsync<T>(Uri documentUri)
+        public async Task<T> ReadDocumentAsync<T>(Uri documentUri, RequestOptions options)
         {
-            ResourceResponse<Document> response = await _client.ReadDocumentAsync(documentUri);
+            ResourceResponse<Document> response = await _client.ReadDocumentAsync(documentUri, options);
             return (T)(dynamic)response.Resource;
         }
 

--- a/src/WebJobs.Extensions.DocumentDB/Services/IDocumentDBService.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Services/IDocumentDBService.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         /// </summary>
         /// <param name="databaseUri">The self-link of the database to create the collection in.</param>
         /// <param name="documentCollection">The <see cref="DocumentCollection"/> to create.</param>
+        /// <param name="options">The <see cref="RequestOptions"/> for the request.</param>
         /// <returns>The task object representing the service response for the asynchronous operation.</returns>
-        Task<DocumentCollection> CreateDocumentCollectionAsync(Uri databaseUri, DocumentCollection documentCollection);
+        Task<DocumentCollection> CreateDocumentCollectionAsync(Uri databaseUri, DocumentCollection documentCollection, RequestOptions options);
 
         /// <summary>
         /// Inserts or replaces a document.
@@ -40,8 +41,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         /// Reads a document.
         /// </summary>
         /// <param name="documentUri">The self-link of the document.</param>
+        /// <param name="options">The <see cref="RequestOptions"/> for the request.</param>
         /// <returns>The task object representing the service response for the asynchronous operation.</returns>
-        Task<T> ReadDocumentAsync<T>(Uri documentUri);
+        Task<T> ReadDocumentAsync<T>(Uri documentUri, RequestOptions options);
 
         /// <summary>
         /// Replaces a document.

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -40,8 +40,8 @@
     <DocumentationFile>bin\Release\Microsoft.Azure.WebJobs.Extensions.DocumentDB.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.5.3\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -102,6 +102,7 @@
     <Compile Include="Bindings\DocumentDBItemBinding.cs" />
     <Compile Include="Bindings\DocumentDBItemValueBinder.cs" />
     <Compile Include="Bindings\DocumentDBOutputBindingProvider.cs" />
+    <Compile Include="Bindings\DocumentDBItemBindingContext.cs" />
     <Compile Include="Config\DefaultDocumentDBServiceFactory.cs" />
     <Compile Include="Config\DocumentDBConfiguration.cs" />
     <Compile Include="Config\DocumentDBConnectionString.cs" />
@@ -137,7 +138,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.DocumentDB" version="1.5.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10271" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10271" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
+++ b/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
@@ -61,11 +61,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.1.2-alpha-10267\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.1.2-alpha-10271\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=1.1.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.1.2-alpha-10267\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.1.1.2-alpha-10271\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Extensions.NotificationHubs/packages.config
+++ b/src/WebJobs.Extensions.NotificationHubs/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10267" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10267" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10271" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10271" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBItemBindingTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBItemBindingTests.cs
@@ -13,6 +13,7 @@ using DocumentDB::Microsoft.Azure.WebJobs.Extensions.DocumentDB;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Models;
 using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
@@ -60,25 +61,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
         public void ResolveId_CreatesExpectedString(string token, string expected)
         {
             // Arrange
-            ParameterInfo parameter = DocumentDBTestUtility.GetValidItemInputParameters().First();
-
-            var docDbContext = new DocumentDBContext()
-            {
-                ResolvedId = token
-            };
-
+            var template = BindingTemplate.FromString(token);
             var bindingContract = new Dictionary<string, Type>();
             bindingContract.Add("MyItemId", typeof(string));
-
-            var bindingProviderContext = new BindingProviderContext(parameter, bindingContract, CancellationToken.None);
-
-            var binding = new DocumentDBItemBinding(parameter, docDbContext, bindingProviderContext);
 
             var bindingData = new Dictionary<string, object>();
             bindingData.Add("MyItemId", "abc123");
 
             // Act
-            var resolved = binding.ResolveId(bindingData);
+            var resolved = DocumentDBItemBinding.ResolveTemplate(template, bindingData);
 
             // Assert
             Assert.Equal(expected, resolved);

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBOutputBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBOutputBindingProviderTests.cs
@@ -2,11 +2,20 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 extern alias DocumentDB;
-
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DocumentDB::Microsoft.Azure.WebJobs;
 using DocumentDB::Microsoft.Azure.WebJobs.Extensions.DocumentDB;
 using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Models;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -14,6 +23,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
 {
     public class DocumentDBOutputBindingProviderTests
     {
+        private const string DatabaseName = "TestDatabase";
+        private const string CollectionName = "TestCollection";
+        private readonly Uri databaseUri = UriFactory.CreateDatabaseUri(DatabaseName);
+
         [Theory]
         [InlineData(typeof(Item), true, true)]
         [InlineData(typeof(JObject), true, true)]
@@ -37,6 +50,187 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
 
             // Assert
             Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task CreateIfNotExists_DoesNotCreate_IfFalse()
+        {
+            // Arrange
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+            var config = new DocumentDBConfiguration
+            {
+                ConnectionString = "AccountEndpoint=http://someuri;AccountKey=some_key",
+                DocumentDBServiceFactory = new TestDocumentDBServiceFactory(mockService.Object)
+            };
+            var attribute = new DocumentDBAttribute { CreateIfNotExists = false };
+            var provider = new DocumentDBAttributeBindingProvider(new JobHostConfiguration(), config, new TestTraceWriter());
+
+            // Act
+            await provider.TryCreateAsync(new BindingProviderContext(DocumentDBTestUtility.GetCreateIfNotExistsParameters().First(), null, CancellationToken.None));
+
+            // Assert
+            // Nothing to assert. Since the service was null, it was never called.
+        }
+
+        [Theory]
+        [InlineData(null, 100)]
+        [InlineData("partitionKeyPath", 1000)]
+        public async Task CreateIfNotExists_Creates_IfTrue(string partitionKeyPath, int collectionThroughput)
+        {
+            // Arrange
+            DocumentDBContext context = null;
+            var mockService = InitializeMockService(partitionKeyPath, collectionThroughput, out context);
+
+            var expectedPaths = new List<string>();
+            if (!string.IsNullOrEmpty(partitionKeyPath))
+            {
+                expectedPaths.Add(partitionKeyPath);
+            }
+
+            mockService
+                .Setup(m => m.CreateDocumentCollectionAsync(databaseUri,
+                    It.Is<DocumentCollection>(d => d.Id == CollectionName && Enumerable.SequenceEqual(d.PartitionKey.Paths, expectedPaths)),
+                    It.Is<RequestOptions>(r => r.OfferThroughput == collectionThroughput)))
+                .ReturnsAsync(new DocumentCollection());
+
+            var provider = new DocumentDBOutputBindingProvider(context, null);
+
+            // Act
+            await provider.TryCreateAsync(new BindingProviderContext(DocumentDBTestUtility.GetCreateIfNotExistsParameters().Last(), null, CancellationToken.None));
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateIfNotExists_DoesNotSetThroughput_IfZero()
+        {
+            // Arrange
+            string partitionKeyPath = "partitionKey";
+            DocumentDBContext context = null;
+            var mockService = InitializeMockService(partitionKeyPath, 0, out context);
+
+            var expectedPaths = new List<string>();
+            if (!string.IsNullOrEmpty(partitionKeyPath))
+            {
+                expectedPaths.Add(partitionKeyPath);
+            }
+
+            mockService
+                .Setup(m => m.CreateDocumentCollectionAsync(databaseUri,
+                    It.Is<DocumentCollection>(d => d.Id == CollectionName && Enumerable.SequenceEqual(d.PartitionKey.Paths, expectedPaths)),
+                    null))
+                .ReturnsAsync(new DocumentCollection());
+
+            var provider = new DocumentDBOutputBindingProvider(context, null);
+
+            // Act
+            await provider.TryCreateAsync(new BindingProviderContext(DocumentDBTestUtility.GetCreateIfNotExistsParameters().Last(), null, CancellationToken.None));
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateIfNotExist_Succeeds_IfDbAndCollectionDoNotExist()
+        {
+            // Arrange
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+
+            mockService
+                .Setup(m => m.CreateDatabaseAsync(It.Is<Database>(d => d.Id == DatabaseName)))
+                .ReturnsAsync(new Database());
+
+            mockService
+                .Setup(m => m.CreateDocumentCollectionAsync(databaseUri, It.Is<DocumentCollection>(d => d.Id == CollectionName), null))
+                .ReturnsAsync(new DocumentCollection());
+
+            // Act
+            await DocumentDBOutputBindingProvider.CreateIfNotExistAsync(mockService.Object, DatabaseName, CollectionName, null, 0);
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateIfNotExist_Succeeds_IfCollectionDoesNotExist()
+        {
+            // Arrange
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+
+            mockService
+                .Setup(m => m.CreateDatabaseAsync(It.Is<Database>(d => d.Id == DatabaseName)))
+                .ThrowsAsync(DocumentDBTestUtility.CreateDocumentClientException(HttpStatusCode.Conflict));
+
+            mockService
+                .Setup(m => m.CreateDocumentCollectionAsync(databaseUri, It.Is<DocumentCollection>(d => d.Id == CollectionName), null))
+                .ReturnsAsync(new DocumentCollection());
+
+            // Act
+            await DocumentDBOutputBindingProvider.CreateIfNotExistAsync(mockService.Object, DatabaseName, CollectionName, null, 0);
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateIfNotExist_Succeeds_IfDbAndCollectionExist()
+        {
+            // Arrange
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+
+            mockService
+                .Setup(m => m.CreateDatabaseAsync(It.Is<Database>(d => d.Id == DatabaseName)))
+                .ThrowsAsync(DocumentDBTestUtility.CreateDocumentClientException(HttpStatusCode.Conflict));
+
+            mockService
+                .Setup(m => m.CreateDocumentCollectionAsync(databaseUri, It.Is<DocumentCollection>(d => d.Id == CollectionName), null))
+                .ThrowsAsync(DocumentDBTestUtility.CreateDocumentClientException(HttpStatusCode.Conflict));
+
+            // Act
+            await DocumentDBOutputBindingProvider.CreateIfNotExistAsync(mockService.Object, DatabaseName, CollectionName, null, 0);
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateIfNotExist_Throws_IfExceptionIsNotConflict()
+        {
+            // Arrange
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+
+            mockService
+                .Setup(m => m.CreateDatabaseAsync(It.Is<Database>(d => d.Id == DatabaseName)))
+                .ThrowsAsync(DocumentDBTestUtility.CreateDocumentClientException(HttpStatusCode.BadRequest));
+
+            // Act
+            await Assert.ThrowsAsync<DocumentClientException>(
+                () => DocumentDBOutputBindingProvider.CreateIfNotExistAsync(mockService.Object, DatabaseName, CollectionName, null, 0));
+
+            // Assert            
+            mockService.VerifyAll();
+        }
+
+        private Mock<IDocumentDBService> InitializeMockService(string partitionKey, int throughput, out DocumentDBContext context)
+        {
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+
+            context = new DocumentDBContext
+            {
+                ResolvedDatabaseName = DatabaseName,
+                ResolvedCollectionName = CollectionName,
+                Service = new TestDocumentDBServiceFactory(mockService.Object).CreateService("AccountEndpoint=http://someuri;AccountKey=some_key"),
+                ResolvedPartitionKey = partitionKey,
+                CreateIfNotExists = true,
+                CollectionThroughput = throughput
+            };
+
+            mockService
+                .Setup(m => m.CreateDatabaseAsync(It.Is<Database>(d => d.Id == DatabaseName)))
+                .ReturnsAsync(new Database());
+
+            return mockService;
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -55,8 +55,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.5\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.5.3\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -296,8 +296,10 @@
     <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebHooks.Receivers" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Receivers.GitHub" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.5" targetFramework="net45" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.5.3" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="1.1.2-alpha-10271" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.1.2-alpha-10271" targetFramework="net45" />


### PR DESCRIPTION
Adds support for `PartitionKey` and `CollectionThroughput` on `DocumentDbAttribute`. Also changes `CreateIfNotExists` to only apply to output bindings. For background, see: https://azure.microsoft.com/en-us/documentation/articles/documentdb-partition-data/

The behavior of the two new properties is as such:

- `PartitionKey` on an **output** paramter: If  `CreateIfNotExists` is `true`, the collection will be created with this partition key path. If the value is invalid, DocumentClient will throw an exception.
- `PartitionKey` on an **input** parameter: The value will be used in conjunction with `Id` to lookup the record. If there is no partition for the collection, this value is not required.
- `CollectionThroughput` on an **output** parameter: If `CreateIfNotExists` is `true` and the value is non-zero, the value will be used to specify throughput for the collection. If the value is invalid, DocumentClient will throw an exception.

Note: Also updated ApiHub to target the latest Core SDK. I was getting build warnings that there were version mismatches.