### PR TITLE
Pastdue

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 // check to see if we've missed an occurrence since we last started.
                 // If we have, invoke it immediately.
                 ScheduleStatus = await ScheduleMonitor.GetStatusAsync(_timerName);
-                _trace.Verbose($"Function '{_timerName}' initial status: Last='{ScheduleStatus?.Last.ToString("o")}', Next='{ScheduleStatus?.Next.ToString("o")}'");
+                _trace.Verbose($"Function '{_timerName}' initial status: Last='{ScheduleStatus?.Last.ToString("o")}', Next='{ScheduleStatus?.Next.ToString("o")}', LastUpdated='{ScheduleStatus?.LastUpdated.ToString("o")}'");
                 TimeSpan pastDueDuration = await ScheduleMonitor.CheckPastDueAsync(_timerName, now, _schedule, ScheduleStatus);
                 isPastDue = pastDueDuration != TimeSpan.Zero;
             }
@@ -231,13 +231,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             ScheduleStatus = new ScheduleStatus
             {
                 Last = adjustedInvocationTime,
-                Next = _schedule.GetNextOccurrence(adjustedInvocationTime)
+                Next = _schedule.GetNextOccurrence(adjustedInvocationTime),
+                LastUpdated = adjustedInvocationTime
             };
 
             if (ScheduleMonitor != null)
             {
                 await ScheduleMonitor.UpdateStatusAsync(_timerName, ScheduleStatus);
-                _trace.Verbose($"Function '{_timerName}' updated status: Last='{ScheduleStatus.Last.ToString("o")}', Next='{ScheduleStatus.Next.ToString("o")}'");
+                _trace.Verbose($"Function '{_timerName}' updated status: Last='{ScheduleStatus.Last.ToString("o")}', Next='{ScheduleStatus.Next.ToString("o")}', LastUpdated='{ScheduleStatus.LastUpdated}'");
             }
         }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleStatus.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleStatus.cs
@@ -19,5 +19,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// The expected next schedule occurrence
         /// </summary>
         public DateTime Next { get; set; }
+
+        /// <summary>
+        /// The last time this record was updated. This is used to re-calculate Next
+        /// with the current Schedule after a host restart.
+        /// </summary>
+        public DateTime LastUpdated { get; set; }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -115,7 +115,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             var status = new ScheduleStatus
             {
                 Last = new DateTime(2016, 3, 4),
-                Next = new DateTime(2016, 3, 5)
+                Next = new DateTime(2016, 3, 5),
+                LastUpdated = new DateTime(2016, 3, 4)
             };
             DateTime invocationTime = status.Next.AddMilliseconds(-1);
             ScheduleStatus updatedStatus = null;
@@ -340,17 +341,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             var status = new ScheduleStatus
             {
                 Last = new DateTime(2016, 3, 4),
-                Next = new DateTime(2016, 3, 4, 0, 0, 1)
+                Next = new DateTime(2016, 3, 4, 0, 0, 1),
+                LastUpdated = new DateTime(2016, 3, 3, 23, 59, 59)
             };
 
-            var expected = $"Function 'Program.TestTimerJob' initial status: Last='{status.Last.ToString("o")}', Next='{status.Next.ToString("o")}'";
+            var expected = $"Function 'Program.TestTimerJob' initial status: Last='{status.Last.ToString("o")}', Next='{status.Next.ToString("o")}', LastUpdated='{status.LastUpdated.ToString("o")}'";
             await RunInitialStatusTestAsync(status, expected);
         }
 
         [Fact]
         public async Task Listener_LogsInitialNullStatus_WhenUsingMonitor()
         {
-            await RunInitialStatusTestAsync(null, "Function 'Program.TestTimerJob' initial status: Last='', Next=''");
+            await RunInitialStatusTestAsync(null, "Function 'Program.TestTimerJob' initial status: Last='', Next='', LastUpdated=''");
         }
 
         public async Task RunInitialStatusTestAsync(ScheduleStatus initialStatus, string expected)

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Timers;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
+{
+    public class ScheduleMonitorTests
+    {
+        private const string _timerName = "TestTimer";
+        private readonly CronSchedule _hourlySchedule;
+        private readonly CronSchedule _halfHourlySchedule;
+        private readonly CronSchedule _dailySchedule;
+
+        public ScheduleMonitorTests()
+        {
+            _hourlySchedule = new CronSchedule("0 0 * * * *");
+            _halfHourlySchedule = new CronSchedule("0 */30 * * * *");
+            _dailySchedule = new CronSchedule("0 0 0 * * *");
+        }
+
+        [Fact]
+        public async Task CheckPastDue_NullStatus()
+        {
+            DateTime now = DateTime.Parse("1/1/2017 9:35");
+            MockScheduleMonitor monitor = new MockScheduleMonitor();
+
+            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _dailySchedule, null);
+            Assert.Equal(TimeSpan.Zero, pastDueAmount);
+            Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+            Assert.Equal(DateTime.Parse("1/2/2017 00:00"), monitor.CurrentStatus.Next);
+            Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public async Task CheckPastDue(bool lastSet, bool lastUpdatedSet)
+        {
+            DateTime now = DateTime.Parse("1/1/2017 9:35");
+
+            ScheduleStatus status = new ScheduleStatus
+            {
+                Last = lastSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime),
+                Next = DateTime.Parse("1/1/2017 10:00"),
+                LastUpdated = lastUpdatedSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime)
+            };
+
+            MockScheduleMonitor monitor = new MockScheduleMonitor();
+
+            // Check the schedule (simulating a host start without any schedule change). We should not 
+            // update the status.
+            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _hourlySchedule, status);
+            Assert.Equal(TimeSpan.Zero, pastDueAmount);
+            Assert.Null(monitor.CurrentStatus);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public async Task CheckPastDue_NowPastNext(bool lastSet, bool lastUpdatedSet)
+        {
+            // Move the time 1 second ahead of 'Next'. We should catch this as past due.
+            DateTime now = DateTime.Parse("1/1/2017 10:00:01");
+
+            ScheduleStatus status = new ScheduleStatus
+            {
+                Last = lastSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime),
+                Next = DateTime.Parse("1/1/2017 10:00"),
+                LastUpdated = lastUpdatedSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime)
+            };
+
+            MockScheduleMonitor monitor = new MockScheduleMonitor();
+
+            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _hourlySchedule, status);
+
+            if (lastUpdatedSet || lastSet)
+            {
+                Assert.Equal(TimeSpan.FromSeconds(1), pastDueAmount);
+                Assert.Null(monitor.CurrentStatus);
+            }
+            else
+            {
+                // Legacy behavior -- 'LastUpdated' fixed this. The schedule didn't change and we're past due, 
+                //      but we miss it because there is no 'Last' value, which we require to calculate the 'Next'
+                //      value. It also shouldn't register as a schedule change.
+                Assert.Equal(TimeSpan.Zero, pastDueAmount);
+                Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+                Assert.Equal(DateTime.Parse("1/1/2017 11:00"), monitor.CurrentStatus.Next);
+                Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        private async Task CheckPastDue_ScheduleChange_Longer(bool lastSet, bool lastUpdatedSet)
+        {
+            DateTime now = DateTime.Parse("1/1/2017 9:35");
+
+            ScheduleStatus status = new ScheduleStatus
+            {
+                Last = lastSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime),
+                Next = DateTime.Parse("1/1/2017 10:00"),
+                LastUpdated = lastUpdatedSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime)
+            };
+
+            MockScheduleMonitor monitor = new MockScheduleMonitor();
+
+            // change to daily schedule (status is hourly)
+            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _dailySchedule, status);
+
+            Assert.Equal(TimeSpan.Zero, pastDueAmount);
+
+            DateTime expectedNext = DateTime.Parse("1/2/2017 0:00");
+            Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+            Assert.Equal(expectedNext, monitor.CurrentStatus.Next);
+
+            if (lastUpdatedSet || lastSet)
+            {
+                Assert.Equal(DateTime.Parse("1/1/2017 9:00"), monitor.CurrentStatus.LastUpdated);
+            }
+            else
+            {
+                // Legacy behavior -- before 'LastUpdated' was added.
+
+                Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        private async Task CheckPastDue_ScheduleChange_Shorter(bool lastSet, bool lastUpdatedSet)
+        {
+            DateTime now = DateTime.Parse("1/1/2017 9:35");
+
+            ScheduleStatus status = new ScheduleStatus
+            {
+                Last = lastSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime),
+                Next = DateTime.Parse("1/1/2017 10:00"),
+                LastUpdated = lastUpdatedSet ? DateTime.Parse("1/1/2017 9:00") : default(DateTime)
+            };
+
+            MockScheduleMonitor monitor = new MockScheduleMonitor();
+
+            // Change to half-hour schedule (status is hourly). 
+            // The 'Next' time calculated by this could be in the past -- so it will be seen as past due
+            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _halfHourlySchedule, status);
+
+            if (lastUpdatedSet || lastSet)
+            {
+                // Because the new time is in the past, we re-calculate it to be the next invocation from 'now'.
+                Assert.Equal(TimeSpan.Zero, pastDueAmount);
+                Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+                Assert.Equal(DateTime.Parse("1/1/2017 10:00"), monitor.CurrentStatus.Next);
+                Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
+            }
+            else
+            {
+                // Legacy behavior -- before 'LastUpdated' was added.
+
+                // We don't have a 'Last', so we re-calculate from now, which is not past due
+                Assert.Equal(TimeSpan.Zero, pastDueAmount);
+
+                // Because the 'Next' times happen to line up, we don't see it as a new schedule and don't update it
+                Assert.Null(monitor.CurrentStatus);
+            }
+        }
+
+        private class MockScheduleMonitor : ScheduleMonitor
+        {
+            public ScheduleStatus CurrentStatus { get; private set; }
+
+            public override Task<ScheduleStatus> GetStatusAsync(string timerName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task UpdateStatusAsync(string timerName, ScheduleStatus status)
+            {
+                CurrentStatus = status;
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/StorageScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/StorageScheduleMonitorTests.cs
@@ -61,8 +61,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             // update the status
             ScheduleStatus expected = new ScheduleStatus
             {
-                Last = DateTime.Now.Subtract(TimeSpan.FromMinutes(5)),
-                Next = DateTime.Now.AddMinutes(5)
+                Last = DateTime.Now.AddMinutes(-5),
+                Next = DateTime.Now.AddMinutes(5),
+                LastUpdated = DateTime.Now.AddMinutes(-5),
             };
             await _scheduleMonitor.UpdateStatusAsync(TestTimerName, expected);
 
@@ -70,6 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
             Assert.Equal(expected.Last, status.Last);
             Assert.Equal(expected.Next, status.Next);
+            Assert.Equal(expected.LastUpdated, status.LastUpdated);
         }
 
         [Fact]

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -227,6 +227,7 @@
     <Compile Include="Extensions\SendGrid\SendGridEndToEndTests.cs" />
     <Compile Include="Extensions\SendGrid\SendGridHelpersTests.cs" />
     <Compile Include="Extensions\Timers\Bindings\TimerTriggerBindingTests.cs" />
+    <Compile Include="Extensions\Timers\Scheduling\ScheduleMonitorTests.cs" />
     <Compile Include="Extensions\Timers\Scheduling\StorageScheduleMonitorTests.cs" />
     <Compile Include="Extensions\Timers\Scheduling\TimerScheduleTests.cs" />
     <Compile Include="Extensions\Twilio\TwilioSmsMessageAsyncCollectorTests.cs" />


### PR DESCRIPTION
Addressing #194.

The problem is that if the function has never run, we have no `Last` value to use for calculating `Next` when the host starts. So instead, we calculate from `now`. If the timer is past due, that means we'll miss it. Some customers have seen this happen when their site wakes up and restarts for one reason or another -- the timer doesn't get around to evaluating until a couple seconds after the scheduled execution. At that point, we recalculate the next execution and don't know that we've missed one.

This change adds a `LastUpdated` value to our serialized status. Even if the function has never run, we'll update `LastUpdated` to be the last time that we used when calculating `Next`. So when the host restarts, we have something to work with. 

I've added tests to make sure that the 'legacy' behavior still works as expected -- since no one will have a `LastUpdated` value when this code starts running.