### PR TITLE
Onboard Extensions to Functions using new model

### DIFF
--- a/src/Packages/Packages.csproj
+++ b/src/Packages/Packages.csproj
@@ -32,14 +32,21 @@
     </NuGetSpec>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\WebJobs.Extensions.MobileApps.Nuget\WebJobs.Extensions.MobileApps.nuproj">
+    <NuGetProject Include="..\WebJobs.Extensions.NotificationHubs.Nuget\WebJobs.Extensions.NotificationHubs.nuproj">
+      <Link>WebJobs.Extensions.NotificationHubs\WebJobs.Extensions.NotificationHubs.nuproj</Link>
+      <SubType>Designer</SubType>
+    </NuGetProject>
+    <NuGetSpec Include="..\WebJobs.Extensions.NotificationHubs.Nuget\WebJobs.Extensions.NotificationHubs.nuspec">
+      <Link>WebJobs.Extensions.ApiHub\WebJobs.Extensions.NotificationHubs.nuspec</Link>
+    </NuGetSpec>
+  </ItemGroup>
+  <ItemGroup>
+    <NuGetProject Include="..\WebJobs.Extensions.MobileApps.Nuget\WebJobs.Extensions.MobileApps.nuproj">
       <Link>WebJobs.Extensions.MobileApps\WebJobs.Extensions.MobileApps.nuproj</Link>
-    </None>
-    <None Include="..\WebJobs.Extensions.MobileApps.Nuget\WebJobs.Extensions.MobileApps.nuspec">
+    </NuGetProject>
+    <NuGetSpec Include="..\WebJobs.Extensions.MobileApps.Nuget\WebJobs.Extensions.MobileApps.nuspec">
       <Link>WebJobs.Extensions.MobileApps\WebJobs.Extensions.MobileApps.nuspec</Link>
-    </None>
-    <None Include="WebJobs.Extensions.NotificationHubs\WebJobs.Extensions.NotificationHubs.nuproj" />
-    <None Include="WebJobs.Extensions.NotificationHubs\WebJobs.Extensions.NotificationHubs.nuspec" />
+    </NuGetSpec>
     <NuGetProject Include="..\WebJobs.Extensions.DocumentDB.Nuget\WebJobs.Extensions.DocumentDB.nuproj">
       <Link>WebJobs.Extensions.DocumentDB\WebJobs.Extensions.DocumentDB.nuproj</Link>
     </NuGetProject>

--- a/src/WebJobs.Extensions.ApiHub/ApiHubScriptBindingProvider.cs
+++ b/src/WebJobs.Extensions.ApiHub/ApiHubScriptBindingProvider.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Configuration;
+using System.IO;
+using System.Reflection;
+using Microsoft.Azure.ApiHub;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.ApiHub
+{
+    /// <summary>
+    /// BindingProvider for ApiHub extensions
+    /// </summary>
+    public class ApiHubScriptBindingProvider : ScriptBindingProvider
+    {
+        private readonly ApiHubConfiguration _apiHubConfig = new ApiHubConfiguration();
+
+        /// <inheritdoc/>
+        public ApiHubScriptBindingProvider(JobHostConfiguration config, JObject hostMetadata, TraceWriter traceWriter) 
+            : base(config, hostMetadata, traceWriter)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool TryCreate(ScriptBindingContext context, out ScriptBinding binding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            binding = null;
+
+            if (string.Compare(context.Type, "apiHubFileTrigger", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(context.Type, "apiHubFile", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                binding = new ApiHubFileScriptBinding(_apiHubConfig, context);
+            }
+            else if (string.Compare(context.Type, "apiHubTable", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                binding = new ApiHubTableScriptBinding(context);
+            }
+
+            return binding != null;
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            if (_apiHubConfig.Logger == null)
+            {
+                _apiHubConfig.Logger = TraceWriter;
+            }
+
+            Config.UseApiHub(_apiHubConfig);
+        }
+
+        /// <inheritdoc/>
+        public override bool TryResolveAssembly(string assemblyName, out Assembly assembly)
+        {
+            assembly = null;
+
+            if (string.Compare(assemblyName, "Microsoft.Azure.ApiHub.Sdk", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                assembly = typeof(MetadataInfo).Assembly;
+            }
+
+            return assembly != null;
+        }
+
+        private class ApiHubFileScriptBinding : ScriptBinding
+        {
+            private readonly ApiHubConfiguration _apiHubConfig;
+
+            public ApiHubFileScriptBinding(ApiHubConfiguration apiHubConfig, ScriptBindingContext context) : base(context)
+            {
+                _apiHubConfig = apiHubConfig;
+            }
+
+            public override Type DefaultType
+            {
+                get
+                {
+                    return typeof(Stream);
+                }
+            }
+
+            public override Collection<Attribute> GetAttributes()
+            {
+                Collection<Attribute> attributes = new Collection<Attribute>();
+
+                string connection = Context.GetMetadataValue<string>("connection");
+                string key = null;
+                if (!string.IsNullOrEmpty(connection))
+                {
+                    connection = GetAppSettingOrEnvironmentValue(connection);
+
+                    // Register each binding connection with the global config
+                    key = Guid.NewGuid().ToString();
+                    _apiHubConfig.AddKeyPath(key, connection);
+                }
+
+                string path = Context.GetMetadataValue<string>("path");
+                if (Context.IsTrigger)
+                {
+                    FileWatcherType fileWatcherType = Context.GetMetadataEnumValue<FileWatcherType>("fileWatcherType", FileWatcherType.Created);
+                    int pollIntervalInSeconds = Context.GetMetadataValue<int>("pollIntervalInSeconds");
+
+                    attributes.Add(new ApiHubFileTriggerAttribute(key, path, fileWatcherType, pollIntervalInSeconds));
+                }
+                else
+                {
+                    attributes.Add(new ApiHubFileAttribute(key, path, Context.Access));
+                }
+
+                return attributes;
+            }
+
+            // TODO: Helper for this, or otherwise remove need for it
+            private static string GetAppSettingOrEnvironmentValue(string name)
+            {
+                // first check app settings
+                string value = ConfigurationManager.AppSettings[name];
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+
+                // Check environment variables
+                value = Environment.GetEnvironmentVariable(name);
+                if (value != null)
+                {
+                    return value;
+                }
+
+                return null;
+            }
+        }
+
+        private class ApiHubTableScriptBinding : ScriptBinding
+        {
+            public ApiHubTableScriptBinding(ScriptBindingContext context) : base(context)
+            {
+            }
+
+            public override Type DefaultType
+            {
+                get
+                {
+                    if (Context.Access == FileAccess.Read)
+                    {
+                        return typeof(JObject);
+                    }
+                    else
+                    {
+                        return typeof(IAsyncCollector<JObject>);
+                    }
+                }
+            }
+
+            public override Collection<Attribute> GetAttributes()
+            {
+                var connection = Context.GetMetadataValue<string>("connection");
+                return new Collection<Attribute>()
+                {
+                    new ApiHubTableAttribute(connection)
+                    {
+                        DataSetName = Context.GetMetadataValue<string>("dataSetName"),
+                        EntityId = Context.GetMetadataValue<string>("entityId"),
+                        TableName = Context.GetMetadataValue<string>("tableName")
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -48,11 +48,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-alpha1\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -102,6 +106,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApiHubScriptBindingProvider.cs" />
     <Compile Include="Table\ApiHubTableAttributeExtensions.cs" />
     <Compile Include="Table\TableConfigContext.cs" />
     <Compile Include="Table\ConnectionFactory.cs" />

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -3,8 +3,9 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.6-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10331" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10331" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />

--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBScriptBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBScriptBindingProvider.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    /// <summary>
+    /// BindingProvider for DocumentDB extensions
+    /// </summary>
+    public class DocumentDBScriptBindingProvider : ScriptBindingProvider
+    {
+        /// <inheritdoc/>
+        public DocumentDBScriptBindingProvider(JobHostConfiguration config, JObject hostMetadata, TraceWriter traceWriter) 
+            : base(config, hostMetadata, traceWriter)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool TryCreate(ScriptBindingContext context, out ScriptBinding binding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            binding = null;
+
+            if (string.Compare(context.Type, "documentDB", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                binding = new DocumentDBScriptBinding(context);
+            }
+
+            return binding != null;
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            Config.UseDocumentDB();
+        }
+
+        private class DocumentDBScriptBinding : ScriptBinding
+        {
+            public DocumentDBScriptBinding(ScriptBindingContext context) : base(context)
+            {
+            }
+
+            public override Type DefaultType
+            {
+                get
+                {
+                    if (Context.Access == FileAccess.Read)
+                    {
+                        return typeof(JObject);
+                    }
+                    else
+                    {
+                        return typeof(IAsyncCollector<JObject>);
+                    }
+                }
+            }
+
+            public override Collection<Attribute> GetAttributes()
+            {
+                Collection<Attribute> attributes = new Collection<Attribute>();
+
+                string databaseName = Context.GetMetadataValue<string>("databaseName");
+                string collectionName = Context.GetMetadataValue<string>("collectionName");
+
+                DocumentDBAttribute attribute = null;
+                if (!string.IsNullOrEmpty(databaseName) || !string.IsNullOrEmpty(collectionName))
+                {
+                    attribute = new DocumentDBAttribute(databaseName, collectionName);
+                }
+                else
+                {
+                    attribute = new DocumentDBAttribute();
+                }
+
+                attribute.CreateIfNotExists = Context.GetMetadataValue<bool>("createIfNotExists");
+                attribute.ConnectionString = Context.GetMetadataValue<string>("connection");
+                attribute.Id = Context.GetMetadataValue<string>("id");
+                attribute.PartitionKey = Context.GetMetadataValue<string>("partitionKey");
+                attribute.CollectionThroughput = Context.GetMetadataValue<int>("collectionThroughput");
+
+                attributes.Add(attribute);
+
+                return attributes;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -49,11 +49,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-alpha1\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -104,6 +108,7 @@
     <Compile Include="Config\IDocumentDBServiceFactory.cs" />
     <Compile Include="DocumentDBAttribute.cs" />
     <Compile Include="DocumentDBContext.cs" />
+    <Compile Include="DocumentDBScriptBindingProvider.cs" />
     <Compile Include="DocumentDBUtility.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -2,8 +2,9 @@
 <packages>
   <package id="Microsoft.Azure.DocumentDB" version="1.7.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10331" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10331" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />

--- a/src/WebJobs.Extensions.MobileApps/MobileAppsScriptBindingProvider.cs
+++ b/src/WebJobs.Extensions.MobileApps/MobileAppsScriptBindingProvider.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.MobileApps
+{
+    /// <summary>
+    /// BindingProvider for MobileApps extensions
+    /// </summary>
+    public class MobileAppsScriptBindingProvider : ScriptBindingProvider
+    {
+        /// <inheritdoc/>
+        public MobileAppsScriptBindingProvider(JobHostConfiguration config, JObject hostMetadata, TraceWriter traceWriter) 
+            : base(config, hostMetadata, traceWriter)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool TryCreate(ScriptBindingContext context, out ScriptBinding binding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            binding = null;
+
+            if (string.Compare(context.Type, "mobileTable", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                binding = new MobileTableScriptBinding(context);
+            }
+
+            return binding != null;
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            Config.UseMobileApps();
+        }
+
+        private class MobileTableScriptBinding : ScriptBinding
+        {
+            public MobileTableScriptBinding(ScriptBindingContext context) : base(context)
+            {
+            }
+
+            public override Type DefaultType
+            {
+                get
+                {
+                    if (Context.Access == FileAccess.Read)
+                    {
+                        return typeof(JObject);
+                    }
+                    else
+                    {
+                        return typeof(IAsyncCollector<JObject>);
+                    }
+                }
+            }
+
+            public override Collection<Attribute> GetAttributes()
+            {
+                return new Collection<Attribute>
+                {
+                    new MobileTableAttribute
+                    {
+                        TableName = Context.GetMetadataValue<string>("tableName"),
+                        Id = Context.GetMetadataValue<string>("id"),
+                        MobileAppUri = Context.GetMetadataValue<string>("mobileAppUri"),
+                        ApiKey = Context.GetMetadataValue<string>("apiKey")
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -47,11 +47,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-alpha1\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -118,6 +122,7 @@
     <Compile Include="Config\DefaultMobileServiceClientFactory.cs" />
     <Compile Include="Config\IMobileServiceClientFactory.cs" />
     <Compile Include="Config\MobileServiceApiKeyHandler.cs" />
+    <Compile Include="MobileAppsScriptBindingProvider.cs" />
     <Compile Include="MobileTableAttribute.cs" />
     <Compile Include="Config\MobileAppsConfiguration.cs" />
     <Compile Include="MobileTableContext.cs" />

--- a/src/WebJobs.Extensions.MobileApps/packages.config
+++ b/src/WebJobs.Extensions.MobileApps/packages.config
@@ -2,8 +2,9 @@
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10331" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10331" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />

--- a/src/WebJobs.Extensions.NotificationHubs/NotificationHubScriptBindingProvider.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/NotificationHubScriptBindingProvider.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using Microsoft.Azure.NotificationHubs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
+{
+    /// <summary>
+    /// BindingProvider for NotificationHub extensions
+    /// </summary>
+    public class NotificationHubScriptBindingProvider : ScriptBindingProvider
+    {
+        /// <inheritdoc/>
+        public NotificationHubScriptBindingProvider(JobHostConfiguration config, JObject hostMetadata, TraceWriter traceWriter) 
+            : base(config, hostMetadata, traceWriter)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override bool TryCreate(ScriptBindingContext context, out ScriptBinding binding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            binding = null;
+
+            if (string.Compare(context.Type, "notificationHub", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                binding = new NotificationHubScriptBinding(context);
+            }
+
+            return binding != null;
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            Config.UseNotificationHubs();
+        }
+
+        /// <inheritdoc/>
+        public override bool TryResolveAssembly(string assemblyName, out Assembly assembly)
+        {
+            assembly = null;
+
+            if (string.Compare(assemblyName, "Microsoft.Azure.NotificationHubs", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                assembly = typeof(Notification).Assembly;
+            }
+
+            return assembly != null;
+        }
+
+        private class NotificationHubScriptBinding : ScriptBinding
+        {
+            public NotificationHubScriptBinding(ScriptBindingContext context) : base(context)
+            {
+            }
+
+            public override Type DefaultType
+            {
+                get
+                {
+                    // Only output bindings are supported.
+                    return typeof(IAsyncCollector<string>);
+                }
+            }
+
+            public override Collection<Attribute> GetAttributes()
+            {
+                return new Collection<Attribute>
+                {
+                    new NotificationHubAttribute
+                    {
+                        TagExpression = Context.GetMetadataValue<string>("tagExpression"),
+                        ConnectionString = Context.GetMetadataValue<string>("connection"),
+                        HubName = Context.GetMetadataValue<string>("hubName"),
+                        Platform = Context.GetMetadataEnumValue<NotificationPlatform>("platform")
+                    }
+                };
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
+++ b/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Config\NotificationHubJobHostConfigurationExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="NotificationHubAttribute.cs" />
+    <Compile Include="NotificationHubScriptBindingProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\INotificationHubClientService.cs" />
     <Compile Include="Services\NotificationHubClientService.cs" />
@@ -64,11 +65,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-alpha1\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Extensions.NotificationHubs/packages.config
+++ b/src/WebJobs.Extensions.NotificationHubs/packages.config
@@ -2,8 +2,9 @@
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.5" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10331" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10331" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />

--- a/src/WebJobs.Extensions/Extensions/CoreExtensionsScriptBindingProvider.cs
+++ b/src/WebJobs.Extensions/Extensions/CoreExtensionsScriptBindingProvider.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
+using NCrontab;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions
+{
+    /// <summary>
+    /// BindingProvider for the core WebJobs Extensions
+    /// </summary>
+    public class CoreExtensionsScriptBindingProvider : ScriptBindingProvider
+    {
+        /// <inheritdoc/>
+        public CoreExtensionsScriptBindingProvider(JobHostConfiguration config, JObject hostMetadata, TraceWriter traceWriter) 
+            : base(config, hostMetadata, traceWriter)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize()
+        {
+            Config.UseTimers();
+            Config.UseCore();
+        }
+
+        /// <inheritdoc/>
+        public override bool TryCreate(ScriptBindingContext context, out ScriptBinding binding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            binding = null;
+
+            if (string.Compare(context.Type, "timerTrigger", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                binding = new TimerTriggerScriptBinding(context);
+            }
+
+            return binding != null;
+        }
+
+        private class TimerTriggerScriptBinding : ScriptBinding
+        {
+            public TimerTriggerScriptBinding(ScriptBindingContext context) : base(context)
+            {
+            }
+
+            public override Type DefaultType
+            {
+                get
+                {
+                    return typeof(TimerInfo);
+                }
+            }
+
+            public override Collection<Attribute> GetAttributes()
+            {
+                Collection<Attribute> attributes = new Collection<Attribute>();
+
+                string schedule = Context.GetMetadataValue<string>("schedule");
+                bool runOnStartup = Context.GetMetadataValue<bool>("runOnStartup");
+
+                CrontabSchedule.ParseOptions options = new CrontabSchedule.ParseOptions()
+                {
+                    IncludingSeconds = true
+                };
+                if (CrontabSchedule.TryParse(schedule, options) == null)
+                {
+                    throw new ArgumentException(string.Format("'{0}' is not a valid CRON expression.", schedule));
+                }
+
+                attributes.Add(new TimerTriggerAttribute(schedule)
+                {
+                    RunOnStartup = runOnStartup
+                });
+
+                return attributes;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -48,11 +48,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10331\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.0.0-alpha-10343\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Script.Extensibility, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Script.Extensibility.1.0.0-alpha1\lib\net45\Microsoft.Azure.WebJobs.Script.Extensibility.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm">
@@ -123,6 +127,7 @@
     <Compile Include="Extensions\Files\Listener\ProcessingStates.cs" />
     <Compile Include="Extensions\Files\Listener\StatusFileEntry.cs" />
     <Compile Include="Extensions\Files\Bindings\FileTriggerAttributeBindingProvider.cs" />
+    <Compile Include="Extensions\CoreExtensionsScriptBindingProvider.cs" />
     <Compile Include="Extensions\Timers\Scheduling\ScheduleStatus.cs" />
     <Compile Include="Extensions\Timers\Scheduling\StorageScheduleMonitor.cs" />
     <Compile Include="Framework\JobHostConfigurationExtensions.cs" />

--- a/src/WebJobs.Extensions/packages.config
+++ b/src/WebJobs.Extensions/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10331" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10331" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-alpha-10343" targetFramework="net45" />
+  <package id="Microsoft.Azure.WebJobs.Script.Extensibility" version="1.0.0-alpha1" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />

--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -6,6 +6,8 @@
     <WebJobsPackageEULA>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</WebJobsPackageEULA>
     <Version>2.0.0</Version>
     <PrereleaseTag>-alpha</PrereleaseTag>
+    <IncludeBuildNumberInVersion>1</IncludeBuildNumberInVersion>
+    <BUILD_NUMBER>10307</BUILD_NUMBER>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(IncludeBuildNumberInVersion)' == '1'">


### PR DESCRIPTION
See [related PR](https://github.com/Azure/azure-webjobs-sdk-script/pull/427) in the Script repo. Basically for each of the extensions, we add a provider to allow Functions to load the extension automatically. The Functions runtime is then able to onboard these extensions dynamically.