### PR TITLE
Update Http to support SDK return values

### DIFF
--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -70,10 +70,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/ExtensionsSample/packages.config
+++ b/src/ExtensionsSample/packages.config
@@ -7,8 +7,8 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />

--- a/src/Sample.Extension/Sample.Extension.csproj
+++ b/src/Sample.Extension/Sample.Extension.csproj
@@ -38,10 +38,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/Sample.Extension/packages.config
+++ b/src/Sample.Extension/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -48,10 +48,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -3,8 +3,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -49,10 +49,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Azure.DocumentDB" version="1.11.4" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.Http/Config/HttpExtensionConfiguration.cs
+++ b/src/WebJobs.Extensions.Http/Config/HttpExtensionConfiguration.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Http
 {
@@ -50,6 +52,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         public bool DynamicThrottlesEnabled { get; set; }
 
         /// <summary>
+        /// Hook to enable a host to receive the response
+        /// </summary>
+        [JsonIgnore]
+        public Action<HttpRequestMessage, object> SetResponse { get; set; }
+
+        /// <summary>
         /// Initializes the extension.
         /// </summary>
         /// <param name="context">The <see cref="ExtensionConfigContext"/>.</param>
@@ -60,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
                 throw new ArgumentNullException(nameof(context));
             }
 
-            context.Config.RegisterBindingExtension(new HttpTriggerAttributeBindingProvider());
+            context.Config.RegisterBindingExtension(new HttpTriggerAttributeBindingProvider(this.SetResponse));
         }
     }
 }

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -43,10 +43,10 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.Http/packages.config
+++ b/src/WebJobs.Extensions.Http/packages.config
@@ -3,8 +3,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net46" />

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -47,10 +47,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.MobileApps/packages.config
+++ b/src/WebJobs.Extensions.MobileApps/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
+++ b/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
@@ -67,10 +67,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.NotificationHubs/packages.config
+++ b/src/WebJobs.Extensions.NotificationHubs/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions.NuGet/WebJobs.Extensions.nuspec
+++ b/src/WebJobs.Extensions.NuGet/WebJobs.Extensions.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions Files Scheduler Cron Storage Table Blob Queue windowsazureofficial Web</tags>
     <dependencies>
-      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" />
       <dependency id="ncrontab" version="3.3.0" />
       <dependency id="Microsoft.Tpl.Dataflow" version="4.5.24" />
     </dependencies>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -46,10 +46,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.SendGrid/packages.config
+++ b/src/WebJobs.Extensions.SendGrid/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net452" />

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -44,10 +44,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions.Twilio/packages.config
+++ b/src/WebJobs.Extensions.Twilio/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="JWT" version="1.3.4" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -49,10 +49,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/src/WebJobs.Extensions/packages.config
+++ b/src/WebJobs.Extensions/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net45" />

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -58,10 +58,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10851\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.1.0-beta1-10927\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.8.2\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />
-  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10851" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10851" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs" version="2.1.0-beta1-10927" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0-beta1-10927" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net452" />


### PR DESCRIPTION
Requires a latest SDK build.
Specifically minimize the code deltas here to support the parallel migration to core.