### PR TITLE
Ensure ScheduledStatus.Next is adjusted if invocation time is fired too early

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -220,9 +220,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             // Without this, it's possible to set the 'Next' value to the same time twice in a row, 
             // which results in duplicate triggers if the site restarts.
             DateTime adjustedInvocationTime = invocationTime;
-            if (!isPastDue && !runOnStartup && ScheduleStatus?.Next > invocationTime)
+            if (!isPastDue && !runOnStartup && ScheduleStatus?.Next >= invocationTime)
             {
-                adjustedInvocationTime = ScheduleStatus.Next;
+                adjustedInvocationTime = ScheduleStatus.Next + TimeSpan.FromMilliseconds(1);
             }
 
             ScheduleStatus = new ScheduleStatus

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             DateTime invocationTime = status.Next.AddMilliseconds(-1);
 
             // It should not use the same 'Next' value twice in a row.
-            DateTime expectedNextOccurrence = new DateTime(2016, 3, 6);
+            DateTime expectedMinimumNextOcurrence = new DateTime(2016, 3, 6);
 
             bool monitorCalled = false;
             _mockScheduleMonitor.Setup(p => p.UpdateStatusAsync(_testTimerName,
-                It.Is<ScheduleStatus>(q => q.Last == invocationTime && q.Next == expectedNextOccurrence)))
+                It.Is<ScheduleStatus>(q => q.Last == invocationTime && q.Next >= expectedMinimumNextOcurrence)))
                 .Callback(() => monitorCalled = true)
                 .Returns(Task.FromResult(true));
 
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             _listener.Dispose();
 
             Assert.Equal(invocationTime, _listener.ScheduleStatus.Last);
-            Assert.Equal(expectedNextOccurrence, _listener.ScheduleStatus.Next);
+            Assert.True(_listener.ScheduleStatus.Next >= expectedMinimumNextOcurrence);
             Assert.Equal(monitorCalled, useMonitor);
         }
 


### PR DESCRIPTION
Related to #132 

Fixes a bug that can make a `DailySchedule` or  `WeeklySchedule` fire twice in a row if the timer (due to timing skew), is fired before the intented time.
![image](https://cloud.githubusercontent.com/assets/20703505/19558964/7d9f8da4-96cd-11e6-9320-596049561aa7.png)

The `adjustedInvocationTime` were set to the `ScheduledStatus.Next` before calling `_schedule.GetNextOccurrence(adjustedInvocationTime)`.

But if the _scheduler is of type `DailySchedule` or `WeeklySchedule` the result of `_schedule.GetNextOccurrence(adjustedInvocationTime)` would still be the same as `ScheduleStatus.Next`