### PR TITLE
fixing docdb retry bug

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBAsyncCollector.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBAsyncCollector.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             await DocumentDBUtility.ExecuteWithRetriesAsync(async () =>
             {
                 return await _docDBContext.Service.UpsertDocumentAsync(collectionUri, item);
-            });
+            }, _docDBContext.MaxThrottleRetries);
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBAttributeBindingProvider.cs
@@ -17,11 +17,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
     {
         private JobHostConfiguration _jobHostConfig;
         private DocumentDBConfiguration _docDBConfig;
+        private TraceWriter _trace;
 
-        public DocumentDBAttributeBindingProvider(JobHostConfiguration config, DocumentDBConfiguration documentDBConfig)
+        public DocumentDBAttributeBindingProvider(JobHostConfiguration config, DocumentDBConfiguration documentDBConfig, TraceWriter trace)
         {
             _jobHostConfig = config;
             _docDBConfig = documentDBConfig;
+            _trace = trace;
         }
 
         public async Task<IBinding> TryCreateAsync(BindingProviderContext context)
@@ -47,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                     DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName));
             }
 
-            DocumentDBContext documentDBContext = CreateContext(_docDBConfig, attribute, _jobHostConfig.NameResolver);
+            DocumentDBContext documentDBContext = CreateContext(_docDBConfig, attribute, _jobHostConfig.NameResolver, _trace);
 
             if (attribute.CreateIfNotExists)
             {
@@ -64,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             return await compositeProvider.TryCreateAsync(context);
         }
 
-        internal static DocumentDBContext CreateContext(DocumentDBConfiguration config, DocumentDBAttribute attribute, INameResolver resolver)
+        internal static DocumentDBContext CreateContext(DocumentDBConfiguration config, DocumentDBAttribute attribute, INameResolver resolver, TraceWriter trace)
         {
             string resolvedConnectionString = config.ConnectionString;
 
@@ -78,7 +80,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 Service = config.DocumentDBServiceFactory.CreateService(resolvedConnectionString),
                 ResolvedDatabaseName = Resolve(attribute.DatabaseName, resolver),
                 ResolvedCollectionName = Resolve(attribute.CollectionName, resolver),
-                ResolvedId = attribute.Id
+                ResolvedId = attribute.Id,
+                Trace = trace
             };
         }
 

--- a/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBItemValueBinder.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBItemValueBinder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             Uri documentUri = UriFactory.CreateDocumentUri(_context.ResolvedDatabaseName, _context.ResolvedCollectionName, _id);
 
             T document = DocumentDBUtility.ExecuteWithRetriesAsync(() => _context.Service.ReadDocumentAsync<T>(documentUri),
-                ignoreNotFound: true).Result;
+                _context.MaxThrottleRetries, ignoreNotFound: true).Result;
 
             if (document != null)
             {
@@ -87,7 +87,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 }
 
                 Uri documentUri = UriFactory.CreateDocumentUri(context.ResolvedDatabaseName, context.ResolvedCollectionName, originalId);
-                await DocumentDBUtility.ExecuteWithRetriesAsync(() => context.Service.ReplaceDocumentAsync(documentUri, newItem));
+                await DocumentDBUtility.ExecuteWithRetriesAsync(() => context.Service.ReplaceDocumentAsync(documentUri, newItem),
+                    context.MaxThrottleRetries);
             }
         }
 

--- a/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 throw new ArgumentNullException("context");
             }
 
-            context.Config.RegisterBindingExtension(new DocumentDBAttributeBindingProvider(context.Config, this));
+            context.Config.RegisterBindingExtension(new DocumentDBAttributeBindingProvider(context.Config, this, context.Trace));
         }
 
         internal static string GetSettingFromConfigOrEnvironment(string key)

--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBContext.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBContext.cs
@@ -1,13 +1,24 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Host;
+
 namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 {
     internal class DocumentDBContext
     {
+        private const int DefaultMaxThrottleRetries = 10;
+
+        public DocumentDBContext()
+        {
+            MaxThrottleRetries = DefaultMaxThrottleRetries;
+        }
+
         public IDocumentDBService Service { get; set; }
         public string ResolvedDatabaseName { get; set; }
         public string ResolvedCollectionName { get; set; }
         public string ResolvedId { get; set; }
+        public int MaxThrottleRetries { get; set; }
+        public TraceWriter Trace { get; set; }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBAsyncCollectorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBAsyncCollectorTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             await collector.AddAsync(new Item { Text = "hello!" });
 
             // Assert
-            mockDocDBService.VerifyAll();
+            mockDocDBService.Verify(m => m.UpsertDocumentAsync(It.IsAny<Uri>(), It.IsAny<object>()), Times.Exactly(4));
         }
 
         private static DocumentDBContext CreateContext(IDocumentDBService service)

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBAttributeBindingProviderTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             {
                 ConnectionString = "AccountEndpoint=https://someuri;AccountKey=my_key"
             };
-            var provider = new DocumentDBAttributeBindingProvider(jobConfig, docDBConfig);
+            var provider = new DocumentDBAttributeBindingProvider(jobConfig, docDBConfig, new TestTraceWriter());
 
             var context = new BindingProviderContext(parameter, null, CancellationToken.None);
 
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
                 DocumentDBServiceFactory = new TestDocumentDBServiceFactory(mockService.Object)
             };
             var attribute = new DocumentDBAttribute { CreateIfNotExists = false };
-            var provider = new DocumentDBAttributeBindingProvider(new JobHostConfiguration(), config);
+            var provider = new DocumentDBAttributeBindingProvider(new JobHostConfiguration(), config, new TestTraceWriter());
 
             // Act
             await provider.TryCreateAsync(new BindingProviderContext(DocumentDBTestUtility.GetCreateIfNotExistsParameters().First(), null, CancellationToken.None));
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
                 DocumentDBServiceFactory = new TestDocumentDBServiceFactory(mockService.Object)
             };
 
-            var provider = new DocumentDBAttributeBindingProvider(new JobHostConfiguration(), config);
+            var provider = new DocumentDBAttributeBindingProvider(new JobHostConfiguration(), config, new TestTraceWriter());
 
             // Act
             await provider.TryCreateAsync(new BindingProviderContext(DocumentDBTestUtility.GetCreateIfNotExistsParameters().Last(), null, CancellationToken.None));
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             };
 
             // Act
-            var context = DocumentDBAttributeBindingProvider.CreateContext(config, attribute, resolver);
+            var context = DocumentDBAttributeBindingProvider.CreateContext(config, attribute, resolver, new TestTraceWriter());
 
             // Assert
             Assert.Equal("123abc", context.ResolvedDatabaseName);
@@ -277,10 +277,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             };
 
             // Act
-            DocumentDBAttributeBindingProvider.CreateContext(config, attribute, null);
+            DocumentDBAttributeBindingProvider.CreateContext(config, attribute, null, new TestTraceWriter());
 
             // Assert
             mockFactory.VerifyAll();
+        }
+
+        [Fact]
+        public void CreateContext_UsesDefaultRetryValue()
+        {
+            // Arrange            
+            var attribute = new DocumentDBAttribute();
+            var config = new DocumentDBConfiguration();
+
+            // Act
+            var context = DocumentDBAttributeBindingProvider.CreateContext(config, attribute, null, new TestTraceWriter());
+
+            // Assert
+            Assert.Equal(10, context.MaxThrottleRetries);
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBContextTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBContextTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+extern alias DocumentDB;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DocumentDB::Microsoft.Azure.WebJobs.Extensions.DocumentDB;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
+{
+    public class DocumentDBContextTests
+    {
+        [Fact]
+        public void MaxThrottleRetries_DefaultsTo10()
+        {
+            // Act
+            var context = new DocumentDBContext();
+
+            // Assert
+            Assert.Equal(10, context.MaxThrottleRetries);
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBTestUtility.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBTestUtility.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 extern alias DocumentDB;
+
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -19,9 +21,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
 {
     internal static class DocumentDBTestUtility
     {
-        public static DocumentClientException CreateDocumentClientException(HttpStatusCode status)
+        public static DocumentClientException CreateDocumentClientException(HttpStatusCode status, int retryAfter = 0)
         {
-            var parameters = new object[] { null, null, status, null };
+            var headers = new NameValueCollection();
+            headers.Add("x-ms-retry-after-ms", retryAfter.ToString());
+
+            var parameters = new object[] { null, null, headers, status, null };
             return Activator.CreateInstance(typeof(DocumentClientException), BindingFlags.NonPublic | BindingFlags.Instance, null, parameters, null) as DocumentClientException;
         }
 

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBUtilityTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBUtilityTests.cs
@@ -4,10 +4,13 @@
 extern alias DocumentDB;
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using DocumentDB::Microsoft.Azure.WebJobs.Extensions.DocumentDB;
 using Microsoft.Azure.Documents;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Models;
 using Moq;
 using Xunit;
@@ -66,22 +69,55 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             var mockUri = new Uri("https://someuri");
             var mockItem = new Item();
             var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
-            var tooManyRequestException = DocumentDBTestUtility.CreateDocumentClientException((HttpStatusCode)429);
+
+            // make sure that we sleep here
+            var tooManyRequestException = DocumentDBTestUtility.CreateDocumentClientException((HttpStatusCode)429, 1000);
+            var document = new Document();
 
             mockService
                 .SetupSequence(m => m.UpsertDocumentAsync(mockUri, mockItem))
                 .Throws(tooManyRequestException)
                 .Throws(tooManyRequestException)
-                .Returns(Task.FromResult(new Document()));
+                .Returns(Task.FromResult(document));
+
+            var start = DateTime.UtcNow;
 
             // Act
-            await DocumentDBUtility.ExecuteWithRetriesAsync(() =>
+            var result = await DocumentDBUtility.ExecuteWithRetriesAsync(() =>
             {
                 return mockService.Object.UpsertDocumentAsync(mockUri, mockItem);
-            });
+            }, 3);
 
             // Assert
-            mockService.VerifyAll();
+            var stop = DateTime.UtcNow;
+            Assert.True((stop - start).TotalMilliseconds >= 2000);
+            Assert.Same(document, result);
+            mockService.Verify(m => m.UpsertDocumentAsync(mockUri, mockItem), Times.Exactly(3));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(3)]
+        [InlineData(10)]
+        public async Task ExecuteWithRetriesAsync_MaxRetries(int maxRetries)
+        {
+            // Arrange
+            var mockUri = new Uri("https://someuri");
+            var mockItem = new Item();
+            var mockService = new Mock<IDocumentDBService>(MockBehavior.Strict);
+            var tooManyRequestException = DocumentDBTestUtility.CreateDocumentClientException((HttpStatusCode)429);
+            mockService.Setup(m => m.UpsertDocumentAsync(mockUri, mockItem)).Throws(tooManyRequestException);            
+
+            // Act
+            var docEx = await Assert.ThrowsAsync<DocumentClientException>(() =>
+                DocumentDBUtility.ExecuteWithRetriesAsync(() =>
+                {
+                    return mockService.Object.UpsertDocumentAsync(mockUri, mockItem);
+                }, maxRetries));
+
+            // Assert
+            Assert.Same(tooManyRequestException, docEx);
+            mockService.Verify(m => m.UpsertDocumentAsync(mockUri, mockItem), Times.Exactly(maxRetries + 1));
         }
 
         [Fact]
@@ -103,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
                 return DocumentDBUtility.ExecuteWithRetriesAsync(() =>
                 {
                     return mockService.Object.UpsertDocumentAsync(mockUri, mockItem);
-                });
+                }, 3);
             });
 
             // Assert
@@ -125,17 +161,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
                .SetupSequence(m => m.UpsertDocumentAsync(mockUri, mockItem))
                .Throws(tooManyRequestException)
                .Throws(tooManyRequestException)
+               .Throws(tooManyRequestException)
                .Throws(notFoundException);
 
             // Act
             var result = await DocumentDBUtility.ExecuteWithRetriesAsync(() =>
                 {
                     return mockService.Object.UpsertDocumentAsync(mockUri, mockItem);
-                }, ignoreNotFound: true);
+                }, 3, ignoreNotFound: true);
 
             // Assert
-            mockService.VerifyAll();
             Assert.Null(result);
+            mockService.Verify(m => m.UpsertDocumentAsync(mockUri, mockItem), Times.Exactly(4));
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Extensions\Core\TraceMonitorTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBClientValueProviderTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBConnectionStringTests.cs" />
+    <Compile Include="Extensions\DocumentDB\DocumentDBContextTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBItemBindingTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBOutputBindingProviderTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBItemValueBinderTests.cs" />


### PR DESCRIPTION
I accidentally removed the Task.Delay in my last checkin. That effectively broke docdb under any kind of stress where clients were throttled.