### PR TITLE
Update to latest version of ApiHub SDK to add support for FTP/SFTP 

### DIFF
--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -54,7 +54,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.9-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.10-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ExtensionsSample/Samples/ApiHubTableSamples.cs
+++ b/src/ExtensionsSample/Samples/ApiHubTableSamples.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.ApiHub.Sdk.Table;
+using Microsoft.Azure.ApiHub;
 using Microsoft.Azure.WebJobs;
 using Newtonsoft.Json.Linq;
 

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.9-alpha" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.DocumentDB" version="1.7.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />

--- a/src/WebJobs.Extensions.ApiHub.NuGet/WebJobs.Extensions.ApiHub.nuspec
+++ b/src/WebJobs.Extensions.ApiHub.NuGet/WebJobs.Extensions.ApiHub.nuspec
@@ -15,7 +15,7 @@
     <tags>Microsoft Azure WebJobs Jobs Extensions ApiHub windowsazureofficial Web</tags>
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="$WebJobsPackageVersion$" />
-      <dependency id="Microsoft.Azure.ApiHub.Sdk" version="0.6.9-alpha" />
+      <dependency id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" />
     </dependencies>
   </metadata>
 </package>

--- a/src/WebJobs.Extensions.ApiHub/Table/ApiHubTableAttributeExtensions.cs
+++ b/src/WebJobs.Extensions.ApiHub/Table/ApiHubTableAttributeExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.ApiHub.Sdk.Table;
+using Microsoft.Azure.ApiHub;
 using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.ApiHub.Table

--- a/src/WebJobs.Extensions.ApiHub/Table/ConnectionFactory.cs
+++ b/src/WebJobs.Extensions.ApiHub/Table/ConnectionFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.ApiHub.Sdk;
+using Microsoft.Azure.ApiHub;
 
 namespace Microsoft.Azure.WebJobs.Extensions.ApiHub.Common
 {

--- a/src/WebJobs.Extensions.ApiHub/Table/TableAsyncCollector.cs
+++ b/src/WebJobs.Extensions.ApiHub/Table/TableAsyncCollector.cs
@@ -3,7 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApiHub.Sdk.Table;
+using Microsoft.Azure.ApiHub;
 
 namespace Microsoft.Azure.WebJobs.Extensions.ApiHub.Table
 {

--- a/src/WebJobs.Extensions.ApiHub/Table/TableBinding.cs
+++ b/src/WebJobs.Extensions.ApiHub/Table/TableBinding.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApiHub.Sdk.Table;
+using Microsoft.Azure.ApiHub;
 using Microsoft.Azure.WebJobs.Extensions.ApiHub.Extensions;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;

--- a/src/WebJobs.Extensions.ApiHub/Table/TableClientBinding.cs
+++ b/src/WebJobs.Extensions.ApiHub/Table/TableClientBinding.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApiHub.Sdk.Table;
+using Microsoft.Azure.ApiHub;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.9-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.10-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.9-alpha" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-beta1" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubTableBindingTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubTableBindingTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApiHub.Sdk.Table;
+using Microsoft.Azure.ApiHub;
 using Microsoft.Azure.WebJobs.Extensions.ApiHub.Table;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Host.Bindings;

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/FakeConnection.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/FakeConnection.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.ApiHub.Sdk;
-using Microsoft.Azure.ApiHub.Sdk.Table;
-using Microsoft.Azure.ApiHub.Sdk.Table.Internal;
+using Microsoft.Azure.ApiHub;
+using Microsoft.Azure.ApiHub.Table.Internal;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
 {

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/FakeConnectionFactory.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/FakeConnectionFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.ApiHub.Sdk;
+using Microsoft.Azure.ApiHub;
 using Microsoft.Azure.WebJobs.Extensions.ApiHub.Common;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/FakeTabularConnectorAdapter.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/FakeTabularConnectorAdapter.cs
@@ -6,9 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.ApiHub.Sdk.Common;
-using Microsoft.Azure.ApiHub.Sdk.Table;
-using Microsoft.Azure.ApiHub.Sdk.Table.Internal;
+using Microsoft.Azure.ApiHub;
+using Microsoft.Azure.ApiHub.Table.Internal;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub

--- a/test/WebJobs.Extensions.Tests/Extensions/NotificationHubs/NotificationHubConfigurationTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/NotificationHubs/NotificationHubConfigurationTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
 
             // Assert
             Assert.Equal(2, config.ClientCache.Count);
-
         }
 
         [Fact]
@@ -56,7 +55,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
 
             // Assert
             Assert.Equal(1, config.ClientCache.Count);
-
         }
 
         [Fact]

--- a/test/WebJobs.Extensions.Tests/Extensions/NotificationHubs/NotificationHubEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/NotificationHubs/NotificationHubEndToEndTests.cs
@@ -15,7 +15,6 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
 {
     public class NotificationHubEndToEndTests
@@ -29,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
         private const string MessagePropertiesJSON = "{\"message\":\"Hello\",\"location\":\"Redmond\"}";
         private const string WindowsToastPayload = "<toast><visual><binding template=\"ToastText01\"><text id=\"1\">Test message</text></binding></visual></toast>";
         private const string UserIdTag = "myuserid123";
-        private static Notification TestNotification = Converter.BuildTemplateNotificationFromJsonString(MessagePropertiesJSON);
+        private static Notification testNotification = Converter.BuildTemplateNotificationFromJsonString(MessagePropertiesJSON);
 
         [Fact]
         public void OutputBindings()
@@ -49,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
             // Arrange
             var serviceMock = new Mock<INotificationHubClientService>(MockBehavior.Strict);
             serviceMock
-                .Setup(x => x.SendNotificationAsync(TestNotification, UserIdTag))
+                .Setup(x => x.SendNotificationAsync(testNotification, UserIdTag))
                   .Returns(Task.FromResult(new NotificationOutcome()));
 
             var factoryMock = new Mock<INotificationHubClientServiceFactory>(MockBehavior.Strict);
@@ -76,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
             var factoryMock = new Mock<INotificationHubClientServiceFactory>(MockBehavior.Strict);
             factoryMock
                 .Setup(f => f.CreateService(DefaultConnStr, DefaultHubName))
-                .Returns(new NotificationHubClientService(DefaultConnStr,DefaultHubName));
+                .Returns(new NotificationHubClientService(DefaultConnStr, DefaultHubName));
 
             var testTrace = new TestTraceWriter(TraceLevel.Warning);
 
@@ -154,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
             var notificationHubConfig = new NotificationHubsConfiguration()
             {
                 ConnectionString = configConnectionString,
-                HubName =  configHubName,
+                HubName = configHubName,
                 NotificationHubClientServiceFactory = factory
             };
 
@@ -215,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
             }
 
             [NoAutomaticTrigger]
-            public async static void OutputsAsyncCollector(
+            public static async void OutputsAsyncCollector(
                            [NotificationHub] IAsyncCollector<TemplateNotification> asyncCollector,
                            [NotificationHub] IAsyncCollector<string> asyncCollectorString,
                TraceWriter trace)
@@ -241,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.NotificationHubs
               [NotificationHub(HubName = AttributeHubName, TagExpression = "{userIdTag}")] out Notification notification,
               TraceWriter trace)
             {
-                notification = TestNotification;
+                notification = testNotification;
                 trace.Warning("TriggerObject");
             }
 

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.9-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.10-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.9-alpha" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.DocumentDB" version="1.7.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.0.1" targetFramework="net45" />


### PR DESCRIPTION
Update to latest version of ApiHub SDK to add support for FTP/SFTP triggers as well as unify ApiHub Table public namespaces.