### PR TITLE
DocDB: fixing bug in change detection for updates

### DIFF
--- a/src/ExtensionsSample/Samples/DocumentDBSamples.cs
+++ b/src/ExtensionsSample/Samples/DocumentDBSamples.cs
@@ -62,7 +62,7 @@ namespace ExtensionsSample
         // This example uses the binding template "{IsCompleted}" to specify that the value of 'c.isCompleted' should come
         // from the IsCompleted proparty of the queued JSON message.
         public static void QueryDocument(
-            [QueueTrigger("samples-documentdb-csharp")] CustomQueueInput input,
+            [QueueTrigger("samples-documentdb-csharp-query")] CustomQueueInput input,
             [DocumentDB("ItemDb", "ItemCollection", SqlQuery = "SELECT c.id, c.text FROM c where c.isCompleted = {IsCompleted}")] IEnumerable<string> items,
             TraceWriter log)
         {

--- a/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
+++ b/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
@@ -15,7 +15,7 @@
     <tags>Microsoft Azure WebJobs Jobs Extensions DocumentDB document windowsazureofficial Web</tags>
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="$WebJobsPackageVersion$" />
-      <dependency id="Microsoft.Azure.DocumentDB" version="1.12.0" />
+      <dependency id="Microsoft.Azure.DocumentDB" version="1.11.4" />
     </dependencies>
   </metadata>
 </package>

--- a/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBItemValueBinder.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Bindings/DocumentDBItemValueBinder.cs
@@ -60,16 +60,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             }
 
             T item = null;
-            _originalItem = JObject.FromObject(document);
 
             // Strings need to be handled differently.
             if (typeof(T) == typeof(string))
             {
+                _originalItem = JObject.FromObject(document);
                 item = _originalItem.ToString(Formatting.None) as T;
             }
             else
             {
                 item = (T)(dynamic)document;
+                _originalItem = JObject.FromObject(item);
             }
 
             return item;

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -40,8 +40,8 @@
     <DocumentationFile>bin\Release\Microsoft.Azure.WebJobs.Extensions.DocumentDB.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -137,10 +137,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
-  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.DocumentDB" version="1.12.0" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="2.0.1-alpha1-10528" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.0.1-alpha1-10528" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBEndToEndTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.WebJobs.Extensions.DocumentDB;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Models;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Moq;
@@ -338,8 +339,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
                 [QueueTrigger("fakequeue1")] string triggerData,
                 [DocumentDB(DatabaseName, CollectionName, Id = "{QueueTrigger}")] dynamic item1,
                 [DocumentDB(DatabaseName, CollectionName, Id = "docid2", PartitionKey = "{QueueTrigger}")] dynamic item2,
-                [DocumentDB(DatabaseName, CollectionName, Id = "docid3", PartitionKey = "partkey3")] dynamic item3,
-                [DocumentDB("%Database%", "%Collection%", Id = "docid4")] dynamic item4,
+                [DocumentDB(DatabaseName, CollectionName, Id = "docid3", PartitionKey = "partkey3")] Item item3,
+                [DocumentDB("%Database%", "%Collection%", Id = "docid4")] JObject item4,
                 [DocumentDB(DatabaseName, CollectionName, Id = "docid5")] string item5,
                 [DocumentDB(DatabaseName, CollectionName, SqlQuery = "some query")] IEnumerable<JObject> query1,
                 [DocumentDB(DatabaseName, CollectionName, SqlQuery = "some %Query% with '{QueueTrigger}' replacements")] IEnumerable<JObject> query2,

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.2-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -301,10 +301,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.12.0\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net452" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.12.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />


### PR DESCRIPTION
Addresses #198 

The issue was that we were storing all of the 'hidden' values in the original document in `_originalValue`. Since those weren't passed to the function, we'd see them and think that the object had changed. Now we do the conversion to the destination object before storing the `_originalValue`. Then, we can correctly compare whether any changes were made.

Example:
Document comes back as `{"id":"abc", "_ts":100}`, but if your POCO only has an Id, you won't get the `_ts` property, yet we'd store it in `_originalValue`. When we'd check to see if it had changed, we'd see the missing `_ts` and think you had changed it, prompting an update.