### PR TITLE
DocDB: supporting strings as input and output parameters

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBUtility.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBUtility.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 {

--- a/src/WebJobs.Extensions.DocumentDB/Services/DocumentDBService.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Services/DocumentDBService.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Linq;
 using Microsoft.Azure.WebJobs.Extensions.DocumentDB.Config;
 
 namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
@@ -61,10 +60,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             return response.Resource;
         }
 
-        public async Task<T> ReadDocumentAsync<T>(Uri documentUri, RequestOptions options)
+        public async Task<Document> ReadDocumentAsync(Uri documentUri, RequestOptions options)
         {
             ResourceResponse<Document> response = await _client.ReadDocumentAsync(documentUri, options);
-            return (T)(dynamic)response.Resource;
+            return response.Resource;
         }
 
         public void Dispose()

--- a/src/WebJobs.Extensions.DocumentDB/Services/IDocumentDBService.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Services/IDocumentDBService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         /// <param name="documentUri">The self-link of the document.</param>
         /// <param name="options">The <see cref="RequestOptions"/> for the request.</param>
         /// <returns>The task object representing the service response for the asynchronous operation.</returns>
-        Task<T> ReadDocumentAsync<T>(Uri documentUri, RequestOptions options);
+        Task<Document> ReadDocumentAsync(Uri documentUri, RequestOptions options);
 
         /// <summary>
         /// Replaces a document.

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBItemValueBinderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBItemValueBinderTests.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.DocumentDB
             Mock<IDocumentDBService> mockService;
             IValueBinder binder = CreateBinder<Item>(out mockService, partitionKey);
             mockService
-                .Setup(m => m.ReadDocumentAsync<Item>(_expectedUri, It.Is<RequestOptions>(r => r.PartitionKey.ToString() == partitionKeyValue)))
-                .ReturnsAsync(new Item());
+                .Setup(m => m.ReadDocumentAsync(_expectedUri, It.Is<RequestOptions>(r => r.PartitionKey.ToString() == partitionKeyValue)))
+                .ReturnsAsync(new Document());
 
             // Act
-            var value = binder.GetValue();
+            var value = binder.GetValue() as Item;
 
             // Assert
             mockService.VerifyAll();
@@ -50,11 +50,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.DocumentDB
             Mock<IDocumentDBService> mockService;
             IValueBinder binder = CreateBinder<Item>(out mockService);
             mockService
-                .Setup(m => m.ReadDocumentAsync<Item>(_expectedUri, null))
-                .ReturnsAsync(new Item());
+                .Setup(m => m.ReadDocumentAsync(_expectedUri, null))
+                .ReturnsAsync(new Document());
 
             // Act
-            var value = binder.GetValue();
+            var value = binder.GetValue() as Item;
 
             // Assert
             mockService.VerifyAll();
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.DocumentDB
             Mock<IDocumentDBService> mockService;
             IValueBinder binder = CreateBinder<Item>(out mockService);
             mockService
-                .Setup(m => m.ReadDocumentAsync<Item>(_expectedUri, null))
+                .Setup(m => m.ReadDocumentAsync(_expectedUri, null))
                 .ThrowsAsync(DocumentDBTestUtility.CreateDocumentClientException(HttpStatusCode.NotFound));
 
             // Act
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.DocumentDB
             Mock<IDocumentDBService> mockService;
             IValueBinder binder = CreateBinder<Item>(out mockService);
             mockService
-                .Setup(m => m.ReadDocumentAsync<Item>(_expectedUri, null))
+                .Setup(m => m.ReadDocumentAsync(_expectedUri, null))
                 .ThrowsAsync(DocumentDBTestUtility.CreateDocumentClientException(HttpStatusCode.ServiceUnavailable));
 
             // Act


### PR DESCRIPTION
Takes care of #137. 