### PR TITLE
MobileTable: fixing a bug with ApiKey behavior

### DIFF
--- a/src/WebJobs.Extensions.MobileApps/MobileTableAttribute.cs
+++ b/src/WebJobs.Extensions.MobileApps/MobileTableAttribute.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Azure.WebJobs
         /// - If it is equal to string.Empty, no Api Key is used.
         /// - Otherwise, this value is used to indicate the app setting that contains the Azure Mobile App Api Key.
         /// </summary>
-        [AutoResolve(AllowTokens = false)]
         public string ApiKeySetting { get; set; }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/MobileApps/MobileAppsConfigurationTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/MobileApps/MobileAppsConfigurationTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.MobileApps
             var apiKey = config.ResolveApiKey("Attribute");
 
             // Assert            
-            Assert.Equal("Attribute", apiKey);
+            Assert.Equal("ResolvedAttribute", apiKey);
         }
 
         [Fact]
@@ -297,6 +297,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.MobileApps
             var nameResolver = new TestNameResolver();
             nameResolver.Values[MobileAppsConfiguration.AzureWebJobsMobileAppApiKeyName] = "Default";
             nameResolver.Values[MobileAppsConfiguration.AzureWebJobsMobileAppUriName] = "https://default";
+            nameResolver.Values["Attribute"] = "ResolvedAttribute";
 
             var jobHostConfig = new JobHostConfiguration();
             jobHostConfig.NameResolver = nameResolver;


### PR DESCRIPTION
The issue here was that ApiKey has special behavior so you can override the default value if you need to. That behavior is defined here: https://github.com/Azure/azure-webjobs-sdk-extensions/blob/master/src/WebJobs.Extensions.MobileApps/MobileTableAttribute.cs#L53-L56.

When I changed this to use AutoResolve, I didn't add any E2E tests that actually went through the AttributeCloner. I forgot that the AttributeCloner will throw if it doesn't find any matching lookup, and it treats an empty string as a valid key (maybe it shouldn't - but we can address that elsewhere). So if you tried to use ApiKey="", it would throw because the AttributeCloner could not find any value in the INameResolver that matched "".

The fix here is to not use AutoResolve and perform this resolution myself. I also added E2E tests that would have caught this.

This affects Functions b/c the portal will sometimes generate an "apiKey":"" metadata value, which will throw currently.