### PR TITLE
Fixing the bug for non-C# functions not being triggered

### DIFF
--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -65,9 +65,8 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebHooks.Receivers.GitHub.1.2.0-rc1\lib\net45\Microsoft.AspNet.WebHooks.Receivers.GitHub.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.5\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+    <Reference Include="Microsoft.Azure.ApiHub.Sdk">
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.1\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebHooks.Common" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Receivers" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Receivers.GitHub" version="1.2.0-rc1" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.5" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.1" targetFramework="net45" />
   <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.3" targetFramework="net45" />

--- a/src/WebJobs.Extensions.ApiHub/ApiHubFileTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.ApiHub/ApiHubFileTriggerAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Azure.ApiHub;
 
 namespace Microsoft.Azure.WebJobs
 {
@@ -13,11 +14,13 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="key">App settings key name that have the connections string</param>
         /// <param name="path">Relative path to the file <example>/folder/subfolder/file.txt</example></param>
+        /// <param name="fileWatcherType">Type of the file watcher.</param>
         /// <param name="pollIntervalInSeconds">The poll interval in seconds.</param>
-        public ApiHubFileTriggerAttribute(string key, string path, int pollIntervalInSeconds = 0)
+        public ApiHubFileTriggerAttribute(string key, string path, FileWatcherType fileWatcherType = FileWatcherType.Created, int pollIntervalInSeconds = 0)
             : base(key, path)
         {
             this.PollIntervalInSeconds = pollIntervalInSeconds;
+            this.FileWatcherType = fileWatcherType;
         }
 
         /// <summary>
@@ -27,5 +30,13 @@ namespace Microsoft.Azure.WebJobs
         /// The poll interval in seconds.
         /// </value>
         public int PollIntervalInSeconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the file watcher. Default is 'Created'.
+        /// </summary>
+        /// <value>
+        /// The type of the file watcher.
+        /// </value>
+        public FileWatcherType FileWatcherType { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.ApiHub/Common/ConstantObj.cs
+++ b/src/WebJobs.Extensions.ApiHub/Common/ConstantObj.cs
@@ -27,14 +27,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.ApiHub.Common
 
         public Task SetValueAsync(object value, CancellationToken cancellationToken)
         {
-            if (value == null)
-            {
-                return Task.FromResult(0);
-            }
-
             if (_onCompleted != null)
             {
                 return _onCompleted(value); // Flush hook 
+            }
+
+            if (value == null)
+            {
+                return Task.FromResult(0);
             }
 
             if (typeof(Stream).IsAssignableFrom(value.GetType()))

--- a/src/WebJobs.Extensions.ApiHub/Config/ApiHubConfiguration.cs
+++ b/src/WebJobs.Extensions.ApiHub/Config/ApiHubConfiguration.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs
 
             var folder = await root.GetFolderReferenceAsync(folderName);
 
-            var listener = new ApiHubListener(folder, executor, attribute.PollIntervalInSeconds);
+            var listener = new ApiHubListener(folder, executor, attribute.PollIntervalInSeconds, attribute.FileWatcherType);
 
             return listener;
         }

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.5\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.1\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.1.2.0-alpha-10291\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.5" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.1" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10291" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs.Core" version="1.2.0-alpha-10291" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -53,7 +53,7 @@
     </Reference>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.5\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.1\tools\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.6.3\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebHooks.Common" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Receivers" version="1.2.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebHooks.Receivers.GitHub" version="1.2.0-rc1" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.5" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.1" targetFramework="net45" />
   <package id="Microsoft.Azure.DocumentDB" version="1.6.3" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="1.2.0-alpha-10291" targetFramework="net45" />


### PR DESCRIPTION
Fixing the bug for non-C# functions not being triggered as well as adding support for FileWatcherType

And making the ApiHubListener as singleton.