### PR TITLE
Renaming all key lookup attribute properties to end with 'Setting'

### DIFF
--- a/src/WebJobs.Extensions.ApiHub/ApiHubFileAttribute.cs
+++ b/src/WebJobs.Extensions.ApiHub/ApiHubFileAttribute.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Create an instance of an attribute that points to the file on SAAS file provider
         /// </summary>
-        /// <param name="key">App settings key name that have the connections string</param>
+        /// <param name="connectionStringSetting">App settings key name that have the connections string</param>
         /// <param name="path">Relative path to the file <example>/folder/subfolder/file.txt</example> </param>
         /// <param name="access">Type of access requests <seealso cref="FileAccess"/></param>
-        public ApiHubFileAttribute(string key, string path, FileAccess access = FileAccess.Read)
+        public ApiHubFileAttribute(string connectionStringSetting, string path, FileAccess access = FileAccess.Read)
         {
-            this.Key = key;
+            this.ConnectionStringSetting = connectionStringSetting;
             this.Path = path;
             this.Access = access;
         }
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets app settings key name that have the connections string to the SAAS provider
         /// </summary>
-        public string Key { get; private set; }
+        public string ConnectionStringSetting { get; private set; }
 
         /// <summary>
         /// Type of access requests <seealso cref="FileAccess"/>

--- a/src/WebJobs.Extensions.ApiHub/Config/ApiHubConfiguration.cs
+++ b/src/WebJobs.Extensions.ApiHub/Config/ApiHubConfiguration.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs
 
         private async Task<IListener> BuildListener(ApiHubFileTriggerAttribute attribute, ITriggeredFunctionExecutor executor, TraceWriter trace)
         {
-            var root = GetFileSource(attribute.Key);
+            var root = GetFileSource(attribute.ConnectionStringSetting);
 
             string path = attribute.Path;
             int i = path.LastIndexOf('/');
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs
         // Attribute has path resolved
         private async Task<ApiHubFile> BuildFromAttribute(ApiHubFileAttribute attribute)
         {
-            var source = GetFileSource(attribute.Key);
+            var source = GetFileSource(attribute.ConnectionStringSetting);
             ApiHubFile file = await ApiHubFile.New(source, attribute.Path);
             return file;
         }

--- a/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         internal void ValidateConnection(DocumentDBAttribute attribute, Type paramType)
         {
             if (string.IsNullOrEmpty(ConnectionString) &&
-                string.IsNullOrEmpty(attribute.ConnectionString))
+                string.IsNullOrEmpty(attribute.ConnectionStringSetting))
             {
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.CurrentCulture,
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
         internal DocumentClient BindForClient(DocumentDBAttribute attribute)
         {
-            string resolvedConnectionString = ResolveConnectionString(this.ConnectionString, attribute.ConnectionString);
+            string resolvedConnectionString = ResolveConnectionString(this.ConnectionString, attribute.ConnectionStringSetting);
             IDocumentDBService service = GetService(resolvedConnectionString);
 
             return service.GetClient();
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
         internal DocumentDBContext CreateContext(DocumentDBAttribute attribute, TraceWriter trace)
         {
-            string resolvedConnectionString = ResolveConnectionString(ConnectionString, attribute.ConnectionString);
+            string resolvedConnectionString = ResolveConnectionString(ConnectionString, attribute.ConnectionStringSetting);
 
             IDocumentDBService service = GetService(resolvedConnectionString);
 

--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBAttribute.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBAttribute.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs
         /// Optional. A string value indicating the app setting to use as the DocumentDB connection string, if different
         /// than the one specified in the <see cref="DocumentDBConfiguration"/>.
         /// </summary>
-        public string ConnectionString { get; set; }
+        public string ConnectionStringSetting { get; set; }
 
         /// <summary>
         /// Optional. The Id of the document to retrieve from the collection.

--- a/src/WebJobs.Extensions.MobileApps/Config/MobileAppsConfiguration.cs
+++ b/src/WebJobs.Extensions.MobileApps/Config/MobileAppsConfiguration.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.MobileApps
         internal void ValidateMobileAppUri(MobileTableAttribute attribute, Type paramType)
         {
             if (MobileAppUri == null &&
-                string.IsNullOrEmpty(attribute.MobileAppUri))
+                string.IsNullOrEmpty(attribute.MobileAppUriSetting))
             {
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.CurrentCulture,
@@ -253,8 +253,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.MobileApps
 
         internal MobileTableContext CreateContext(MobileTableAttribute attribute)
         {
-            Uri resolvedUri = ResolveMobileAppUri(MobileAppUri, attribute.MobileAppUri);
-            string resolvedApiKey = ResolveApiKey(ApiKey, attribute.ApiKey);
+            Uri resolvedUri = ResolveMobileAppUri(MobileAppUri, attribute.MobileAppUriSetting);
+            string resolvedApiKey = ResolveApiKey(ApiKey, attribute.ApiKeySetting);
 
             return new MobileTableContext
             {

--- a/src/WebJobs.Extensions.MobileApps/MobileTableAttribute.cs
+++ b/src/WebJobs.Extensions.MobileApps/MobileTableAttribute.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs
         /// Optional. A string value indicating the app setting to use as the Azure Mobile App Uri, if different
         /// than the one specified in the <see cref="MobileAppsConfiguration"/>.
         /// </summary>
-        public string MobileAppUri { get; set; }
+        public string MobileAppUriSetting { get; set; }
 
         /// <summary>
         /// Optional. A string value indicating the app setting to use as the Azure Mobile App Api Key, if different
@@ -54,6 +54,6 @@ namespace Microsoft.Azure.WebJobs
         /// - If it is equal to string.Empty, no Api Key is used.
         /// - Otherwise, this value is used to indicate the app setting that contains the Azure Mobile App Api Key.
         /// </summary>
-        public string ApiKey { get; set; }
+        public string ApiKeySetting { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.NotificationHubs/Config/NotificationHubsConfiguration.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Config/NotificationHubsConfiguration.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
 
         private IAsyncCollector<Notification> BuildFromAttribute(NotificationHubAttribute attribute)
         {
-            string resolvedConnectionString = ResolveConnectionString(ConnectionString, attribute.ConnectionString);
+            string resolvedConnectionString = ResolveConnectionString(ConnectionString, attribute.ConnectionStringSetting);
             string resolvedHubName = ResolveHubName(HubName, attribute.HubName);
 
             INotificationHubClientService service = new NotificationHubClientService(resolvedConnectionString, resolvedHubName);

--- a/src/WebJobs.Extensions.NotificationHubs/NotificationHubAttribute.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/NotificationHubAttribute.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs
         /// Optional. A string value indicating the app setting to use as the Notification Hubs connection
         /// string, if different than the one specified in the <see cref="NotificationHubsConfiguration"/>.
         /// </summary>
-        public string ConnectionString { get; set; }
+        public string ConnectionStringSetting { get; set; }
 
         /// <summary>
         /// Optional. The Notification Hub Name to use, if different than the one specified in the

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBConfigurationTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBConfigurationTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             // Arrange            
             var attribute = new DocumentDBAttribute
             {
-                ConnectionString = attributeConnection
+                ConnectionStringSetting = attributeConnection
             };
 
             var mockFactory = new Mock<IDocumentDBServiceFactory>();

--- a/test/WebJobs.Extensions.Tests/Extensions/MobileApps/MobileAppsConfigurationTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/MobileApps/MobileAppsConfigurationTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.MobileApps
             // Arrange
             var attribute = new MobileTableAttribute
             {
-                MobileAppUri = attributeUriString
+                MobileAppUriSetting = attributeUriString
             };
 
             var mockFactory = new Mock<IMobileServiceClientFactory>();
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.MobileApps
             // Arrange
             var attribute = new MobileTableAttribute
             {
-                ApiKey = attributeKey
+                ApiKeySetting = attributeKey
             };
 
             var handler = new TestHandler();


### PR DESCRIPTION
Addresses #67.

@safihamid @emilcicos FYI -- I've renamed one of the ApiHubAttribute properties (Key -> ConnectionStringSetting) to match the convention that I'm introducing here. I'm not 100% sure that's the right name. I'll wait for your 'OK' before merging.