### PR TITLE
DocDb SQL resolution policy update to handle extended binding data object types

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,26 @@ public static void ReadDocument(
 }
 ```
 
+It is also possible to access through dot expression a value of a Dictionary<string,string> list. The following example uses a HttpTrigger's header values within a query.
+
+```
+Request  HTTP  GET  /api/something
+Headers  headerKey:value
+```
+
+```csharp
+public static void ReadDocument(
+    [HttpTrigger("get", Route = "something")]HttpRequestMessage req,
+    IDictionary<string, string> headers,
+    [DocumentDB("ItemDb", "ItemCollection", SqlQuery = "SELECT c.id, c.fullName, c.department FROM c where c.department = {headers.headerKey}")] IEnumerable<JObject> documents)
+{
+    foreach(JObject doc in documents)
+    {
+        // do something
+    }
+}
+```
+
 
 If you need more control, you can also specify a parameter of type `DocumentClient`. The following example uses DocumentClient to query for all documents in `ItemCollection` and log their ids.
 

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBSqlResolutionPolicyTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
             // Arrange
             PropertyInfo propInfo = null;
             DocumentDBAttribute resolvedAttribute = new DocumentDBAttribute();
-            BindingTemplate bindingTemplate =
+            BindingTemplate bindingTemplate = 
                 BindingTemplate.FromString("SELECT * FROM c WHERE c.id = {foo} AND c.value = {bar}");
             Dictionary<string, object> bindingData = new Dictionary<string, object>();
             bindingData.Add("foo", "1234");


### PR DESCRIPTION
Pull request to add function to DocumentDb's custom SQL binding resolution policy to allow dot expansion to bind into a dictionary's value.  (Eg, HttpTrigger headers output).

-- Background --
(Note; Found through Compiled Azure Functions, Vs 2017 preview 15.3)

Binding data can now be provided as more complex objects into a docDb Sql query.  Specifically #225 expands the usability of Http Trigger data (eg, headers & query parameters) providing Dictionary<string, string> properties.

Dot expressions were added Azure/azure-webjobs-sdk#1117 in the binding template, enabling consumption. eg. `[Blob("output/{headers.foo}")] string outBlob`

Issue noted at end of #225 was later isolated to DocDb Sql resolution policy, as AutoResolveAttribute's policy was being over ridden with this custom policy (only catering for simple string binding).

-- Scope --

Currently, this DocumentDbAttribute usage would fail (note dot expansion in SqlQuery) when trying to take a header value from a HttpTrigger (Simply a binding property of type Dictionary<string, string>)
`[DocumentDB("dbName", "dbColName", ConnectionStringSetting = "DocumentDbConnectionString", SqlQuery = "SELECT * FROM c WHERE c.SomeValue = {headers.testHeaderValue}")]`

Pull request code and tests to implement the above.