### PR TITLE
Expanding HttpTrigger binding data support

### DIFF
--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -70,10 +70,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10711\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10711\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -7,8 +7,8 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />

--- a/src/Sample.Extension/Sample.Extension.csproj
+++ b/src/Sample.Extension/Sample.Extension.csproj
@@ -38,10 +38,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/Sample.Extension/packages.config
+++ b/src/Sample.Extension/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -48,10 +48,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -3,8 +3,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -49,10 +49,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/WebJobs.Extensions.Http/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Http
+{
+    internal static class HttpRequestMessageExtensions
+    {
+        public static IDictionary<string, string> GetRawHeaders(this HttpRequestMessage request)
+        {
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var allHeadersRaw = request.Headers.ToString() + Environment.NewLine + request.Content?.Headers?.ToString();
+            var rawHeaderLines = allHeadersRaw.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (var header in rawHeaderLines)
+            {
+                int idx = header.IndexOf(':');
+                string name = header.Substring(0, idx);
+                string value = header.Substring(idx + 1).Trim();
+                headers.Add(name, value);
+            }
+
+            return headers;
+        }
+
+        public static IDictionary<string, string> GetQueryParameterDictionary(this HttpRequestMessage request)
+        {
+            var keyValuePairs = request.GetQueryNameValuePairs();
+
+            // last one wins for any duplicate query parameters
+            return keyValuePairs.GroupBy(p => p.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(p => p.Key, s => s.Last().Value, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Http/Extensions/IDictionaryExtensions.cs
+++ b/src/WebJobs.Extensions.Http/Extensions/IDictionaryExtensions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Http
 {

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -43,10 +43,10 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -167,6 +167,7 @@
     <Compile Include="AuthorizationLevel.cs" />
     <Compile Include="Config\HttpExtensionConfiguration.cs" />
     <Compile Include="Config\HttpJobHostConfigurationExtensions.cs" />
+    <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
     <Compile Include="HttpExtensionConstants.cs" />
     <Compile Include="Extensions\IDictionaryExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/WebJobs.Extensions.Http/packages.config
+++ b/src/WebJobs.Extensions.Http/packages.config
@@ -3,8 +3,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -47,10 +47,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.MobileApps/packages.config
+++ b/src/WebJobs.Extensions.MobileApps/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
+++ b/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
@@ -67,10 +67,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.NotificationHubs/packages.config
+++ b/src/WebJobs.Extensions.NotificationHubs/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.NuGet/WebJobs.Extensions.nuspec
+++ b/src/WebJobs.Extensions.NuGet/WebJobs.Extensions.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions Files Scheduler Cron Storage Table Blob Queue windowsazureofficial Web</tags>
     <dependencies>
-      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" />
       <dependency id="ncrontab" version="3.3.0" />
       <dependency id="Microsoft.Tpl.Dataflow" version="4.5.24" />
     </dependencies>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -46,10 +46,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.SendGrid/packages.config
+++ b/src/WebJobs.Extensions.SendGrid/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -44,10 +44,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.Twilio/packages.config
+++ b/src/WebJobs.Extensions.Twilio/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="JWT" version="1.3.4" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -49,10 +49,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions/packages.config
+++ b/src/WebJobs.Extensions/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerEndToEndTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Timers;
+using Xunit;
+
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
+{
+    public class HttpTriggerEndToEndTests
+    {
+        private JobHost _host;
+
+        public HttpTriggerEndToEndTests()
+        {
+            var config = new JobHostConfiguration();
+            config.UseHttp();
+            _host = new JobHost(config);
+        }
+
+        public void HttpToBlobTest()
+        {
+
+        }
+
+        public class RequestInfo
+        {
+            public string A { get; set; }
+            public string B { get; set; }
+        }
+
+        public static class TestFunctions
+        {
+            public static void HttpToBlob([HttpTrigger("get", "post")] RequestInfo request)
+            {
+
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerEndToEndTests.cs
@@ -2,43 +2,118 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
-using Microsoft.Azure.WebJobs.Extensions.Timers;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Xunit;
-
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
 {
     public class HttpTriggerEndToEndTests
     {
+        private JobHostConfiguration _config;
         private JobHost _host;
 
         public HttpTriggerEndToEndTests()
         {
-            var config = new JobHostConfiguration();
-            config.UseHttp();
-            _host = new JobHost(config);
+            _config = new JobHostConfiguration
+            {
+                TypeLocator = new ExplicitTypeLocator(typeof(TestFunctions))
+            };
+            _config.UseHttp();
+            _host = new JobHost(_config);
         }
 
-        public void HttpToBlobTest()
+        [Fact]
+        public void BasicInvoke()
         {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://functions.com/api/123/two/test?q1=123&q2=two");
+            request.Headers.Add("h1", "value1");
+            request.Headers.Add("h2", "value2");
+            var routeDataValues = new Dictionary<string, object>
+            {
+                { "r1", 123 },
+                { "r2",  "two" }
+            };
+            request.Properties[HttpExtensionConstants.AzureWebJobsHttpRouteDataKey] = routeDataValues;
 
+            var method = typeof(TestFunctions).GetMethod("TestFunction1");
+            _host.Call(method, new { req = request });
         }
 
-        public class RequestInfo
+        [Fact]
+        public async Task QueryHeaderBindingParameters()
         {
-            public string A { get; set; }
-            public string B { get; set; }
+            string testId = Guid.NewGuid().ToString();
+            string testValue = Guid.NewGuid().ToString();
+            string testSuffix = Guid.NewGuid().ToString();
+            var request = new HttpRequestMessage(HttpMethod.Get, $"http://functions.com/api/test?testId={testId}");
+            request.Headers.Add("h1", "value1");
+            request.Headers.Add("h2", "value2");
+            request.Headers.Add("testSuffix", testSuffix);
+            request.Headers.Add("testValue", testValue);
+            var routeDataValues = new Dictionary<string, object>
+            {
+                { "r1", 123 },
+                { "r2",  "two" }
+            };
+            request.Properties[HttpExtensionConstants.AzureWebJobsHttpRouteDataKey] = routeDataValues;
+
+            var method = typeof(TestFunctions).GetMethod("TestFunction2");
+            await _host.CallAsync(method, new { req = request });
+
+            // verify blob was written
+            string blobName = $"test-{testId}-{testSuffix}";
+            var account = CloudStorageAccount.Parse(_config.StorageConnectionString);
+            CloudBlobClient client = account.CreateCloudBlobClient();
+            CloudBlobContainer container = client.GetContainerReference("test-output");
+            var blobRef = await container.GetBlobReferenceFromServerAsync(blobName);
+            await TestHelpers.Await(() => blobRef.Exists());
+
+            MemoryStream stream = new MemoryStream();
+            await blobRef.DownloadToStreamAsync(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            string result;
+            using (var streamReader = new StreamReader(stream))
+            {
+                result = await streamReader.ReadToEndAsync();
+            }
+
+            Assert.Equal(testValue, result);
         }
 
         public static class TestFunctions
         {
-            public static void HttpToBlob([HttpTrigger("get", "post")] RequestInfo request)
+            public static void TestFunction1(
+                [HttpTrigger("get", "post", Route = "{r1:int}/{r2:alpha}/test")] HttpRequestMessage req, 
+                int r1, 
+                string r2, 
+                IDictionary<string, string> headers,
+                IDictionary<string, string> query)
             {
+                Assert.Equal(123, r1);
+                Assert.Equal("two", r2);
 
+                Assert.Equal("123", query["q1"]);
+                Assert.Equal("two", query["q2"]);
+
+                Assert.Equal("value1", headers["h1"]);
+                Assert.Equal("value2", headers["h2"]); 
+            }
+
+            public static void TestFunction2(
+                [HttpTrigger("post")] HttpRequestMessage req,
+                [Blob("test-output/test-{query.testId}-{headers.testSuffix}")] out string blob,
+                IDictionary<string, string> headers,
+                IDictionary<string, string> query)
+            {
+                blob = headers["testValue"];
             }
         }
     }

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -275,6 +275,7 @@
     <Compile Include="Extensions\Http\HttpRouteFactoryTests.cs" />
     <Compile Include="Extensions\Http\HttpTriggerAttributeBindingProviderTests.cs" />
     <Compile Include="Extensions\Http\HttpTriggerBindingTests.cs" />
+    <Compile Include="Extensions\Http\HttpTriggerEndToEndTests.cs" />
     <Compile Include="Extensions\MobileApps\MobileTableAsyncCollectorTests.cs" />
     <Compile Include="Extensions\MobileApps\MobileAppsConfigurationTests.cs" />
     <Compile Include="Extensions\MobileApps\MobileTableEndToEndTests.cs" />

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -58,10 +58,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10711\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10711\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10729\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10729" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10729" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />


### PR DESCRIPTION
Adding `IDictionary<string, string>` bindings for request query and header collections. Adding dictionary bindings for these collections is consistent with what we do for other bindings (e.g. Blob bindings expose dictionaries for Metadata/Properties). See [binding doc](https://github.com/Azure/azure-webjobs-sdk/wiki/Trigger-Binding-Data#blobtrigger) for more details.

In conjunction with the recent addition of path expression support to the core binding pipeline, the following binding expressions for http are enabled:

```csharp
public static void TestFunction(
    [HttpTrigger("post")] HttpRequestMessage req,
    [Blob("test-output/test-{query.testId}-{headers.testSuffix}")] out string blob,
    IDictionary<string, string> headers,
    IDictionary<string, string> query)
{
    blob = headers["testValue"];
}
```