### PR TITLE
Adding a constructor to the HttpTriggerAttribute to specify only methods

### DIFF
--- a/src/WebJobs.Extensions.Http/HttpTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.Http/HttpTriggerAttribute.cs
@@ -24,6 +24,15 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>
         /// Constructs a new instance.
+        /// </summary>        
+        /// <param name="methods">The http methods to allow.</param>
+        public HttpTriggerAttribute(params string[] methods) : this()
+        {
+            Methods = methods;
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
         /// </summary>
         /// <param name="authLevel">The <see cref="AuthorizationLevel"/> to apply.</param>
         /// <param name="methods">The http methods to allow.</param>


### PR DESCRIPTION
Right now through HttpTrigger forces you to add authtype if you want to restrict httpTrigger to a certain http methods. However the if the HttpTrigger is of type webhook Authlevel does not apply. Adding another constructor to specify only methods parameter.