### PR TITLE
Fixups to ExecutionContext

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Core/Config/CoreJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions/Extensions/Core/Config/CoreJobHostConfigurationExtensions.cs
@@ -19,18 +19,21 @@ namespace Microsoft.Azure.WebJobs
         /// Registers the Core extensions
         /// </summary>
         /// <param name="config"></param>
-        public static void UseCore(this JobHostConfiguration config)
+        /// <param name="appDirectory"></param>
+        public static void UseCore(this JobHostConfiguration config, string appDirectory = null)
         {
             if (config == null)
             {
                 throw new ArgumentNullException("config");
             }
 
-            config.RegisterExtensionConfigProvider(new CoreExtensionConfig());
+            config.RegisterExtensionConfigProvider(new CoreExtensionConfig { AppDirectory = appDirectory });
         }
 
-        private class CoreExtensionConfig : IExtensionConfigProvider
+        internal class CoreExtensionConfig : IExtensionConfigProvider
         {
+            public string AppDirectory { get; set; }
+
             public void Initialize(ExtensionConfigContext context)
             {
                 if (context == null)
@@ -39,7 +42,7 @@ namespace Microsoft.Azure.WebJobs
                 }
 
                 context.Config.RegisterBindingExtensions(
-                    new ExecutionContextBindingProvider(),
+                    new ExecutionContextBindingProvider(this),
                     new ErrorTriggerAttributeBindingProvider(context.Config));
             }
         }

--- a/src/WebJobs.Extensions/Extensions/Core/ExecutionContext.cs
+++ b/src/WebJobs.Extensions/Extensions/Core/ExecutionContext.cs
@@ -21,8 +21,16 @@ namespace Microsoft.Azure.WebJobs
         public string FunctionName { get; set; }
 
         /// <summary>
-        /// Gets or sets the function directory
+        /// Gets or sets the function directory. This is <see cref="FunctionAppDirectory"/> concatenated with <see cref="FunctionName"/>
         /// </summary>
         public string FunctionDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function application directory as determined by the host.  May be null if not set. 
+        /// </summary>
+        /// <remarks>
+        /// A host can set this via <see cref="CoreJobHostConfigurationExtensions.UseCore(JobHostConfiguration, string)"/>
+        /// </remarks>
+        public string FunctionAppDirectory { get; set; }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Core/CoreBindingEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Core/CoreBindingEndToEndTests.cs
@@ -40,6 +40,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Core
             {
                 Context = context;
             }
+
+            [NoAutomaticTrigger]
+            [FunctionName("myfunc")] 
+            public static void ExecutionContext2(ExecutionContext context)
+            {
+                Context = context;
+            }
+        }
+
+        [Fact]
+        public async Task SetAppDirectory()
+        {
+            JobHostConfiguration config = new JobHostConfiguration
+            {
+                TypeLocator = new ExplicitTypeLocator(typeof(CoreTestJobs))
+            };
+            config.UseCore(@"z:\home");
+            JobHost host = new JobHost(config);
+
+            await host.CallAsync("myfunc");
+
+            ExecutionContext result = CoreTestJobs.Context;
+            Assert.NotNull(result);
+            Assert.NotEqual(Guid.Empty, result.InvocationId);
+            Assert.Equal("myfunc", result.FunctionName);
+            Assert.Equal(@"z:\home\myfunc", result.FunctionDirectory);
+            Assert.Equal(@"z:\home", result.FunctionAppDirectory);
         }
     }
 }


### PR DESCRIPTION
Add FunctionAppDirectory path, set to  something determined by the host. Script runtime will set this to ScriptConfig.RootScriptPath

Also fix ExecutionContext.FunctionName to properly honor [FunctionName] attribute. 
