### PR TITLE
Fix docdb issue with duplicate SQL query parameters

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBSqlResolutionPolicy.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBSqlResolutionPolicy.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.WebJobs.Host.Bindings;
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             SqlParameterCollection paramCollection = new SqlParameterCollection();
             // also build up a dictionary replacing '{token}' with '@token' 
             IDictionary<string, string> replacements = new Dictionary<string, string>();
-            foreach (var token in bindingTemplate.ParameterNames)
+            foreach (var token in bindingTemplate.ParameterNames.Distinct())
             {
                 string sqlToken = $"@{token}";
                 paramCollection.Add(new SqlParameter(sqlToken, bindingData[token]));

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBSqlResolutionPolicyTests.cs
@@ -28,9 +28,29 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             string result = policy.TemplateBind(propInfo, resolvedAttribute, bindingTemplate, bindingData);
 
             // Assert
-            Assert.Contains(resolvedAttribute.SqlQueryParameters, p => p.Name == "@foo" && p.Value.ToString() == "1234");
-            Assert.Contains(resolvedAttribute.SqlQueryParameters, p => p.Name == "@bar" && p.Value.ToString() == "5678");
+            Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@foo" && p.Value.ToString() == "1234");
+            Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@bar" && p.Value.ToString() == "5678");
             Assert.Equal("SELECT * FROM c WHERE c.id = @foo AND c.value = @bar", result);
+        }
+
+        [Fact]
+        public void TemplateBind_DuplicateParameters()
+        {
+            // Arrange
+            PropertyInfo propInfo = null;
+            DocumentDBAttribute resolvedAttribute = new DocumentDBAttribute();
+            BindingTemplate bindingTemplate =
+                BindingTemplate.FromString("SELECT * FROM c WHERE c.id = {foo} AND c.value = {foo}");
+            Dictionary<string, object> bindingData = new Dictionary<string, object>();
+            bindingData.Add("foo", "1234");
+            DocumentDBSqlResolutionPolicy policy = new DocumentDBSqlResolutionPolicy();
+
+            // Act
+            string result = policy.TemplateBind(propInfo, resolvedAttribute, bindingTemplate, bindingData);
+
+            // Assert
+            Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@foo" && p.Value.ToString() == "1234");
+            Assert.Equal("SELECT * FROM c WHERE c.id = @foo AND c.value = @foo", result);
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBSqlResolutionPolicyTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Azure.WebJobs.Extensions.DocumentDB;
+using Microsoft.Azure.WebJobs.Host.Bindings.Path;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
+{
+    public class DocumentDBSqlResolutionPolicyTests
+    {
+        [Fact]
+        public void TemplateBind_MultipleParameters()
+        {
+            // Arrange
+            PropertyInfo propInfo = null;
+            DocumentDBAttribute resolvedAttribute = new DocumentDBAttribute();
+            BindingTemplate bindingTemplate = 
+                BindingTemplate.FromString("SELECT * FROM c WHERE c.id = {foo} AND c.value = {bar}");
+            Dictionary<string, object> bindingData = new Dictionary<string, object>();
+            bindingData.Add("foo", "1234");
+            bindingData.Add("bar", "5678");
+            DocumentDBSqlResolutionPolicy policy = new DocumentDBSqlResolutionPolicy();
+
+            // Act
+            string result = policy.TemplateBind(propInfo, resolvedAttribute, bindingTemplate, bindingData);
+
+            // Assert
+            Assert.Contains(resolvedAttribute.SqlQueryParameters, p => p.Name == "@foo" && p.Value.ToString() == "1234");
+            Assert.Contains(resolvedAttribute.SqlQueryParameters, p => p.Name == "@bar" && p.Value.ToString() == "5678");
+            Assert.Equal("SELECT * FROM c WHERE c.id = @foo AND c.value = @bar", result);
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -270,6 +270,7 @@
     <Compile Include="Extensions\DocumentDB\DocumentDBEndToEndTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBEnumerableBuilderTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBItemValueBinderTests.cs" />
+    <Compile Include="Extensions\DocumentDB\DocumentDBSqlResolutionPolicyTests.cs" />
     <Compile Include="Extensions\DocumentDB\TestDocumentDBServiceFactory.cs" />
     <Compile Include="Extensions\Http\HttpRequestManagerTests.cs" />
     <Compile Include="Extensions\Http\HttpRouteFactoryTests.cs" />


### PR DESCRIPTION
The DocDB binding currently does not handle duplicate parameters in `SqlQuery`. For instance:

    SELECT * FROM c WHERE c.id = {foo} AND c.value = {foo}

This results in an exception: `mscorlib: An item with the same key has already been added.`

- Changed behavior such that only a single `SqlParameter` is created for duplicate parameter names
- Fixed "same key" exception
- Added tests
