### PR TITLE
CosmosDB Change Feed trigger

### DIFF
--- a/CustomDictionary.xml
+++ b/CustomDictionary.xml
@@ -65,6 +65,9 @@
       <Word>Twilio</Word>
       <Word>IEnumerable</Word>
       <Word>sqlquery</Word>
+      <Word>DocumentDB</Word>
+      <Word>AccountEndpoint</Word>
+      <Word>AccountKey</Word>
     </Recognized>
     <Deprecated/>
     <Compound>

--- a/WebJobs.Extensions.sln
+++ b/WebJobs.Extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.12
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1118E0AD-83C8-4B67-859B-FCDEF54338C1}"
 EndProject

--- a/src/ExtensionsSample/App.config
+++ b/src/ExtensionsSample/App.config
@@ -53,6 +53,10 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -57,9 +57,8 @@
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.2-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -113,7 +112,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
@@ -241,6 +239,7 @@
     <Compile Include="SamplesTypeLocator.cs" />
     <Compile Include="Samples\ApiHubTableSamples.cs" />
     <Compile Include="Samples\ApiHubSamples.cs" />
+    <Compile Include="Samples\CosmosDBTriggerSamples.cs" />
     <Compile Include="Samples\MobileAppSamples.cs" />
     <Compile Include="Samples\DocumentDBSamples.cs" />
     <Compile Include="GlobalSuppressions.cs" />
@@ -323,10 +322,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ExtensionsSample/Samples/CosmosDBTriggerSamples.cs
+++ b/src/ExtensionsSample/Samples/CosmosDBTriggerSamples.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Newtonsoft.Json.Linq;
+
+namespace ExtensionsSample.Samples
+{
+    // To use the DocumentDB samples:
+    // 1. Create a new DocumentDB account
+    // 2. Add the DocumentDB Connection String to the 'AzureWebJobsDocumentDBTriggerConnectionString' App Setting in app.config    
+    // 3. Create a Database called ItemDb.
+    // 4. Create a Collection named ItemCollection. This will be the monitored collection.
+    // 5. Create a Collection named Leases. This will be used to store auxiliary leases to support multi-observer scenarios and partitioning.
+    // 6. Optionally create a Collection named ItemCollectionCopy for the ListenAndCopy scenario. And add an 'AzureWebJobsDocumentDBConnectionString' App Setting in app.config with its Connection String
+    // 7. Add typeof(DocumentDBTriggerSamples) to the SamplesTypeLocator in Program.cs
+    public static class CosmosDBTriggerSamples
+    {
+        // Sample implementation of the CosmosDBTrigger that listens for changes in a collection.
+        // The trigger uses an auxiliary collection for leases for multiple partitions.
+        public static void Listen(
+            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseCollectionName = "Leases")] IReadOnlyList<Document> modifiedDocuments,
+            TraceWriter log)
+        {
+            foreach (Document modifiedDocument in modifiedDocuments)
+            {
+                log.Info(modifiedDocument.Id);
+            }
+        }
+
+        public static void ListenJArray(
+            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseCollectionName = "Leases")] JArray modifiedDocuments,
+            TraceWriter log)
+        {
+            foreach (var modifiedDocument in modifiedDocuments.Children())
+            {
+                log.Info(modifiedDocument["id"].ToString());
+            }
+        }
+
+        // Sample implementation of the CosmosDBTrigger that listens for changes in a collection.
+        // The trigger uses an auxiliary collection for leases for multiple partitions.
+        // This sample will also copy modifications to another target collection.
+        public static async Task ListenAndCopy(
+            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseCollectionName = "Leases")] IReadOnlyList<Document> modifiedDocuments,
+            [DocumentDB("ItemDb", "ItemCollectionCopy")] IAsyncCollector<Document> copyItems)
+        {
+            foreach (Document modifiedDocument in modifiedDocuments)
+            {
+                await copyItems.AddAsync(modifiedDocument);
+            }
+        }
+    }
+}

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -3,7 +3,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net452" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />

--- a/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
+++ b/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
@@ -15,7 +15,8 @@
     <tags>Microsoft Azure WebJobs Jobs Extensions DocumentDB document windowsazureofficial Web</tags>
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="$WebJobsPackageVersion$" />
-      <dependency id="Microsoft.Azure.DocumentDB" version="1.11.4" />
+      <dependency id="Microsoft.Azure.DocumentDB" version="1.13.2" />
+      <dependency id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" />
     </dependencies>
   </metadata>
 </package>

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    using System;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.WebJobs.Extensions.DocumentDB;
+
+    /// <summary>
+    /// Defines the [CosmosDBTrigger] attribute
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments")]
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public sealed class CosmosDBTriggerAttribute : Attribute
+    {
+        /// <summary>
+        /// Triggers an event when changes occur on a monitored collection
+        /// </summary>
+        /// <param name="databaseName">Name of the database of the collection to monitor for changes</param>
+        /// <param name="collectionName">Name of the collection to monitor for changes</param>
+        public CosmosDBTriggerAttribute(string databaseName, string collectionName)
+        {
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new ArgumentException("Missing information for the collection to monitor", "collectionName");
+            }
+
+            if (string.IsNullOrWhiteSpace(databaseName))
+            {
+                throw new ArgumentException("Missing information for the collection to monitor", "databaseName");
+            }
+
+            CollectionName = collectionName;
+            DatabaseName = databaseName;
+            LeaseCollectionName = CosmosDBTriggerConstants.DefaultLeaseCollectionName;
+            LeaseDatabaseName = this.DatabaseName;
+        }
+
+        /// <summary>
+        /// Connection string for the service containing the collection to monitor
+        /// </summary>
+        [AppSetting]
+        public string ConnectionStringSetting { get; set; }
+
+        /// <summary>
+        /// Name of the collection to monitor for changes
+        /// </summary>
+        [AutoResolve]
+        public string CollectionName { get; private set; }
+
+        /// <summary>
+        /// Name of the database containing the collection to monitor for changes
+        /// </summary>
+        [AutoResolve]
+        public string DatabaseName { get; private set; }
+
+        /// <summary>
+        /// Connection string for the service containing the lease collection
+        /// </summary>
+        [AppSetting]
+        public string LeaseConnectionStringSetting { get; set; }
+
+        /// <summary>
+        /// Name of the lease collection
+        /// </summary>
+        [AutoResolve]
+        public string LeaseCollectionName { get; set; }
+
+        /// <summary>
+        /// Name of the database containing the lease collection
+        /// </summary>
+        [AutoResolve]
+        public string LeaseDatabaseName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the lease options for this particular DocumentDB Trigger. Overrides any value defined in <see cref="DocumentDBConfiguration" /> 
+        /// </summary>
+        public ChangeFeedHostOptions LeaseOptions { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Config;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.WebJobs.Host.Triggers;
+
+    internal class CosmosDBTriggerAttributeBindingProvider : ITriggerBindingProvider
+    {
+        private readonly string _monitorConnectionString;
+        private readonly string _leasesConnectionString;
+        private readonly ChangeFeedHostOptions _leasesOptions;
+
+        public CosmosDBTriggerAttributeBindingProvider(string monitorConnectionString, string leasesConnectionString, ChangeFeedHostOptions leasesOptions = null)
+        {
+            _monitorConnectionString = monitorConnectionString;
+            _leasesConnectionString = leasesConnectionString;
+            _leasesOptions = leasesOptions ?? new ChangeFeedHostOptions();
+        }
+
+        public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+        {
+            // Tries to parse the context parameters and see if it belongs to this [CosmosDBTrigger] binder
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            ParameterInfo parameter = context.Parameter;
+            CosmosDBTriggerAttribute attribute = parameter.GetCustomAttribute<CosmosDBTriggerAttribute>(inherit: false);
+            if (attribute == null)
+            {
+                return Task.FromResult<ITriggerBinding>(null);
+            }
+          
+            DocumentCollectionInfo documentCollectionLocation;
+            DocumentCollectionInfo leaseCollectionLocation;
+            ChangeFeedHostOptions leaseHostOptions = ResolveLeaseOptions(attribute);
+
+            try
+            {
+                string triggerConnectionString = ResolveAttributeConnectionString(attribute);
+                DocumentDBConnectionString triggerConnection = new DocumentDBConnectionString(triggerConnectionString);
+                if (triggerConnection.ServiceEndpoint == null)
+                {
+                    throw new InvalidOperationException("The connection string for the monitored collection is in an invalid format, please use AccountEndpoint=XXXXXX;AccountKey=XXXXXX;.");
+                }
+
+                DocumentDBConnectionString leasesConnection = new DocumentDBConnectionString(ResolveAttributeLeasesConnectionString(attribute, triggerConnectionString));
+                if (triggerConnection.ServiceEndpoint == null)
+                {
+                    throw new InvalidOperationException("The connection string for the leases collection is in an invalid format, please use AccountEndpoint=XXXXXX;AccountKey=XXXXXX;.");
+                }
+
+                documentCollectionLocation = new DocumentCollectionInfo
+                {
+                    Uri = triggerConnection.ServiceEndpoint,
+                    MasterKey = triggerConnection.AuthKey,
+                    DatabaseName = attribute.DatabaseName,
+                    CollectionName = attribute.CollectionName
+                };
+
+                leaseCollectionLocation = new DocumentCollectionInfo
+                {
+                    Uri = leasesConnection.ServiceEndpoint,
+                    MasterKey = leasesConnection.AuthKey,
+                    DatabaseName = attribute.LeaseDatabaseName,
+                    CollectionName = attribute.LeaseCollectionName
+                };
+
+                if (documentCollectionLocation.Uri.Equals(leaseCollectionLocation.Uri)
+                    && documentCollectionLocation.DatabaseName.Equals(leaseCollectionLocation.DatabaseName)
+                    && documentCollectionLocation.CollectionName.Equals(leaseCollectionLocation.CollectionName))
+                {
+                    throw new InvalidOperationException("The monitored collection cannot be the same as the collection storing the leases.");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(string.Format("Cannot create Collection Information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.CollectionName, attribute.DatabaseName, attribute.LeaseCollectionName, attribute.LeaseDatabaseName, ex.Message), ex);
+            }
+
+            return Task.FromResult<ITriggerBinding>(new CosmosDBTriggerBinding(parameter, documentCollectionLocation, leaseCollectionLocation, leaseHostOptions));
+        }
+
+        private string ResolveAttributeConnectionString(CosmosDBTriggerAttribute attribute)
+        {
+            if (string.IsNullOrEmpty(_monitorConnectionString) &&
+                string.IsNullOrEmpty(attribute.ConnectionStringSetting))
+            {
+                throw new InvalidOperationException(
+                    string.Format(CultureInfo.CurrentCulture,
+                    "The DocumentDBTrigger connection string must be set either via a '{0}' app setting, via the DocumentDBTriggerAttribute.ConnectionString property or via DocumentDBConfiguration.TriggerConnectionString.",
+                    DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName));
+            }
+
+            return attribute.ConnectionStringSetting ?? _monitorConnectionString;
+        }
+
+        private string ResolveAttributeLeasesConnectionString(CosmosDBTriggerAttribute attribute, string triggerConnectionString)
+        {
+            // If the leases connection is not specified, it connects to the monitored service
+            return attribute.LeaseConnectionStringSetting ?? _leasesConnectionString ?? triggerConnectionString;
+        }
+
+        private ChangeFeedHostOptions ResolveLeaseOptions(CosmosDBTriggerAttribute attribute)
+        {
+            return attribute.LeaseOptions ?? _leasesOptions;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.WebJobs.Host.Bindings;
+    using Microsoft.Azure.WebJobs.Host.Listeners;
+    using Microsoft.Azure.WebJobs.Host.Protocols;
+    using Microsoft.Azure.WebJobs.Host.Triggers;
+
+    internal class CosmosDBTriggerBinding : ITriggerBinding
+    {
+        private readonly ParameterInfo _parameter;
+        private readonly DocumentCollectionInfo _documentCollectionLocation;
+        private readonly DocumentCollectionInfo _leaseCollectionLocation;
+        private readonly ChangeFeedHostOptions _leaseHostOptions;
+        private readonly IBindingDataProvider _bindingDataProvider;
+
+        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions)
+        {
+            _bindingDataProvider = BindingDataProvider.FromType(parameter.ParameterType);
+            _documentCollectionLocation = documentCollectionLocation;
+            _leaseCollectionLocation = leaseCollectionLocation;
+            _leaseHostOptions = leaseHostOptions;
+            _parameter = parameter;
+        }
+
+        /// <summary>
+        /// Type of value that the Trigger receives from the Executor
+        /// </summary>
+        public Type TriggerValueType => typeof(IReadOnlyList<Document>);
+
+        public IReadOnlyDictionary<string, Type> BindingDataContract
+        {
+            get { return _bindingDataProvider.Contract; }
+        }
+
+        public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+        {
+            IReadOnlyList<Document> triggerValue;
+            try
+            {
+                triggerValue = value as IReadOnlyList<Document>;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("Unable to convert trigger to DocumentDBTrigger:" + ex.Message);
+            }
+
+            var valueBinder = new CosmosDBTriggerValueBinder(_parameter.ParameterType, triggerValue);            
+            return Task.FromResult<ITriggerData>(new TriggerData(valueBinder, _bindingDataProvider.GetBindingData(valueBinder.GetValue())));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context", "Missing listener context");
+            }
+            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions));
+        }
+
+        /// <summary>
+        /// Shows display information on the dashboard
+        /// </summary>
+        /// <returns></returns>
+        public ParameterDescriptor ToParameterDescriptor()
+        {
+            return new CosmosDBTriggerParameterDescriptor
+            {
+                Name = _parameter.Name,
+                Type = CosmosDBTriggerConstants.TriggerName,
+                CollectionName = this._documentCollectionLocation.CollectionName
+            };
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerConstants.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerConstants.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    internal static class CosmosDBTriggerConstants
+    {
+        public const string DefaultLeaseCollectionName = "leases";
+
+        public const string TriggerName = "DocumentDBTrigger";
+
+        public const string TriggerDescription = "New changes on collection {0} at {1}";
+
+        public const string InvokeString = "{0} changes detected.";
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerListener.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.WebJobs.Host.Executors;
+    using Microsoft.Azure.WebJobs.Host.Listeners;
+
+    internal class CosmosDBTriggerListener : IListener, IChangeFeedObserverFactory
+    {
+        private readonly ITriggeredFunctionExecutor executor;
+        private readonly ChangeFeedEventHost host;
+        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions)
+        {
+            this.executor = executor;
+            string hostName = Guid.NewGuid().ToString();
+            this.host = new ChangeFeedEventHost(hostName, documentCollectionLocation, leaseCollectionLocation, new ChangeFeedOptions(), leaseHostOptions);
+        }
+
+        public void Cancel()
+        {
+            this.StopAsync(CancellationToken.None).Wait();
+        }
+
+        public IChangeFeedObserver CreateObserver()
+        {
+            return new CosmosDBTriggerObserver(this.executor);
+        }
+
+        public void Dispose()
+        {
+            //Nothing to dispose
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return host.RegisterObserverFactoryAsync(this);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return host.UnregisterObserversAsync();
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerObserver.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerObserver.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.WebJobs.Host.Executors;
+
+    internal class CosmosDBTriggerObserver : IChangeFeedObserver
+    {
+        private readonly ITriggeredFunctionExecutor executor;
+
+        public CosmosDBTriggerObserver(ITriggeredFunctionExecutor executor)
+        {
+            this.executor = executor;
+        }
+        public Task CloseAsync(ChangeFeedObserverContext context, ChangeFeedObserverCloseReason reason)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context", "Missing observer context");
+            }
+            return Task.CompletedTask;
+        }
+        public Task OpenAsync(ChangeFeedObserverContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context", "Missing observer context");
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyList<Document> docs)
+        {
+            return this.executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = docs }, CancellationToken.None);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerParameterDescriptor.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerParameterDescriptor.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.WebJobs.Host.Protocols;
+
+    /// <summary>
+    /// Trigger parameter descriptor for [CosmosDBTrigger]
+    /// </summary>
+    internal class CosmosDBTriggerParameterDescriptor : TriggerParameterDescriptor
+    {
+        /// <summary>
+        /// Name of the collection being monitored
+        /// </summary>
+        public string CollectionName { get; set; }
+
+        public override string GetTriggerReason(IDictionary<string, string> arguments)
+        {
+            return string.Format(CosmosDBTriggerConstants.TriggerDescription, this.CollectionName, DateTime.UtcNow.ToString("o"));
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerValueBinder.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerValueBinder.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.WebJobs.Extensions.Bindings;
+    using Newtonsoft.Json.Linq;
+
+    internal class CosmosDBTriggerValueBinder : ValueBinder
+    {
+        private readonly Type _type;
+        private readonly object _value;
+        private readonly string _invokeString;
+
+        public CosmosDBTriggerValueBinder(Type type, IReadOnlyList<Document> value)
+                    : base(type)
+        {
+            if (!type.Equals(typeof(IReadOnlyList<Document>)) && !type.Equals(typeof(JArray)))
+            {
+                throw new ArgumentException("Binding can only be done with IReadOnlyList<Document> or JArray", "type");
+            }
+
+            _value = value;
+            _type = type;
+            _invokeString = string.Format(CosmosDBTriggerConstants.InvokeString, value?.Count);
+        }
+
+        public override Task<object> GetValueAsync()
+        {
+            if (_type.Equals(typeof(IReadOnlyList<Document>)))
+            {
+                return Task.FromResult(_value);
+            }
+
+            return Task.FromResult((object)JArray.FromObject(_value));
+        }
+
+        public object GetValue()
+        {
+            if (_type.Equals(typeof(IReadOnlyList<Document>)))
+            {
+                return _value;
+            }
+
+            return JArray.FromObject(_value);
+        }
+
+        public override string ToInvokeString()
+        {
+            return _invokeString;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -40,9 +40,11 @@
     <DocumentationFile>bin\Release\Microsoft.Azure.WebJobs.Extensions.DocumentDB.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.0.0\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -84,7 +86,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -187,6 +188,14 @@
     <Compile Include="Services\DocumentDBService.cs" />
     <Compile Include="Services\DocumentQueryResponse.cs" />
     <Compile Include="Services\IDocumentDBService.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerConstants.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerListener.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerObserver.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerAttribute.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerAttributeBindingProvider.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerBinding.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerValueBinder.cs" />
+    <Compile Include="Trigger\CosmosDBTriggerParameterDescriptor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -209,10 +218,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
-  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/WebJobs.Extensions.DocumentDB/app.config
+++ b/src/WebJobs.Extensions.DocumentDB/app.config
@@ -30,6 +30,10 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net45" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.WebJobs.Extensions.DocumentDB;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
+{
+    public class CosmosDBTriggerAttributeBindingProviderTests
+    {
+        [Theory]
+        [MemberData("InvalidCosmosDBTriggerParameters")]
+        public async Task InvalidParameters_Fail(ParameterInfo parameter)
+        {
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider("notAConnectionString", string.Empty);
+            
+            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None)));
+
+            Assert.NotNull(ex);            
+        }
+
+        [Theory]
+        [MemberData("ValidCosmosDBTriggerParameters")]
+        public async Task ValidParameters_Succeed(ParameterInfo parameter)
+        {
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider("AccountEndpoint=https://someEndpoint;AccountKey=someKey;", string.Empty);
+
+            ITriggerBinding binding = await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.Equal(binding.TriggerValueType, typeof(IReadOnlyList<Document>));
+        }
+
+        public static IEnumerable<ParameterInfo[]> InvalidCosmosDBTriggerParameters
+        {
+            get { return InvalidCosmosDBTriggerBindigs.GetParameters(); }
+        }
+
+        public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerParameters
+        {
+            get { return ValidCosmosDBTriggerBindigs.GetParameters(); }
+        }
+
+        private static ParameterInfo GetFirstParameter(Type type, string methodName)
+        {
+            var methodInfo = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            var paramInfo = methodInfo.GetParameters().First();
+
+            return paramInfo;
+        }
+
+        private static class InvalidCosmosDBTriggerBindigs
+        {
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString")] IReadOnlyList<Document> docs)
+            {
+                
+            }
+
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString", LeaseConnectionStringSetting = "notAConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func4([CosmosDBTrigger("aDatabase", "aCollection", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func5([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString")] object docs)
+            {
+
+            }
+
+            public static void Func6([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static IEnumerable<ParameterInfo[]> GetParameters()
+            {
+                var type = typeof(InvalidCosmosDBTriggerBindigs);
+
+                return new[]
+                {
+                    new[] { GetFirstParameter(type, "Func1") },
+                    new[] { GetFirstParameter(type, "Func2") },
+                    new[] { GetFirstParameter(type, "Func3") },
+                    new[] { GetFirstParameter(type, "Func4") },
+                    new[] { GetFirstParameter(type, "Func5") },
+                    new[] { GetFirstParameter(type, "Func6") }
+                };
+            }
+        }
+
+        private static class ValidCosmosDBTriggerBindigs
+        {
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func4([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;")] JArray docs)
+            {
+
+            }
+
+            public static IEnumerable<ParameterInfo[]> GetParameters()
+            {
+                var type = typeof(ValidCosmosDBTriggerBindigs);
+
+                return new[]
+                {
+                    new[] { GetFirstParameter(type, "Func1") },
+                    new[] { GetFirstParameter(type, "Func2") },
+                    new[] { GetFirstParameter(type, "Func3") },
+                    new[] { GetFirstParameter(type, "Func4") }
+                };
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
+{
+    public class CosmosDBTriggerAttributeTests
+    {
+        [Fact]
+        public void MissingArguments_Fail()
+        {
+            ArgumentException missingDatabaseAndCollection = Assert.Throws<ArgumentException>(() => new CosmosDBTriggerAttribute(null, null));
+            Assert.Equal(missingDatabaseAndCollection.ParamName, "collectionName");
+
+            ArgumentException missingDatabase = Assert.Throws<ArgumentException>(() => new CosmosDBTriggerAttribute(null, "someCollection"));
+            Assert.Equal(missingDatabase.ParamName, "databaseName");
+
+            }
+
+        [Fact]
+        public void CompleteArguments_Succeed()
+        {
+            const string collectionName = "someCollection";
+            const string databaseName = "someDatabase";
+            const string leaseCollectionName = "someLeaseCollection";
+            const string leaseDatabaseName = "someLeaseDatabase";
+            const string defaultLeaseCollectionName = "leases";
+
+            CosmosDBTriggerAttribute attributeWithNoLeaseSpecified = new CosmosDBTriggerAttribute(databaseName, collectionName);
+
+            Assert.Equal(collectionName, attributeWithNoLeaseSpecified.CollectionName);
+            Assert.Equal(databaseName, attributeWithNoLeaseSpecified.DatabaseName);
+            Assert.Equal(defaultLeaseCollectionName, attributeWithNoLeaseSpecified.LeaseCollectionName);
+            Assert.Equal(databaseName, attributeWithNoLeaseSpecified.LeaseDatabaseName);
+
+            CosmosDBTriggerAttribute attributeWithLeaseSpecified = new CosmosDBTriggerAttribute(databaseName, collectionName) { LeaseDatabaseName = leaseDatabaseName, LeaseCollectionName = leaseCollectionName };
+
+            Assert.Equal(collectionName, attributeWithLeaseSpecified.CollectionName);
+            Assert.Equal(databaseName, attributeWithLeaseSpecified.DatabaseName);
+            Assert.Equal(leaseCollectionName, attributeWithLeaseSpecified.LeaseCollectionName);
+            Assert.Equal(leaseDatabaseName, attributeWithLeaseSpecified.LeaseDatabaseName);
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/PublicSurfaceTests.cs
+++ b/test/WebJobs.Extensions.Tests/PublicSurfaceTests.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests
             {
                 "DocumentDBAttribute",
                 "DocumentDBConfiguration",
-                "DocumentDBJobHostConfigurationExtensions"
+                "DocumentDBJobHostConfigurationExtensions",
+                "CosmosDBTriggerAttribute"
             };
 
             AssertPublicTypes(expected, assembly);

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,9 +45,11 @@
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.2-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.11.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.0.0\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
@@ -230,20 +232,18 @@
       <HintPath>..\..\packages\Twilio.4.7.2\lib\3.5\Twilio.Api.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.abstractions">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -272,6 +272,8 @@
     <Compile Include="Extensions\DocumentDB\DocumentDBItemValueBinderTests.cs" />
     <Compile Include="Extensions\DocumentDB\DocumentDBSqlResolutionPolicyTests.cs" />
     <Compile Include="Extensions\DocumentDB\TestDocumentDBServiceFactory.cs" />
+    <Compile Include="Extensions\DocumentDB\Trigger\CosmosDBTriggerAttributeBindingProviderTests.cs" />
+    <Compile Include="Extensions\DocumentDB\Trigger\CosmosDBTriggerAttributeTests.cs" />
     <Compile Include="Extensions\Http\HttpRequestManagerTests.cs" />
     <Compile Include="Extensions\Http\HttpRouteFactoryTests.cs" />
     <Compile Include="Extensions\Http\HttpTriggerAttributeBindingProviderTests.cs" />
@@ -382,11 +384,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.11.4\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/WebJobs.Extensions.Tests/app.config
+++ b/test/WebJobs.Extensions.Tests/app.config
@@ -49,6 +49,10 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.Documents.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.13.0.0" newVersion="1.13.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -4,7 +4,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net452" />
-  <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
@@ -78,12 +79,12 @@
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="Twilio" version="4.7.2" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="7.2.1" targetFramework="net452" />
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net46" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net46" />
   <package id="xunit.MSBuild" version="2.0.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This change adds the `[CosmosDBTrigger]` extension that allows users to subscribe to collection changes.

When changes are detected, the trigger will fire and provide the user with a `IReadOnlyList<Document>` to read and use the documents. The Trigger can also be chained with the `DocumentDB` output binding as demonstrated in one of the samples.

Due to this ability to chain Trigger and Binding, the Trigger has a separate explicit set of Connection Strings to avoid infinite loops. Support for AppSettings, Configuration and Attribute set of the Connection Strings has also been added.

Internally it uses the [ChangeFeedProcessor](https://github.com/Azure/azure-documentdb-dotnet/tree/master/samples/ChangeFeedProcessor) distributed as a Nuget package. Package is still in publishing process.

Samples were added also to the ExtensionsSample Project. 