### PR TITLE
Fix for ApiHubFile triggers to support Paths starting with or without a forward slash

### DIFF
--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.10-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.0-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.0-alpha" targetFramework="net452" />
   <package id="Microsoft.Azure.DocumentDB" version="1.9.5" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.1.1" targetFramework="net45" />

--- a/src/WebJobs.Extensions.ApiHub.NuGet/WebJobs.Extensions.ApiHub.nuspec
+++ b/src/WebJobs.Extensions.ApiHub.NuGet/WebJobs.Extensions.ApiHub.nuspec
@@ -15,7 +15,7 @@
     <tags>Microsoft Azure WebJobs Jobs Extensions ApiHub windowsazureofficial Web</tags>
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="$WebJobsPackageVersion$" />
-      <dependency id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" />
+      <dependency id="Microsoft.Azure.ApiHub.Sdk" version="0.7.0-alpha" />
     </dependencies>
   </metadata>
 </package>

--- a/src/WebJobs.Extensions.ApiHub/Common/GenericFileTriggerBindingProvider.cs
+++ b/src/WebJobs.Extensions.ApiHub/Common/GenericFileTriggerBindingProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ApiHub.Common
                 MethodInfo methodInfo = (MethodInfo)parameter.Member;
                 _functionName = methodInfo.Name;
 
-                _bindingDataProvider = BindingDataProvider.FromTemplate(_attribute.Path, ignoreCase: true);
+                _bindingDataProvider = BindingDataProvider.FromTemplate(_attribute.Path.TrimStart('/'), ignoreCase: true);
                 _bindingContract = CreateBindingContract();
             }
 

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.10-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.0-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.0-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.0-beta1-10442" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.0-beta1-10442" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubBindingEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubBindingEndToEndTests.cs
@@ -52,6 +52,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
         }
 
         [Fact]
+        public async void PathsTemplateCheck()
+        {
+            var fileName = "pathstemplatestest.txt";
+
+            JobHost host = CreateTestJobHost();
+            await host.StartAsync();
+
+            // now write a file to trigger the job
+            string data = Guid.NewGuid().ToString();
+            string inputFileName = ApiHubTestFixture.PathsTestPath + "/" + fileName;
+
+            var inputFile = _fixture.RootFolder.GetFileReference(inputFileName, true);
+            await inputFile.WriteAsync(Encoding.UTF8.GetBytes(data));
+
+            // verifying both PathsTestJob1 and PathsTestJob2 get called. 
+            await VerifyOutputBinding(data, string.Format("{0}.path1", fileName));
+            await VerifyOutputBinding(data, string.Format("{0}.path2", fileName));
+
+            await host.StopAsync();
+        }
+
+        [Fact]
         public async void ChecksRelatedBlobsGettingUpdated()
         {
             JobHost host = CreateTestJobHost();

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubFileTestJobs.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubFileTestJobs.cs
@@ -27,6 +27,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
             Processed.Add(name);
         }
 
+        public static void PathsTestJob1(
+            [ApiHubFileTrigger("dropbox", ApiHubTestFixture.PathsTestPath + @"/{name}")] string input,
+            [ApiHubFile("dropbox", ApiHubTestFixture.OutputTestPath + @"/{name}.path1", FileAccess.Write)] out string outputString)
+        {
+            outputString = input;            
+        }
+
+        public static void PathsTestJob2(
+            [ApiHubFileTrigger("dropbox", "/" + ApiHubTestFixture.PathsTestPath + @"/{name}")] string input,
+            [ApiHubFile("dropbox", "/" + ApiHubTestFixture.OutputTestPath + @"/{name}.path2", FileAccess.Write)] out string outputString)
+        {
+            outputString = input;
+        }
+
         public static void ThrowException(
             [ApiHubFileTrigger("dropbox", ApiHubTestFixture.ExceptionPath + @"/{name}")] Stream sr,
             string name)

--- a/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubTestFixture.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/ApiHub/ApiHubTestFixture.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
         public const string ImportTestPath = @"import";
         public const string OutputTestPath = @"output";
         public const string ExceptionPath = @"exceptionPath";
+        public const string PathsTestPath = @"paths";
 
         public ApiHubTestFixture()
         {
@@ -67,6 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
 
             CreateFolder(ImportTestPath).Wait();
             CreateFolder(ExceptionPath).Wait();
+            CreateFolder(PathsTestPath).Wait();
 
             DeleteExistingArtifcats();
 
@@ -147,6 +149,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.ApiHub
             EmptyFolder(ImportTestPath).Wait();
             EmptyFolder(OutputTestPath).Wait();
             EmptyFolder(ExceptionPath).Wait();
+            EmptyFolder(PathsTestPath).Wait();
 
             DeleteApiHubBlobs();
 

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ApiHub.Sdk, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.6.10-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.0-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.6.10-alpha" targetFramework="net45" />
+  <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.0-alpha" targetFramework="net452" />
   <package id="Microsoft.Azure.DocumentDB" version="1.9.5" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="2.1.1" targetFramework="net45" />


### PR DESCRIPTION
This was discovered while investigating a customer issue and is to avoid confusion.