### PR TITLE
Added support for Direct Send in Notification Hubs

### DIFF
--- a/src/WebJobs.Extensions.NotificationHubs/Bindings/NotificationHubDirectSendAsyncCollector.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Bindings/NotificationHubDirectSendAsyncCollector.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.NotificationHubs;
+using Microsoft.Azure.WebJobs.Host;
+
+namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
+{
+    internal class NotificationHubDirectSendAsyncCollector : IAsyncCollector<DirectNotification>
+    {
+        private INotificationHubClientService _notificationHubclientService;
+        private bool _enableTestSend;
+        private TraceWriter _traceWriter;
+
+        public NotificationHubDirectSendAsyncCollector(INotificationHubClientService clientService, bool enableTestSend, TraceWriter traceWriter)
+        {
+            _notificationHubclientService = clientService;
+            _enableTestSend = enableTestSend;
+            _traceWriter = traceWriter;
+        }
+
+        public async Task AddAsync(DirectNotification item, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            NotificationOutcome notificationOutcome = await _notificationHubclientService.SendDirectNotificationAsync(item.Notification, item.DeviceHandle);
+            if (_enableTestSend)
+            {
+                string debugLog = $"NotificationHubs Test Send\r\n" +
+                    $"  TrackingId = {notificationOutcome.TrackingId}\r\n" +
+                    $"  State = {notificationOutcome.State}\r\n" +
+                    $"  Results (Success = {notificationOutcome.Success}, Failure = {notificationOutcome.Failure})\r\n";
+                if (notificationOutcome.Results != null)
+                {
+                    foreach (RegistrationResult result in notificationOutcome.Results)
+                    {
+                        debugLog += $"    ApplicationPlatform:{result.ApplicationPlatform}, RegistrationId:{result.RegistrationId}, Outcome:{result.Outcome}\r\n";
+                    }
+                }
+                _traceWriter.Info(debugLog);
+            }
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.NotificationHubs/Bindings/NotificationHubDirectSendClientBuilder.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Bindings/NotificationHubDirectSendClientBuilder.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.NotificationHubs;
+
+namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs.Bindings
+{
+    internal class NotificationHubDirectSendClientBuilder : IConverter<NotificationHubDirectSendAttribute, NotificationHubClient>
+    {
+        private NotificationHubsConfiguration _config;
+
+        public NotificationHubDirectSendClientBuilder(NotificationHubsConfiguration config)
+        {
+            _config = config;
+        }
+
+        public NotificationHubClient Convert(NotificationHubDirectSendAttribute attribute)
+        {
+            if (attribute == null)
+            {
+                throw new ArgumentNullException(nameof(attribute));
+            }
+
+            string resolvedConnectionString = _config.ResolveConnectionString(attribute.ConnectionStringSetting);
+            string resolvedHubName = _config.ResolveHubName(attribute.HubName);
+            INotificationHubClientService service = _config.GetService(resolvedConnectionString, resolvedHubName, attribute.EnableTestSend);
+
+            return service.GetNotificationHubClient();
+        }
+    }
+}

--- a/src/WebJobs.Extensions.NotificationHubs/Config/NotificationHubJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Config/NotificationHubJobHostConfigurationExtensions.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs
             {
                 notificationHubsConfig = new NotificationHubsConfiguration();
             }
+
             config.RegisterExtensionConfigProvider(notificationHubsConfig);
         }
     }

--- a/src/WebJobs.Extensions.NotificationHubs/Config/NotificationHubsConfiguration.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Config/NotificationHubsConfiguration.cs
@@ -65,6 +65,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
             var ruleOutput = bindingFactory.BindToCollector<NotificationHubAttribute, Notification>((attribute) => BuildFromAttribute(attribute, context.Trace));
 
             extensions.RegisterBindingRules<NotificationHubAttribute>(ruleOutput, clientProvider);
+
+            clientProvider = bindingFactory.BindToInput<NotificationHubDirectSendAttribute, NotificationHubClient>(new NotificationHubDirectSendClientBuilder(this));
+
+            ruleOutput = bindingFactory.BindToCollector<NotificationHubDirectSendAttribute, DirectNotification>((attribute) => BuildFromAttribute(attribute, context.Trace));
+
+            extensions.RegisterBindingRules<NotificationHubDirectSendAttribute>(ruleOutput, clientProvider);
         }
 
         internal IAsyncCollector<Notification> BuildFromAttribute(NotificationHubAttribute attribute, TraceWriter trace)
@@ -75,6 +81,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
 
             INotificationHubClientService service = GetService(resolvedConnectionString, resolvedHubName, enableTestSend);
             return new NotificationHubAsyncCollector(service, attribute.TagExpression, attribute.EnableTestSend, trace);
+        }
+
+        internal IAsyncCollector<DirectNotification> BuildFromAttribute(NotificationHubDirectSendAttribute attribute, TraceWriter trace)
+        {
+            string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
+            string resolvedHubName = ResolveHubName(attribute.HubName);
+            bool enableTestSend = attribute.EnableTestSend;
+
+            INotificationHubClientService service = GetService(resolvedConnectionString, resolvedHubName, enableTestSend);
+            return new NotificationHubDirectSendAsyncCollector(service, attribute.EnableTestSend, trace);
         }
 
         internal NotificationHubClient BindForNotificationHubClient(NotificationHubAttribute attribute)

--- a/src/WebJobs.Extensions.NotificationHubs/DirectNotification.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/DirectNotification.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.NotificationHubs;
+
+namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
+{
+    /// <summary>
+    /// Describes a direct send notification
+    /// </summary>
+    public class DirectNotification
+    {
+        /// <summary>
+        /// Notification
+        /// </summary>
+        public Notification Notification { get; set; }
+
+        /// <summary>
+        /// Handle of device
+        /// </summary>
+        public string DeviceHandle { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.NotificationHubs/NotificationHubDirectSendAttribute.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/NotificationHubDirectSendAttribute.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.NotificationHubs;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Extensions.NotificationHubs;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Attribute used to bind a parameter to an Azure NotificationHub
+    /// </summary>
+    /// <remarks>
+    /// The method parameter type can be one of the following:
+    /// <list type="bullet">
+    /// <item><description><see cref="IAsyncCollector{T}"/>, where T is a <see cref="DirectNotification"/>.</description></item>
+    /// </list>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    [Binding]
+    public sealed class NotificationHubDirectSendAttribute : Attribute
+    {
+        /// <summary>
+        /// Optional. A string value indicating the app setting to use as the Notification Hubs connection
+        /// string, if different than the one specified in the <see cref="NotificationHubsConfiguration"/>.
+        /// </summary>
+        [AppSetting]
+        public string ConnectionStringSetting { get; set; }
+
+        /// <summary>
+        /// Optional. The Notification Hub Name to use, if different than the one specified in the
+        /// <see cref="NotificationHubsConfiguration"/>.
+        /// </summary>
+        public string HubName { get; set; }
+
+        /// <summary>
+        /// Optional. Boolean value to enable debug send on NotificationHubClient
+        /// <see cref="NotificationHubClient"/>.
+        /// </summary>
+        public bool EnableTestSend { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.NotificationHubs/Services/INotificationHubClientService.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Services/INotificationHubClientService.cs
@@ -20,6 +20,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
         Task<NotificationOutcome> SendNotificationAsync(Notification notification, string tagExpression);
 
         /// <summary>
+        /// Asynchronously sends a direct notification to a specific device
+        /// </summary>
+        /// <param name="notification">notification to send</param>
+        /// <param name="deviceHandle">the deviceHandle of the target device</param>
+        /// <returns></returns>
+        Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, string deviceHandle);
+
+        /// <summary>
         /// Returns the underlying <see cref="NotificationHubClient"/>.
         /// </summary>
         /// <returns></returns>

--- a/src/WebJobs.Extensions.NotificationHubs/Services/NotificationHubClientService.cs
+++ b/src/WebJobs.Extensions.NotificationHubs/Services/NotificationHubClientService.cs
@@ -3,7 +3,6 @@
 
 using System.Threading.Tasks;
 using Microsoft.Azure.NotificationHubs;
-using Microsoft.Azure.WebJobs.Host;
 
 namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
 {
@@ -23,6 +22,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.NotificationHubs
         public Task<NotificationOutcome> SendNotificationAsync(Notification notification, string tagExpression)
         {
             return _notificationHubClient.SendNotificationAsync(notification, tagExpression);
+        }
+
+        public Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, string deviceHandle)
+        {
+            return _notificationHubClient.SendDirectNotificationAsync(notification, deviceHandle);
         }
 
         public NotificationHubClient GetNotificationHubClient()

--- a/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
+++ b/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
@@ -18,6 +18,7 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <SyncToOfflineSchemaModel>True</SyncToOfflineSchemaModel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,14 +41,18 @@
     <DocumentationFile>bin\Release\Microsoft.Azure.WebJobs.Extensions.NotificationHubs.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Bindings\NotificationHubDirectSendAsyncCollector.cs" />
     <Compile Include="Bindings\NotificationHubAsyncCollector.cs" />
+    <Compile Include="Bindings\NotificationHubDirectSendClientBuilder.cs" />
     <Compile Include="Bindings\NotificationHubClientBuilder.cs" />
     <Compile Include="Config\Converter.cs" />
     <Compile Include="Config\DefaultNotificationHubServiceFactory.cs" />
     <Compile Include="Config\INotificationHubClientServiceFactory.cs" />
     <Compile Include="Config\NotificationHubsConfiguration.cs" />
     <Compile Include="Config\NotificationHubJobHostConfigurationExtensions.cs" />
+    <Compile Include="DirectNotification.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="NotificationHubDirectSendAttribute.cs" />
     <Compile Include="NotificationHubAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\INotificationHubClientService.cs" />
@@ -180,6 +185,7 @@
       <HintPath>..\..\packages\System.Spatial.5.8.2\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -188,15 +194,15 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <CodeAnalysisDictionary Include="..\..\CustomDictionary.xml">
+      <Link>CustomDictionary.xml</Link>
+    </CodeAnalysisDictionary>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\WebJobs.Extensions\WebJobs.Extensions.csproj">
       <Project>{e6f59990-f3a1-469f-a9d8-6d529121d385}</Project>
       <Name>WebJobs.Extensions</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <CodeAnalysisDictionary Include="..\..\CustomDictionary.xml">
-      <Link>CustomDictionary.xml</Link>
-    </CodeAnalysisDictionary>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -18,6 +18,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <SyncToOfflineSchemaModel>True</SyncToOfflineSchemaModel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
This pull request adds a new NotificationHubDirectSendAttribute which allows a connection to an Azure Notification Hub to send notifications directly to a specific device. A new type called DirectNotification has been added that holds both a notification and a DeviceHandle.