### PR TITLE
Fix for ApiHubFile triggers to support Paths starting with or without a forward slash

### DIFF
--- a/src/WebJobs.Extensions.ApiHub/Common/GenericFileTriggerBindingProvider.cs
+++ b/src/WebJobs.Extensions.ApiHub/Common/GenericFileTriggerBindingProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ApiHub.Common
                 MethodInfo methodInfo = (MethodInfo)parameter.Member;
                 _functionName = methodInfo.Name;
 
-                _bindingDataProvider = BindingDataProvider.FromTemplate(_attribute.Path, ignoreCase: true);
+                _bindingDataProvider = BindingDataProvider.FromTemplate(_attribute.Path.TrimStart('/'), ignoreCase: true);
                 _bindingContract = CreateBindingContract();
             }
 

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubBindingEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubBindingEndToEndTests.cs
@@ -52,6 +52,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
         }
 
         [Fact]
+        public async void PathsTemplateCheck()
+        {
+            var fileName = "pathstemplatestest.txt";
+
+            JobHost host = CreateTestJobHost();
+            await host.StartAsync();
+
+            // now write a file to trigger the job
+            string data = Guid.NewGuid().ToString();
+            string inputFileName = ApiHubTestFixture.PathsTestPath + "/" + fileName;
+
+            var inputFile = _fixture.RootFolder.GetFileReference(inputFileName, true);
+            await inputFile.WriteAsync(Encoding.UTF8.GetBytes(data));
+
+            // verifying both PathsTestJob1 and PathsTestJob2 get called. 
+            await VerifyOutputBinding(data, string.Format("{0}.path1", fileName));
+            await VerifyOutputBinding(data, string.Format("{0}.path2", fileName));
+
+            await host.StopAsync();
+        }
+
+        [Fact]
         public async void ChecksRelatedBlobsGettingUpdated()
         {
             JobHost host = CreateTestJobHost();

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubFileTestJobs.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubFileTestJobs.cs
@@ -27,6 +27,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
             Processed.Add(name);
         }
 
+        public static void PathsTestJob1(
+            [ApiHubFileTrigger("dropbox", ApiHubTestFixture.PathsTestPath + @"/{name}")] string input,
+            [ApiHubFile("dropbox", ApiHubTestFixture.OutputTestPath + @"/{name}.path1", FileAccess.Write)] out string outputString)
+        {
+            outputString = input;            
+        }
+
+        public static void PathsTestJob2(
+            [ApiHubFileTrigger("dropbox", "/" + ApiHubTestFixture.PathsTestPath + @"/{name}")] string input,
+            [ApiHubFile("dropbox", "/" + ApiHubTestFixture.OutputTestPath + @"/{name}.path2", FileAccess.Write)] out string outputString)
+        {
+            outputString = input;
+        }
+
         public static void ThrowException(
             [ApiHubFileTrigger("dropbox", ApiHubTestFixture.ExceptionPath + @"/{name}")] Stream sr,
             string name)

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubTestFixture.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubTestFixture.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
         public const string ImportTestPath = @"import";
         public const string OutputTestPath = @"output";
         public const string ExceptionPath = @"exceptionPath";
+        public const string PathsTestPath = @"paths";
 
         public ApiHubTestFixture()
         {
@@ -67,6 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
 
             CreateFolder(ImportTestPath).Wait();
             CreateFolder(ExceptionPath).Wait();
+            CreateFolder(PathsTestPath).Wait();
 
             DeleteExistingArtifcats();
 
@@ -147,6 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
             EmptyFolder(ImportTestPath).Wait();
             EmptyFolder(OutputTestPath).Wait();
             EmptyFolder(ExceptionPath).Wait();
+            EmptyFolder(PathsTestPath).Wait();
 
             DeleteApiHubBlobs();
 


### PR DESCRIPTION
This issue came up while investigating a customer question