### PR TITLE
Fix TimerTrigger Dynamic schedule restrictions (#181)

### DIFF
--- a/src/WebJobs.Extensions/Utility.cs
+++ b/src/WebJobs.Extensions/Utility.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions
+{
+    internal static class Utility
+    {
+        public const string AzureWebsiteSku = "WEBSITE_SKU";
+        public const string DynamicSku = "Dynamic";
+
+        /// <summary>
+        /// Gets a value indicating whether the JobHost is running in a Dynamic
+        /// App Service WebApp.
+        /// </summary>
+        public static bool IsDynamic
+        {
+            get
+            {
+                string value = GetSettingFromConfigOrEnvironment(AzureWebsiteSku);
+                return string.Compare(value, DynamicSku, StringComparison.OrdinalIgnoreCase) == 0;
+            }
+        }
+
+        public static string GetSettingFromConfigOrEnvironment(string settingName)
+        {
+            string configValue = ConfigurationManager.AppSettings[settingName];
+            if (!string.IsNullOrEmpty(configValue))
+            {
+                // config values take precedence over environment values
+                return configValue;
+            }
+
+            return Environment.GetEnvironmentVariable(settingName) ?? configValue;
+        }
+    }
+}

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -89,6 +89,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Spatial, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -150,6 +151,7 @@
     <Compile Include="Extensions\Timers\TimerInfo.cs" />
     <Compile Include="Extensions\Timers\TimerTriggerAttribute.cs" />
     <Compile Include="Extensions\Timers\Bindings\TimerTriggerAttributeBindingProvider.cs" />
+    <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/test/WebJobs.Extensions.Tests/Extensions/Core/CoreExtensionsScriptBindingProvider.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Core/CoreExtensionsScriptBindingProvider.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using static Microsoft.Azure.WebJobs.Extensions.CoreExtensionsScriptBindingProvider;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Core
+{
+    public class CoreExtensionsScriptBindingProviderTests
+    {
+        [Fact]
+        public void GetAttributes_DynamicSku_ValidatesScheduleExpression()
+        {
+            Environment.SetEnvironmentVariable("TEST_SCHEDULE_CRON", "0 * * * * *");
+            Environment.SetEnvironmentVariable("TEST_SCHEDULE_TIMESPAN", "00:00:15");
+            Environment.SetEnvironmentVariable("WEBSITE_SKU", "Dynamic");
+
+            try
+            {
+                var triggerMetadata = new JObject
+                {
+                    { "direction", "in" },
+                    { "name", "timer" },
+                    { "type", "timerTrigger" }
+                };
+                var bindingContext = new ScriptBindingContext(triggerMetadata);
+                var binding = new TimerTriggerScriptBinding(bindingContext);
+
+                // TimeSpan expression is invalid
+                triggerMetadata["schedule"] = "00:00:15";
+                var ex = Assert.Throws<ArgumentException>(() => binding.GetAttributes());
+                Assert.Equal("'00:00:15' is not a valid CRON expression.", ex.Message);
+
+                // TimeSpan specified via app setting is invalid
+                triggerMetadata["schedule"] = "%TEST_SCHEDULE_TIMESPAN%";
+                ex = Assert.Throws<ArgumentException>(() => binding.GetAttributes());
+                Assert.Equal("'00:00:15' is not a valid CRON expression.", ex.Message);
+
+                // Cron expression is valid
+                triggerMetadata["schedule"] = "0 * * * * *";
+                var timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+                Assert.Equal("0 * * * * *", timerAttribute.ScheduleExpression);
+
+                // Cron expression specified via app setting is valid
+                triggerMetadata["schedule"] = "%TEST_SCHEDULE_CRON%";
+                timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+                Assert.Equal("0 * * * * *", timerAttribute.ScheduleExpression);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("WEBSITE_SKU", null);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Common\TypeExtensionsTests.cs" />
     <Compile Include="Extensions\Core\CoreBindingEndToEndTests.cs" />
     <Compile Include="Extensions\ApiHub\ApiHubBindingEndToEndTests.cs" />
+    <Compile Include="Extensions\Core\CoreExtensionsScriptBindingProvider.cs" />
     <Compile Include="Extensions\Core\ErrorTriggerAttributeTests.cs" />
     <Compile Include="Extensions\Core\SlidingWindowTraceFilterTests.cs" />
     <Compile Include="Extensions\Core\TraceFilterTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-webjobs-sdk-extensions/issues/181. We now only do these schedule restrictions in Dynamic plan.