### PR TITLE
Updating TraceFilter to return a snapshot of TraceEvents instead of live collection

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Core/Bindings/ErrorTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions/Extensions/Core/Bindings/ErrorTriggerAttributeBindingProvider.cs
@@ -151,11 +151,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Core
                 {
                     if (_parameter.ParameterType == typeof(TraceEvent))
                     {
-                        return Task.FromResult<object>(_value.Events.Last());
+                        return Task.FromResult<object>(_value.GetEvents().Last());
                     }
                     else if (_parameter.ParameterType == typeof(IEnumerable<TraceEvent>))
                     {
-                        return Task.FromResult<object>(_value.Events.AsEnumerable());
+                        return Task.FromResult<object>(_value.GetEvents().AsEnumerable());
                     }
                     return Task.FromResult<object>(_value);
                 }

--- a/src/WebJobs.Extensions/Extensions/Core/Listener/ErrorTriggerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Core/Listener/ErrorTriggerListener.cs
@@ -158,12 +158,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Core.Listener
                 }
             }
 
-            public override Collection<TraceEvent> Events
+            public override IEnumerable<TraceEvent> GetEvents()
             {
-                get
-                {
-                    return InnerTraceFilter.Events;
-                }
+                return InnerTraceFilter.GetEvents();
             }
 
             public override bool Filter(TraceEvent traceEvent)

--- a/src/WebJobs.Extensions/Extensions/Core/Monitoring/SlidingWindowTraceFilter.cs
+++ b/src/WebJobs.Extensions/Extensions/Core/Monitoring/SlidingWindowTraceFilter.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions
@@ -56,11 +58,11 @@ namespace Microsoft.Azure.WebJobs.Extensions
         public int Threshold { get; private set; }
 
         /// <inheritdoc/>
-        public override Collection<TraceEvent> Events
+        public override IEnumerable<TraceEvent> GetEvents()
         {
-            get
+            lock (_syncLock)
             {
-                return _events;
+                return _events.ToArray<TraceEvent>();
             }
         }
 
@@ -108,6 +110,14 @@ namespace Microsoft.Azure.WebJobs.Extensions
             }
 
             return passesFilter;
+        }
+
+        internal void AddEvent(TraceEvent traceEvent)
+        {
+            lock (_syncLock)
+            {
+                _events.Add(traceEvent);
+            }
         }
 
         internal void RemoveOldEvents(DateTime now)

--- a/test/WebJobs.Extensions.Tests/Extensions/Core/ErrorTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Core/ErrorTriggerEndToEndTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -37,9 +38,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             await CallSafe(host, method);
             Assert.NotNull(instance.TraceFilter);
 
+            IEnumerable<TraceEvent> events = instance.TraceFilter.GetEvents();
             Assert.Equal("3 events at level 'Error' or lower have occurred within time window 00:05:00.", instance.TraceFilter.Message);
-            Assert.Equal(3, instance.TraceFilter.Events.Count);
-            foreach (TraceEvent traceEvent in instance.TraceFilter.Events)
+            Assert.Equal(3, events.Count());
+            foreach (TraceEvent traceEvent in events)
             {
                 FunctionInvocationException functionException = (FunctionInvocationException)traceEvent.Exception;
                 Assert.Equal("Kaboom!", functionException.InnerException.Message);
@@ -66,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             Assert.NotNull(instance.TraceFilter);
 
             Assert.Equal("One or more WebJob errors have occurred.", instance.TraceFilter.Message);
-            Assert.Equal(1, instance.TraceFilter.Events.Count);
+            Assert.Equal(1, instance.TraceFilter.GetEvents().Count());
         }
 
         [Fact]
@@ -92,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             await CallSafe(host, method);
 
             Assert.Equal("Function 'ErrorTriggerProgram_FunctionLevelHandler.ThrowB' failed.", instance.TraceFilter.Message);
-            Assert.Equal(1, instance.TraceFilter.Events.Count);
+            Assert.Equal(1, instance.TraceFilter.GetEvents().Count());
         }
 
         [Fact]
@@ -116,9 +118,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
 
             await CallSafe(host, method);
 
-            Assert.Equal(3, instance.TraceFilter.Events.Count);
+            IEnumerable<TraceEvent> events = instance.TraceFilter.GetEvents();
+            Assert.Equal(3, events.Count());
             Assert.Equal("3 events at level 'Error' or lower have occurred within time window 00:10:00.", instance.TraceFilter.Message);
-            Assert.True(instance.TraceFilter.Events.All(p => p.Message == "Exception while executing function: ErrorTriggerProgram_FunctionLevelHandler_SlidingWindow.Throw"));
+            Assert.True(events.All(p => p.Message == "Exception while executing function: ErrorTriggerProgram_FunctionLevelHandler_SlidingWindow.Throw"));
         }
 
         [Fact]
@@ -258,7 +261,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             {
                 TraceFilter = traceFilter;
 
-                foreach (TraceEvent error in traceFilter.Events)
+                foreach (TraceEvent error in traceFilter.GetEvents())
                 {
                     Errors.Add(error);
                 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Core/SlidingWindowTraceFilterTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Core/SlidingWindowTraceFilterTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Host;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
 {
@@ -31,9 +32,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
 
             DateTime now = DateTime.Now - TimeSpan.FromMinutes(10);
 
-            Assert.Equal(0, filter.Events.Count);
+            Assert.Equal(0, filter.GetEvents().Count());
             filter.RemoveOldEvents(now);
-            Assert.Equal(0, filter.Events.Count);
+            Assert.Equal(0, filter.GetEvents().Count());
 
             // add some events over a few minutes
             for (int i = 0; i < 10; i++)
@@ -43,33 +44,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
                 {
                     Timestamp = now
                 };
-                filter.Events.Add(traceEvent);
+                filter.AddEvent(traceEvent);
             }
 
-            Assert.Equal(10, filter.Events.Count);
+            Assert.Equal(10, filter.GetEvents().Count());
             filter.RemoveOldEvents(now);
-            Assert.Equal(10, filter.Events.Count);
-            Assert.Equal("Error 0", filter.Events.First().Message);
-            Assert.Equal("Error 9", filter.Events.Last().Message);
+            IEnumerable<TraceEvent> traceEvents = filter.GetEvents();
+            Assert.Equal(10, traceEvents.Count());
+            Assert.Equal("Error 0", traceEvents.First().Message);
+            Assert.Equal("Error 9", traceEvents.Last().Message);
 
             // now advance forward a minute
             now += TimeSpan.FromMinutes(1);
             filter.RemoveOldEvents(now);
-            Assert.Equal(9, filter.Events.Count);
-            Assert.Equal("Error 1", filter.Events.First().Message);
-            Assert.Equal("Error 9", filter.Events.Last().Message);
+            traceEvents = filter.GetEvents();
+            Assert.Equal(9, traceEvents.Count());
+            Assert.Equal("Error 1", traceEvents.First().Message);
+            Assert.Equal("Error 9", traceEvents.Last().Message);
 
             // now advance forward a few more minutes
             now += TimeSpan.FromMinutes(5);
             filter.RemoveOldEvents(now);
-            Assert.Equal(4, filter.Events.Count);
-            Assert.Equal("Error 6", filter.Events.First().Message);
-            Assert.Equal("Error 9", filter.Events.Last().Message);
+            traceEvents = filter.GetEvents();
+            Assert.Equal(4, traceEvents.Count());
+            Assert.Equal("Error 6", traceEvents.First().Message);
+            Assert.Equal("Error 9", traceEvents.Last().Message);
 
             // finally advance forward past all existing events
             now += TimeSpan.FromMinutes(5);
             filter.RemoveOldEvents(now);
-            Assert.Equal(0, filter.Events.Count);
+            Assert.Equal(0, filter.GetEvents().Count());
         }
 
         [Fact]
@@ -82,10 +86,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             Assert.False(filter.Filter(new TraceEvent(TraceLevel.Info, "Error 3")));  // expect this to be ignored based on Level
             Assert.True(filter.Filter(new TraceEvent(TraceLevel.Error, "Error 4")));
 
-            Assert.Equal(3, filter.Events.Count);
-            Assert.Equal("Error 1", filter.Events[0].Message);
-            Assert.Equal("Error 2", filter.Events[1].Message);
-            Assert.Equal("Error 4", filter.Events[2].Message);
+            Assert.Equal(3, filter.GetEvents().Count());
+            TraceEvent[] events = filter.GetEvents().ToArray<TraceEvent>();
+            Assert.Equal("Error 1", events[0].Message);
+            Assert.Equal("Error 2", events[1].Message);
+            Assert.Equal("Error 4", events[2].Message);
         }
 
         [Fact]
@@ -101,10 +106,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             Assert.False(filter.Filter(new TraceEvent(TraceLevel.Info, "Error 4 (Ignore)")));  // expect this to be ignored based inner filter
             Assert.True(filter.Filter(new TraceEvent(TraceLevel.Error, "Error 5")));
 
-            Assert.Equal(3, filter.Events.Count);
-            Assert.Equal("Error 1", filter.Events[0].Message);
-            Assert.Equal("Error 2", filter.Events[1].Message);
-            Assert.Equal("Error 5", filter.Events[2].Message);
+            TraceEvent[] events = filter.GetEvents().ToArray<TraceEvent>();
+            Assert.Equal(3, events.Length);            
+            Assert.Equal("Error 1", events[0].Message);
+            Assert.Equal("Error 2", events[1].Message);
+            Assert.Equal("Error 5", events[2].Message);
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Core/TraceFilterTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Core/TraceFilterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Host;
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             Assert.Equal(11, messageLines.Length);
 
             // test with no events
-            filter.Events.Clear();
+            filter = new TestTraceFilter("WebJob failures detected.");
             message = filter.GetDetailedMessage(3);
             messageLines = message.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
             Assert.Equal(2, messageLines.Length);
@@ -65,12 +66,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
                 }
             }
 
-            public override Collection<TraceEvent> Events
+            public override IEnumerable<TraceEvent> GetEvents()
             {
-                get
-                {
-                    return _events;
-                }
+                return _events;
             }
 
             public override bool Filter(TraceEvent traceEvent)

--- a/test/WebJobs.Extensions.Tests/Extensions/Core/TraceMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Core/TraceMonitorTests.cs
@@ -129,8 +129,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Core
             monitor.Trace(traceEvent);
 
             Assert.Equal("Custom Message", filter.Message);
-            Assert.Equal(1, filter.Events.Count);
-            Assert.Same(traceEvent, filter.Events.Single());
+            Assert.Equal(1, filter.GetEvents().Count());
+            Assert.Same(traceEvent, filter.GetEvents().Single());
         }
 
         [Fact]


### PR DESCRIPTION
Updating TraceFilter to return a snapshot of TraceEvents instead of live collection

Fix for https://github.com/Azure/azure-webjobs-sdk-extensions/issues/176