### PR TITLE
GetNextOccurrence Scheduling fix

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
@@ -50,8 +50,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 throw new InvalidOperationException("The schedule is empty.");
             }
 
-            // find the next occurrence in the schedule
-            int idx = schedule.FindIndex(p => now.TimeOfDay <= p);
+            // find the next occurrence in the schedule where the time
+            // is strictly greater than now
+            int idx = schedule.FindIndex(p => now.TimeOfDay < p);
             if (idx == -1)
             {
                 // no more occurrences for today, so start back at the beginning of the

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
             {
                 DateTime next = GetNextOccurrence(now.Value);
                 occurrences.Add(next);
-                now = next + TimeSpan.FromMilliseconds(1);
+                now = next;
             }
 
             return occurrences;

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
             int nextTimeIndex = -1;
             if (daySchedule != null)
             {
-                // we have a schedule for today
-                // determine the next time
-                nextTimeIndex = daySchedule.FindIndex(p => p.TotalMilliseconds >= now.TimeOfDay.TotalMilliseconds);
+                // We have a schedule for today. Determine the next time
+                // where the time is strictly greater than the current time
+                nextTimeIndex = daySchedule.FindIndex(p => p.TotalMilliseconds > now.TimeOfDay.TotalMilliseconds);
                 if (nextTimeIndex != -1)
                 {
                     nextTime = daySchedule[nextTimeIndex];

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -10,6 +10,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
     public class CronScheduleTests
     {
         [Fact]
+        public void GetNextOccurrence_NowEqualToNext_ReturnsCorrectValue()
+        {
+            CronSchedule schedule = new CronSchedule("0 * * * * *");
+
+            var now = schedule.GetNextOccurrence(DateTime.Now);
+            var next = schedule.GetNextOccurrence(now);
+
+            Assert.True(next > now);
+        }
+
+        [Fact]
         public void GetNextOccurrence_ThreeDaySchedule_MultipleScheduleIterations()
         {
             // 11:59AM on Mondays, Tuesdays, Wednesdays, Thursdays and Fridays

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/DailyScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/DailyScheduleTests.cs
@@ -26,6 +26,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         }
 
         [Fact]
+        public void GetNextOccurrence_NowEqualToNext_ReturnsCorrectValue()
+        {
+            var scheduleData = new List<TimeSpan>
+            {
+                new TimeSpan(8, 0, 0),
+                new TimeSpan(11, 30, 0),
+                new TimeSpan(15, 0, 0),
+                new TimeSpan(19, 15, 0)
+            };
+            var schedule = new DailySchedule(scheduleData.ToArray());
+
+            var now = schedule.GetNextOccurrence(DateTime.Now);
+            var next = schedule.GetNextOccurrence(now);
+
+            Assert.True(next > now);
+        }
+
+        [Fact]
         public void Constructor_TimeStrings()
         {
             DailySchedule schedule = new DailySchedule("08:30:00", "12:00:00", "15:00:00");

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/WeeklyScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/WeeklyScheduleTests.cs
@@ -21,15 +21,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void GetNextOccurrence_SingleDaySchedule_MultipleScheduleIterations()
         {
-            // simple MWF schedule
             Tuple<DayOfWeek, TimeSpan>[] scheduleData = new Tuple<DayOfWeek, TimeSpan>[]
             {
                 new Tuple<DayOfWeek, TimeSpan>(DayOfWeek.Monday, new TimeSpan(9, 0, 0))
             };
 
+            var schedule = new WeeklySchedule();
+            foreach (var occurrence in scheduleData)
+            {
+                schedule.Add(occurrence.Item1, occurrence.Item2);
+            }
+
             // set now to be before the first occurrence
             DateTime now = new DateTime(2015, 5, 23, 7, 30, 0);
             VerifySchedule(scheduleData, now);
+        }
+
+        [Fact]
+        public void GetNextOccurrence_NowEqualToNext_ReturnsCorrectValue()
+        {
+            var schedule = new WeeklySchedule();
+            schedule.Add(DayOfWeek.Monday, new TimeSpan(9, 0, 0));
+            schedule.Add(DayOfWeek.Wednesday, new TimeSpan(18, 0, 0));
+            schedule.Add(DayOfWeek.Friday, new TimeSpan(18, 0, 0));
+
+            var now = schedule.GetNextOccurrence(DateTime.Now);
+            var next = schedule.GetNextOccurrence(now);
+
+            Assert.True(next > now);
         }
 
         [Fact]
@@ -40,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             {
                 new Tuple<DayOfWeek, TimeSpan>(DayOfWeek.Monday, new TimeSpan(9, 0, 0)),
                 new Tuple<DayOfWeek, TimeSpan>(DayOfWeek.Wednesday, new TimeSpan(18, 0, 0)),
-                new Tuple<DayOfWeek, TimeSpan>(DayOfWeek.Friday, new TimeSpan(9, 30, 0))
+                new Tuple<DayOfWeek, TimeSpan>(DayOfWeek.Friday, new TimeSpan(18, 0, 0))
             };
 
             // set now to be before the first occurrence


### PR DESCRIPTION
GetNextOccurrence should not return same occurrence when now is equal to an occurrence. This fix is inspired by the issue reported in https://github.com/Azure/azure-webjobs-sdk-extensions/pull/164.