### PR TITLE
Migrate Event Hub Extension to .Net Core

### DIFF
--- a/WebJobs.Extensions.sln
+++ b/WebJobs.Extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26724.1
+VisualStudioVersion = 15.0.26730.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1118E0AD-83C8-4B67-859B-FCDEF54338C1}"
 EndProject
@@ -22,11 +22,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtensionsSample", "src\Ext
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.Tests", "test\WebJobs.Extensions.Tests\WebJobs.Extensions.Tests.csproj", "{1729561F-D598-4208-9154-3A5497523D54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.Extension", "src\Sample.Extension\Sample.Extension.csproj", "{55EDABA0-8D31-43C9-AB3C-2A40D0EFF28A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Extension", "src\Sample.Extension\Sample.Extension.csproj", "{55EDABA0-8D31-43C9-AB3C-2A40D0EFF28A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions", "src\WebJobs.Extensions\WebJobs.Extensions.csproj", "{7719584E-9863-405A-9D26-2CC02AFC2427}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.Http", "src\WebJobs.Extensions.Http\WebJobs.Extensions.Http.csproj", "{47B3ECC3-DDDB-4C80-8A13-E6279A2EB835}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.EventHubs", "src\WebJobs.Extensions.EventHubs\WebJobs.Extensions.EventHubs.csproj", "{37B71EB7-54DF-45FC-B25C-C80A797BB765}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +56,10 @@ Global
 		{47B3ECC3-DDDB-4C80-8A13-E6279A2EB835}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{47B3ECC3-DDDB-4C80-8A13-E6279A2EB835}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47B3ECC3-DDDB-4C80-8A13-E6279A2EB835}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37B71EB7-54DF-45FC-B25C-C80A797BB765}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37B71EB7-54DF-45FC-B25C-C80A797BB765}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37B71EB7-54DF-45FC-B25C-C80A797BB765}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37B71EB7-54DF-45FC-B25C-C80A797BB765}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -64,6 +70,7 @@ Global
 		{55EDABA0-8D31-43C9-AB3C-2A40D0EFF28A} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
 		{7719584E-9863-405A-9D26-2CC02AFC2427} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
 		{47B3ECC3-DDDB-4C80-8A13-E6279A2EB835} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
+		{37B71EB7-54DF-45FC-B25C-C80A797BB765} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {821EF04F-5408-46AD-94ED-0E939B89D4B8}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,8 @@ build_script:
     dotnet pack src\WebJobs.Extensions\WebJobs.Extensions.csproj -o ..\..\buildoutput --no-build --version-suffix "-$env:APPVEYOR_BUILD_NUMBER"
 
     dotnet pack src\WebJobs.Extensions.Http\WebJobs.Extensions.Http.csproj -o ..\..\buildoutput --no-build --version-suffix "-$env:APPVEYOR_BUILD_NUMBER"
+
+    dotnet pack src\WebJobs.Extensions.EventHubs\WebJobs.Extensions.EventHubs.csproj -o ..\..\buildoutput --no-build --version-suffix "-$env:APPVEYOR_BUILD_NUMBER"
 test_script:
 - ps: >-
     dotnet test .\test\WebJobs.Extensions.Tests\ -v q --no-build -p:ParallelizeTestCollections=false

--- a/src/WebJobs.Extensions.EventHubs/EventHubAsyncCollector.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubAsyncCollector.cs
@@ -16,17 +16,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
     /// </summary>
     public class EventHubAsyncCollector : IAsyncCollector<EventData>
     {
+        private const int BatchSize = 100;
+
+        // Suggested to use 240k instead of 256k to leave padding room for headers.
+        private const int MaxByteSize = 240 * 1024;
+
         private readonly EventHubClient _client;
 
         private List<EventData> _list = new List<EventData>();
 
         // total size of bytes in _list that we'll be sending in this batch. 
         private int _currentByteSize = 0;
-
-        private const int BatchSize = 100;
-
-        // Suggested to use 240k instead of 256k to leave padding room for headers.
-        private const int MaxByteSize = 240 * 1024; 
 
         /// <summary>
         /// Create a sender around the given client. 
@@ -74,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
                         _currentByteSize += size;
                         return;
                     }
+
                     // We should flush. 
                     // Release the lock, flush, and then loop around and try again. 
                 }                    

--- a/src/WebJobs.Extensions.EventHubs/EventHubAsyncCollector.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubAsyncCollector.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Core object to send events to EventHub. 
+    /// Any user parameter that sends EventHub events will eventually get bound to this object. 
+    /// This will queue events and send in batches, also keeping under the 256kb event hub limit per batch. 
+    /// </summary>
+    public class EventHubAsyncCollector : IAsyncCollector<EventData>
+    {
+        private readonly EventHubClient _client;
+
+        private List<EventData> _list = new List<EventData>();
+
+        // total size of bytes in _list that we'll be sending in this batch. 
+        private int _currentByteSize = 0;
+
+        private const int BatchSize = 100;
+
+        // Suggested to use 240k instead of 256k to leave padding room for headers.
+        private const int MaxByteSize = 240 * 1024; 
+
+        /// <summary>
+        /// Create a sender around the given client. 
+        /// </summary>
+        /// <param name="client"></param>
+        public EventHubAsyncCollector(EventHubClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException("client");
+            }
+            _client = client;
+        }
+
+        /// <summary>
+        /// Add an event. 
+        /// </summary>
+        /// <param name="item">The event to add</param>
+        /// <param name="cancellationToken">a cancellation token. </param>
+        /// <returns></returns>
+        public async Task AddAsync(EventData item, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException("item");
+            }
+
+            while (true)
+            {
+                lock (_list)
+                {
+                    var size = (int)item.SerializedSizeInBytes;
+
+                    if (size > MaxByteSize)
+                    {
+                        // Single event is too large to add.
+                        string msg = string.Format("Event is too large. Event is approximately {0}b and max size is {1}b", size, MaxByteSize);
+                        throw new InvalidOperationException(msg);
+                    }
+
+                    bool flush = (_currentByteSize + size > MaxByteSize) || (_list.Count >= BatchSize);
+                    if (!flush)
+                    {
+                        _list.Add(item);
+                        _currentByteSize += size;
+                        return;
+                    }
+                    // We should flush. 
+                    // Release the lock, flush, and then loop around and try again. 
+                }                    
+
+                await this.FlushAsync(cancellationToken);                
+            }
+        }
+
+        /// <summary>
+        /// synchronously flush events that have been queued up via AddAsync.
+        /// </summary>
+        /// <param name="cancellationToken">a cancellation token</param>
+        public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            EventData[] batch = null;
+            lock (_list)
+            {
+                batch = _list.ToArray();
+                _list.Clear();
+                _currentByteSize = 0;
+            }
+
+            if (batch.Length > 0)
+            {
+                await this.SendBatchAsync(batch);
+
+                // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
+                foreach (var msg in batch)
+                {
+                    msg.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Send the batch of events.
+        /// </summary>
+        /// <param name="batch">the set of events to send</param>
+        protected virtual async Task SendBatchAsync(EventData[] batch)
+        {
+            await _client.SendBatchAsync(batch);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubAsyncCollector.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubAsyncCollector.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ServiceBus.Messaging;
+using Microsoft.Azure.EventHubs;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     /// <summary>
     /// Core object to send events to EventHub. 
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             {
                 lock (_list)
                 {
-                    var size = (int)item.SerializedSizeInBytes;
+                    var size = item.Body.Count;
 
                     if (size > MaxByteSize)
                     {
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
         /// <param name="batch">the set of events to send</param>
         protected virtual async Task SendBatchAsync(EventData[] batch)
         {
-            await _client.SendBatchAsync(batch);
+            await _client.SendAsync(batch);
         }
     }
 }

--- a/src/WebJobs.Extensions.EventHubs/EventHubAttribute.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubAttribute.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Setup an 'output' binding to an EventHub. This can be any output type compatible with an IAsyncCollector.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    [Binding]
+    public sealed class EventHubAttribute : Attribute, IConnectionProvider
+    {
+        /// <summary>
+        /// Initialize a new instance of the <see cref="EventHubAttribute"/>
+        /// </summary>
+        /// <param name="eventHubName">Name of the event hub as resolved against the <see cref="EventHubConfiguration"/> </param>
+        public EventHubAttribute(string eventHubName)
+        {
+            this.EventHubName = eventHubName;
+        }
+
+        /// <summary>
+        /// The name of the event hub. This is resolved against the <see cref="EventHubConfiguration"/>
+        /// </summary>
+        [AutoResolve]
+        public string EventHubName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub sender.
+        /// </summary>
+        [AppSetting]
+        public string Connection { get; set; }
+    }    
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubAttribute.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubAttribute.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Azure.WebJobs.Description;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     /// <summary>
     /// Setup an 'output' binding to an EventHub. This can be any output type compatible with an IAsyncCollector.

--- a/src/WebJobs.Extensions.EventHubs/EventHubConfiguration.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubConfiguration.cs
@@ -1,0 +1,450 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.ServiceBus;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Provide configuration for event hubs. 
+    /// This is primarily mapping names to underlying EventHub listener and receiver objects from the EventHubs SDK. 
+    /// </summary>
+    public class EventHubConfiguration : IExtensionConfigProvider
+    {
+        // Event Hub Names are case-insensitive.
+        // The same path can have multiple connection strings with different permissions (sending and receiving), 
+        // so we track senders and receivers separately and infer which one to use based on the EventHub (sender) vs. EventHubTrigger (receiver) attribute. 
+        // Connection strings may also encapsulate different endpoints. 
+        private readonly Dictionary<string, EventHubClient> _senders = new Dictionary<string, EventHubClient>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, ReceiverCreds> _receiverCreds = new Dictionary<string, ReceiverCreds>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, EventProcessorHost> _explicitlyProvidedHosts = new Dictionary<string, EventProcessorHost>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly EventProcessorOptions _options;
+        private readonly PartitionManagerOptions _partitionOptions; // optional, used to create EventProcessorHost
+
+        private string _defaultStorageString; // set to JobHostConfig.StorageConnectionString
+        private int _batchCheckpointFrequency = 1;
+
+        /// <summary>
+        /// Name of the blob container that the EventHostProcessor instances uses to coordinate load balancing listening on an event hub. 
+        /// Each event hub gets its own blob prefix within the container. 
+        /// </summary>
+        public const string LeaseContainerName = "azure-webjobs-eventhub";
+
+        /// <summary>
+        /// default constructor. Callers can reference this without having any assembly references to service bus assemblies. 
+        /// </summary>
+        public EventHubConfiguration()
+            : this(null, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="options">The optional <see cref="EventProcessorOptions"/> to use when receiving events.</param>
+        /// <param name="partitionOptions">Optional <see cref="PartitionManagerOptions"/> to use to configure any EventProcessorHosts. </param>
+        public EventHubConfiguration(
+            EventProcessorOptions options, 
+            PartitionManagerOptions partitionOptions = null)
+        {
+            if (options == null)
+            {
+                options = EventProcessorOptions.DefaultOptions;
+                options.MaxBatchSize = 64;
+                options.PrefetchCount = options.MaxBatchSize * 4;
+            }
+            _partitionOptions = partitionOptions;
+
+            _options = options;
+        }
+
+        /// <summary>
+        /// Gets or sets the number of batches to process before creating an EventHub cursor checkpoint. Default 1.
+        /// </summary>
+        public int BatchCheckpointFrequency
+        {
+            get
+            {
+                return _batchCheckpointFrequency;
+            }
+
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new InvalidOperationException("Batch checkpoint frequency must be larger than 0.");
+                }
+                _batchCheckpointFrequency = value;
+            }
+        }
+
+        /// <summary>
+        /// Add an existing client for sending messages to an event hub.  Infer the eventHub name from client.path
+        /// </summary>
+        /// <param name="client"></param>
+        public void AddEventHubClient(EventHubClient client)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException("client");
+            }
+            string eventHubName = client.Path;
+            AddEventHubClient(eventHubName, client);
+        }
+
+        /// <summary>
+        /// Add an existing client for sending messages to an event hub.  Infer the eventHub name from client.path
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub</param>
+        /// <param name="client"></param>
+        public void AddEventHubClient(string eventHubName, EventHubClient client)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (client == null)
+            {
+                throw new ArgumentNullException("client");
+            }
+           
+            _senders[eventHubName] = client;
+        }
+
+        /// <summary>
+        /// Add a connection for sending messages to an event hub. Connect via the connection string. 
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub. </param>
+        /// <param name="sendConnectionString">connection string for sending messages. If this includes an EntityPath, it takes precedence over the eventHubName parameter.</param>
+        public void AddSender(string eventHubName, string sendConnectionString)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (sendConnectionString == null)
+            {
+                throw new ArgumentNullException("sendConnectionString");
+            }
+
+            ServiceBusConnectionStringBuilder sb = new ServiceBusConnectionStringBuilder(sendConnectionString);
+            if (string.IsNullOrWhiteSpace(sb.EntityPath))
+            {
+                sb.EntityPath = eventHubName;
+            }            
+
+            var client = EventHubClient.CreateFromConnectionString(sb.ToString());
+            AddEventHubClient(eventHubName, client);
+        }
+
+        /// <summary>
+        /// Add a connection for listening on events from an event hub. 
+        /// </summary>
+        /// <param name="eventHubName">Name of the event hub</param>
+        /// <param name="listener">initialized listener object</param>
+        /// <remarks>The EventProcessorHost type is from the ServiceBus SDK. 
+        /// Allow callers to bind to EventHubConfiguration without needing to have a direct assembly reference to the ServiceBus SDK. 
+        /// The compiler needs to resolve all types in all overloads, so give methods that use the ServiceBus SDK types unique non-overloaded names
+        /// to avoid eager compiler resolution. 
+        /// </remarks>
+        public void AddEventProcessorHost(string eventHubName, EventProcessorHost listener)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (listener == null)
+            {
+                throw new ArgumentNullException("listener");
+            }
+
+            _explicitlyProvidedHosts[eventHubName] = listener;
+        }
+
+        /// <summary>
+        /// Add a connection for listening on events from an event hub. Connect via the connection string and use the SDK's built-in storage account.
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub</param>
+        /// <param name="receiverConnectionString">connection string for receiving messages. This can encapsulate other service bus properties like the namespace and endpoints.</param>
+        public void AddReceiver(string eventHubName, string receiverConnectionString)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (receiverConnectionString == null)
+            {
+                throw new ArgumentNullException("receiverConnectionString");
+            }
+
+            this._receiverCreds[eventHubName] = new ReceiverCreds
+            {
+                 EventHubConnectionString = receiverConnectionString
+            };
+        }
+
+        /// <summary>
+        /// Add a connection for listening on events from an event hub. Connect via the connection string and use the supplied storage account
+        /// </summary>
+        /// <param name="eventHubName">name of the event hub</param>
+        /// <param name="receiverConnectionString">connection string for receiving messages</param>
+        /// <param name="storageConnectionString">storage connection string that the EventProcessorHost client will use to coordinate multiple listener instances. </param>
+        public void AddReceiver(string eventHubName, string receiverConnectionString, string storageConnectionString)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (receiverConnectionString == null)
+            {
+                throw new ArgumentNullException("receiverConnectionString");
+            }
+            if (storageConnectionString == null)
+            {
+                throw new ArgumentNullException("storageConnectionString");
+            }
+
+            this._receiverCreds[eventHubName] = new ReceiverCreds
+            {
+                EventHubConnectionString = receiverConnectionString,
+                StorageConnectionString = storageConnectionString
+            };
+        }
+        
+        internal EventHubClient GetEventHubClient(string eventHubName, string connection)
+        {
+            EventHubClient client;
+            if (_senders.TryGetValue(eventHubName, out client))             
+            {
+                return client;
+            }
+            else if (!string.IsNullOrWhiteSpace(connection))
+            {
+                AddSender(eventHubName, connection);
+                return _senders[eventHubName];
+            }
+            throw new InvalidOperationException("No event hub sender named " + eventHubName);
+        }
+
+        // Lookup a listener for receiving events given the name provided in the [EventHubTrigger] attribute. 
+        internal EventProcessorHost GetEventProcessorHost(string eventHubName, string consumerGroup)
+        {
+            ReceiverCreds creds;
+            if (this._receiverCreds.TryGetValue(eventHubName, out creds))
+            {
+                // Common case. Create a new EventProcessorHost instance to listen. 
+                string eventProcessorHostName = Guid.NewGuid().ToString();
+
+                if (consumerGroup == null)
+                {
+                    consumerGroup = EventHubConsumerGroup.DefaultGroupName;
+                }
+                var storageConnectionString = creds.StorageConnectionString;
+                if (storageConnectionString == null)
+                {
+                    storageConnectionString = _defaultStorageString;
+                }
+
+                // If the connection string provides a hub name, that takes precedence. 
+                // Note that connection strings *can't* specify a consumerGroup, so must always be passed in. 
+                string actualPath = eventHubName;
+                ServiceBusConnectionStringBuilder sb = new ServiceBusConnectionStringBuilder(creds.EventHubConnectionString);
+                if (sb.EntityPath != null)
+                {
+                    actualPath = sb.EntityPath;
+                    sb.EntityPath = null; // need to remove to use with EventProcessorHost
+                }
+
+                var @namespace = GetServiceBusNamespace(sb);
+                var blobPrefix = GetBlobPrefix(actualPath, @namespace);
+
+                // Use blob prefix support available in EPH starting in 2.2.6 
+                EventProcessorHost host = new EventProcessorHost(
+                    hostName: eventProcessorHostName,
+                    eventHubPath: actualPath,
+                    consumerGroupName: consumerGroup, 
+                    eventHubConnectionString: sb.ToString(),
+                    storageConnectionString: storageConnectionString, 
+                    leaseContainerName: LeaseContainerName,
+                   leaseBlobPrefix: blobPrefix);
+
+                if (_partitionOptions != null)
+                {
+                    host.PartitionManagerOptions = _partitionOptions;
+                }
+
+                return host;
+            }
+            else
+            {
+                // Rare case: a power-user caller specifically provided an event processor host to use. 
+                EventProcessorHost host;
+                if (_explicitlyProvidedHosts.TryGetValue(eventHubName, out host))
+                {
+                    return host;
+                }
+            }
+            throw new InvalidOperationException("No event hub receiver named " + eventHubName);
+        }
+
+        private static string EscapeStorageCharacter(char character)
+        {
+            var ordinalValue = (ushort)character;
+            if (ordinalValue < 0x100)
+            {
+                return string.Format(CultureInfo.InvariantCulture, ":{0:X2}", ordinalValue);
+            }
+            else
+            {
+                return string.Format(CultureInfo.InvariantCulture, "::{0:X4}", ordinalValue);
+            }
+        }
+                
+        // Escape a blob path.  
+        // For diagnostics, we want human-readble strings that resemble the input. 
+        // Inputs are most commonly alphanumeric with a fex extra chars (dash, underscore, dot). 
+        // Escape character is a ':', which is also escaped. 
+        // Blob names are case sensitive; whereas input is case insensitive, so normalize to lower.  
+        private static string EscapeBlobPath(string path)
+        {
+            StringBuilder sb = new StringBuilder(path.Length);
+            foreach (char c in path)
+            {
+                if (c >= 'a' && c <= 'z')
+                {
+                    sb.Append(c);
+                }
+                else if (c == '-' || c == '_' || c == '.') 
+                {
+                    // Potentially common carahcters. 
+                    sb.Append(c);
+                }
+                else if (c >= 'A' && c <= 'Z')
+                {
+                    sb.Append((char)(c - 'A' + 'a')); // ToLower
+                }
+                else if (c >= '0' && c <= '9')
+                {
+                    sb.Append(c);
+                }
+                else
+                {
+                    sb.Append(EscapeStorageCharacter(c));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetServiceBusNamespace(ServiceBusConnectionStringBuilder connectionString)
+        {
+            // EventHubs only have 1 endpoint. 
+            var url = connectionString.Endpoints.First();
+            var @namespace = url.Host;
+            return @namespace;
+        }
+
+        /// <summary>
+        /// Get the blob prefix used with EventProcessorHost for a given event hub.  
+        /// </summary>
+        /// <param name="eventHubName">the event hub path</param>
+        /// <param name="serviceBusNamespace">the event hub's service bus namespace.</param>
+        /// <returns>a blob prefix path that can be passed to EventProcessorHost.</returns>
+        /// <remarks>
+        /// An event hub is defined by it's path and namespace. The namespace is extracted from the connection string. 
+        /// This must be an injective one-to-one function because:
+        /// 1. multiple machines listening on the same event hub must use the same blob prefix. This means it must be deterministic. 
+        /// 2. different event hubs must not resolve to the same path. 
+        /// </remarks>        
+        public static string GetBlobPrefix(string eventHubName, string serviceBusNamespace)
+        {
+            if (eventHubName == null)
+            {
+                throw new ArgumentNullException("eventHubName");
+            }
+            if (serviceBusNamespace == null)
+            {
+                throw new ArgumentNullException("serviceBusNamespace");
+            }
+
+            string key = EscapeBlobPath(serviceBusNamespace) + "/" + EscapeBlobPath(eventHubName) + "/";
+            return key;
+        }
+
+        // Get the eventhub options, used by the EventHub SDK for listening on event. 
+        internal EventProcessorOptions GetOptions() => _options;
+
+        void IExtensionConfigProvider.Initialize(ExtensionConfigContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            // apply at eventProcessorOptions level (maxBatchSize, prefetchCount)
+            context.ApplyConfig(_options, "eventHub");
+
+            // apply at config level (batchCheckpointFrequency)
+            context.ApplyConfig(this, "eventHub");
+
+            _defaultStorageString = context.Config.StorageConnectionString;
+
+            context
+                .AddConverter<string, EventData>(ConvertString2EventData)
+                .AddConverter<EventData, string>(ConvertEventData2String)
+                .AddConverter<byte[], EventData>(ConvertBytes2EventData)
+                .AddConverter<EventData, byte[]>(ConvertEventData2Bytes);
+
+            // register our trigger binding provider
+            INameResolver nameResolver = context.Config.NameResolver;
+            IConverterManager cm = context.Config.GetService<IConverterManager>();
+            var triggerBindingProvider = new EventHubTriggerAttributeBindingProvider(nameResolver, cm, this);
+            context.AddBindingRule<EventHubTriggerAttribute>()
+                .BindToTrigger(triggerBindingProvider);
+
+            // register our binding provider
+            context.AddBindingRule<EventHubAttribute>()
+                .BindToCollector(BuildFromAttribute);           
+        }
+
+        private IAsyncCollector<EventData> BuildFromAttribute(EventHubAttribute attribute)
+        {
+            EventHubClient client = this.GetEventHubClient(attribute.EventHubName, attribute.Connection);
+            return new EventHubAsyncCollector(client);
+        }
+
+        private static string ConvertEventData2String(EventData x) 
+            => Encoding.UTF8.GetString(ConvertEventData2Bytes(x));
+
+        private static EventData ConvertBytes2EventData(byte[] input) 
+            => new EventData(input);
+
+        private static byte[] ConvertEventData2Bytes(EventData input) 
+            => input.GetBytes();
+
+        private static EventData ConvertString2EventData(string input) 
+            => ConvertBytes2EventData(Encoding.UTF8.GetBytes(input));
+
+        // Hold credentials for a given eventHub name. 
+        // Multiple consumer groups (and multiple listeners) on the same hub can share the same credentials. 
+        private class ReceiverCreds
+        {
+            // Required.  
+            public string EventHubConnectionString { get; set; }
+
+            // Optional. If not found, use the stroage from JobHostConfiguration
+            public string StorageConnectionString { get; set; }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubConfiguration.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubConfiguration.cs
@@ -4,14 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Text;
-using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host.Config;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {

--- a/src/WebJobs.Extensions.EventHubs/EventHubJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubJobHostConfigurationExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Config;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Extension for registering an event hub configuration with the JobHostConfiguration.
+    /// </summary>
+    public static class EventHubJobHostConfigurationExtensions
+    {
+        /// <summary>
+        /// Enable connecting to event hubs for sending and receiving events. This call is required to the <see cref="EventHubAttribute"/> and <see cref="EventHubTriggerAttribute"/> attributes on parameter bindings.
+        /// </summary>
+        /// <param name="config">job host configuration</param>
+        /// <param name="eventHubConfig">event hub configuration containing connection strings to the event hubs.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
+        public static void UseEventHub(this JobHostConfiguration config, EventHubConfiguration eventHubConfig)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+            if (eventHubConfig == null)
+            {
+                throw new ArgumentNullException("eventHubConfig");
+            }
+
+            IExtensionRegistry extensions = config.GetService<IExtensionRegistry>();
+            extensions.RegisterExtension<IExtensionConfigProvider>(eventHubConfig);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubJobHostConfigurationExtensions.cs
@@ -5,7 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     /// <summary>
     /// Extension for registering an event hub configuration with the JobHostConfiguration.

--- a/src/WebJobs.Extensions.EventHubs/EventHubListener.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubListener.cs
@@ -8,9 +8,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
-using Microsoft.ServiceBus.Messaging;
+using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.EventHubs;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     // Created from the EventHubTrigger attribute to listen on the EventHub. 
     internal sealed class EventHubListener : IListener, IEventProcessorFactory
@@ -111,6 +112,12 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             public Task OpenAsync(PartitionContext context)
             {
                 return Task.FromResult(0);
+            }
+
+            public Task ProcessErrorAsync(PartitionContext context, Exception error)
+            {
+                // TODO: log underlying event hubs error
+                return Task.CompletedTask;
             }
 
             public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)

--- a/src/WebJobs.Extensions.EventHubs/EventHubListener.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubListener.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
-using Microsoft.Azure.EventHubs.Processor;
-using Microsoft.Azure.EventHubs;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
@@ -163,7 +163,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
                 else
                 {
                     // Batch dispatch
-
                     TriggeredFunctionData input = new TriggeredFunctionData
                     {
                         ParentId = null,
@@ -174,6 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
                 }
 
                 bool hasEvents = false;
+
                 // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
                 foreach (var message in messages)
                 {

--- a/src/WebJobs.Extensions.EventHubs/EventHubListener.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubListener.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    // Created from the EventHubTrigger attribute to listen on the EventHub. 
+    internal sealed class EventHubListener : IListener, IEventProcessorFactory
+    {
+        private readonly ITriggeredFunctionExecutor _executor;
+        private readonly EventProcessorHost _eventListener;
+        private readonly bool _singleDispatch;
+        private readonly EventProcessorOptions _options;
+        private readonly EventHubConfiguration _config;
+
+        public EventHubListener(ITriggeredFunctionExecutor executor, EventProcessorHost eventListener, bool single, EventHubConfiguration config)
+        {
+            this._executor = executor;
+            this._eventListener = eventListener;
+            this._singleDispatch = single;
+            this._options = config.GetOptions();
+            this._config = config;
+        }
+
+        void IListener.Cancel()
+        {
+            this.StopAsync(CancellationToken.None).Wait();
+        }
+
+        void IDisposable.Dispose() // via IListener
+        {
+            // nothing to do. 
+        }
+
+        // This will get called once when starting the JobHost. 
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return _eventListener.RegisterEventProcessorFactoryAsync(this, _options);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return _eventListener.UnregisterEventProcessorAsync();
+        }
+        
+        // This will get called per-partition. 
+        IEventProcessor IEventProcessorFactory.CreateEventProcessor(PartitionContext context)
+        {
+            return new Listener(this);
+        }
+
+        internal static Func<Func<Task>, Task> CreateCheckpointStrategy(int batchCheckpointFrequency)
+        {
+            if (batchCheckpointFrequency <= 0)
+            {
+                throw new InvalidOperationException("Batch checkpoint frequency must be larger than 0.");
+            }
+            else if (batchCheckpointFrequency == 1)
+            {
+                return (checkpoint) => checkpoint();
+            }
+            else
+            {
+                int batchCounter = 0;
+                return async (checkpoint) =>
+                {
+                    batchCounter++;
+                    if (batchCounter >= batchCheckpointFrequency)
+                    {
+                        batchCounter = 0;
+                        await checkpoint();
+                    }
+                };
+            }
+        }
+
+        // We get a new instance each time Start() is called. 
+        // We'll get a listener per partition - so they can potentialy run in parallel even on a single machine.
+        private class Listener : IEventProcessor
+        {
+            private readonly EventHubListener _parent;
+            private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+            private readonly Func<PartitionContext, Task> _checkpoint;
+
+            public Listener(EventHubListener parent)
+            {
+                this._parent = parent;
+                var checkpointStrategy = CreateCheckpointStrategy(parent._config.BatchCheckpointFrequency);
+                _checkpoint = (context) => checkpointStrategy(context.CheckpointAsync);
+            }
+
+            public async Task CloseAsync(PartitionContext context, CloseReason reason)
+            {
+                this._cts.Cancel(); // Signal interuption to ProcessEventsAsync()
+
+                // Finish listener
+                if (reason == CloseReason.Shutdown)
+                {
+                    await context.CheckpointAsync();
+                }
+            }
+
+            public Task OpenAsync(PartitionContext context)
+            {
+                return Task.FromResult(0);
+            }
+
+            public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
+            {
+                EventHubTriggerInput value = new EventHubTriggerInput
+                {
+                    Events = messages.ToArray(),
+                    PartitionContext = context
+                };
+
+                // Single dispatch 
+                if (_parent._singleDispatch)
+                {
+                    int len = value.Events.Length;
+
+                    List<Task> dispatches = new List<Task>();
+                    for (int i = 0; i < len; i++)
+                    {
+                        if (_cts.IsCancellationRequested)
+                        {
+                            // If we stopped the listener, then we may lose the lease and be unable to checkpoint. 
+                            // So skip running the rest of the batch. The new listener will pick it up. 
+                            continue;
+                        }
+                        else
+                        {
+                            TriggeredFunctionData input = new TriggeredFunctionData
+                            {
+                                ParentId = null,
+                                TriggerValue = value.GetSingleEventTriggerInput(i)
+                            };
+                            Task task = this._parent._executor.TryExecuteAsync(input, _cts.Token);
+                            dispatches.Add(task);
+                        }
+                    }
+
+                    // Drain the whole batch before taking more work
+                    if (dispatches.Count > 0)
+                    {
+                        await Task.WhenAll(dispatches);
+                    }
+                }
+                else
+                {
+                    // Batch dispatch
+
+                    TriggeredFunctionData input = new TriggeredFunctionData
+                    {
+                        ParentId = null,
+                        TriggerValue = value
+                    };
+
+                    FunctionResult result = await this._parent._executor.TryExecuteAsync(input, CancellationToken.None);
+                }
+
+                bool hasEvents = false;
+                // Dispose all messages to help with memory pressure. If this is missed, the finalizer thread will still get them. 
+                foreach (var message in messages)
+                {
+                    hasEvents = true;
+                    message.Dispose();
+                }
+
+                // Don't checkpoint if no events. This can reset the sequence counter to 0. 
+                if (hasEvents)
+                {
+                    await _checkpoint(context);
+                }
+            }
+        } // end class Listener 
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    /// <summary>
+    /// Setup an 'trigger' on a parameter to listen on events from an event hub. 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Binding]
+    public sealed class EventHubTriggerAttribute : Attribute, IConnectionProvider
+    {
+        /// <summary>
+        /// Create an instance of this attribute.
+        /// </summary>
+        /// <param name="eventHubName">Event hub to listen on for messages. </param>
+        public EventHubTriggerAttribute(string eventHubName)
+        {
+            this.EventHubName = eventHubName;
+        }
+
+        /// <summary>
+        /// Name of the event hub. 
+        /// </summary>
+        public string EventHubName { get; private set; }
+
+        /// <summary>
+        /// Optional Name of the consumer group. If missing, then use the default name, "$Default"
+        /// </summary>
+        public string ConsumerGroup { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional app setting name that contains the Event Hub connection string. If missing, tries to use a registered event hub receiver.
+        /// </summary>
+        [AppSetting]
+        public string Connection { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttribute.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Azure.WebJobs.Description;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     /// <summary>
     /// Setup an 'trigger' on a parameter to listen on events from an event hub. 

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttributeBindingProvider.cs
@@ -8,9 +8,9 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.ServiceBus.Messaging;
+using Microsoft.Azure.EventHubs;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     internal class EventHubTriggerAttributeBindingProvider : ITriggerBindingProvider
     {
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             string resolvedEventHubName = _nameResolver.ResolveWholeString(attribute.EventHubName);
 
-            string consumerGroup = attribute.ConsumerGroup ?? EventHubConsumerGroup.DefaultGroupName;
+            string consumerGroup = attribute.ConsumerGroup ?? PartitionReceiver.DefaultConsumerGroupName;
             string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
 
             if (!string.IsNullOrWhiteSpace(attribute.Connection))

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerAttributeBindingProvider.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    internal class EventHubTriggerAttributeBindingProvider : ITriggerBindingProvider
+    {
+        private readonly INameResolver _nameResolver;
+        private readonly EventHubConfiguration _eventHubConfig;
+        private readonly IConverterManager _converterManager;
+
+        public EventHubTriggerAttributeBindingProvider(
+            INameResolver nameResolver,
+            IConverterManager converterManager,
+            EventHubConfiguration eventHubConfig)
+        {
+            this._nameResolver = nameResolver;
+            this._converterManager = converterManager;
+            this._eventHubConfig = eventHubConfig;
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            ParameterInfo parameter = context.Parameter;
+            EventHubTriggerAttribute attribute = parameter.GetCustomAttribute<EventHubTriggerAttribute>(inherit: false);
+
+            if (attribute == null)
+            {
+                return Task.FromResult<ITriggerBinding>(null);
+            }
+
+            string resolvedEventHubName = _nameResolver.ResolveWholeString(attribute.EventHubName);
+
+            string consumerGroup = attribute.ConsumerGroup ?? EventHubConsumerGroup.DefaultGroupName;
+            string resolvedConsumerGroup = _nameResolver.ResolveWholeString(consumerGroup);
+
+            if (!string.IsNullOrWhiteSpace(attribute.Connection))
+            {
+                _eventHubConfig.AddReceiver(resolvedEventHubName, _nameResolver.Resolve(attribute.Connection));
+            }
+            
+            var eventHostListener = _eventHubConfig.GetEventProcessorHost(resolvedEventHubName, resolvedConsumerGroup);
+
+            Func<ListenerFactoryContext, bool, Task<IListener>> createListener =
+             (factoryContext, singleDispatch) =>
+             {
+                 IListener listener = new EventHubListener(factoryContext.Executor, eventHostListener, singleDispatch, _eventHubConfig);
+                 return Task.FromResult(listener);
+             };
+
+            ITriggerBinding binding = BindingFactory.GetTriggerBinding(new EventHubTriggerBindingStrategy(), parameter, _converterManager, createListener);
+            return Task.FromResult<ITriggerBinding>(binding);         
+        }
+    } // end class
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerBindingStrategy.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerBindingStrategy.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Microsoft.Azure.WebJobs.Host.Bindings;
-using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.EventHubs.Processor;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Triggers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerInput.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerInput.cs
@@ -14,7 +14,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
         private int _selector = -1;
 
         internal EventData[] Events { get; set; }
+
         internal PartitionContext PartitionContext { get; set; }
+
+        public bool IsSingleDispatch
+        {
+            get
+            {
+                return _selector != -1;
+            }
+        }
 
         public static EventHubTriggerInput New(EventData eventData)
         {
@@ -27,14 +36,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
                 },
                 _selector = 0,
             };
-        }
-
-        public bool IsSingleDispatch
-        {
-            get
-            {
-                return _selector != -1;
-            }
         }
 
         public EventHubTriggerInput GetSingleEventTriggerInput(int idx)

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerInput.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerInput.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.ServiceBus.Messaging;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     // The core object we get when an EventHub is triggered. 
     // This gets converted to the user type (EventData, string, poco, etc) 

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerInput.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerInput.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    // The core object we get when an EventHub is triggered. 
+    // This gets converted to the user type (EventData, string, poco, etc) 
+    internal sealed class EventHubTriggerInput      
+    {        
+        // If != -1, then only process a single event in this batch. 
+        private int _selector = -1;
+
+        internal EventData[] Events { get; set; }
+        internal PartitionContext PartitionContext { get; set; }
+
+        public static EventHubTriggerInput New(EventData eventData)
+        {
+            return new EventHubTriggerInput
+            {
+                PartitionContext = null,
+                Events = new EventData[]
+                {
+                      eventData
+                },
+                _selector = 0,
+            };
+        }
+
+        public bool IsSingleDispatch
+        {
+            get
+            {
+                return _selector != -1;
+            }
+        }
+
+        public EventHubTriggerInput GetSingleEventTriggerInput(int idx)
+        {
+            return new EventHubTriggerInput
+            {
+                Events = this.Events,
+                PartitionContext = this.PartitionContext,
+                _selector = idx
+            };
+        }
+
+        public EventData GetSingleEventData()
+        {
+            return this.Events[this._selector];
+        }        
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerInputBindingStrategy.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerInputBindingStrategy.cs
@@ -6,9 +6,10 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.ServiceBus.Messaging;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.EventHubs.Processor;
 
-namespace Microsoft.Azure.WebJobs.ServiceBus
+namespace Microsoft.Azure.WebJobs.Extensions.EventHubs
 {
     // Binding strategy for an event hub triggers. 
     internal class EventHubTriggerBindingStrategy : ITriggerBindingStrategy<EventData, EventHubTriggerInput>
@@ -96,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
             var sequenceNumbers = new long[length];
             var enqueuedTimesUtc = new DateTime[length];
             var properties = new IDictionary<string, object>[length];
-            var systemProperties = new IDictionary<string, object>[length];
+            var systemProperties = new EventData.SystemPropertiesCollection[length];
 
             SafeAddValue(() => bindingData.Add("PartitionKeyArray", partitionKeys));
             SafeAddValue(() => bindingData.Add("OffsetArray", offsets));
@@ -107,10 +108,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
             for (int i = 0; i < events.Length; i++)
             {
-                partitionKeys[i] = events[i].PartitionKey;
-                offsets[i] = events[i].Offset;
-                sequenceNumbers[i] = events[i].SequenceNumber;
-                enqueuedTimesUtc[i] = events[i].EnqueuedTimeUtc;
+                partitionKeys[i] = events[i].SystemProperties.PartitionKey;
+                offsets[i] = events[i].SystemProperties.Offset;
+                sequenceNumbers[i] = events[i].SystemProperties.SequenceNumber;
+                enqueuedTimesUtc[i] = events[i].SystemProperties.EnqueuedTimeUtc;
                 properties[i] = events[i].Properties;
                 systemProperties[i] = events[i].SystemProperties;
             }
@@ -118,10 +119,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus
 
         private static void AddBindingData(Dictionary<string, object> bindingData, EventData eventData)
         {
-            SafeAddValue(() => bindingData.Add(nameof(eventData.PartitionKey), eventData.PartitionKey));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.Offset), eventData.Offset));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.SequenceNumber), eventData.SequenceNumber));
-            SafeAddValue(() => bindingData.Add(nameof(eventData.EnqueuedTimeUtc), eventData.EnqueuedTimeUtc));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.PartitionKey), eventData.SystemProperties.PartitionKey));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.Offset), eventData.SystemProperties.Offset));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.SequenceNumber), eventData.SystemProperties.SequenceNumber));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties.EnqueuedTimeUtc), eventData.SystemProperties.EnqueuedTimeUtc));
             SafeAddValue(() => bindingData.Add(nameof(eventData.Properties), eventData.Properties));
             SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties), eventData.SystemProperties));
         }

--- a/src/WebJobs.Extensions.EventHubs/EventHubTriggerInputBindingStrategy.cs
+++ b/src/WebJobs.Extensions.EventHubs/EventHubTriggerInputBindingStrategy.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Microsoft.Azure.WebJobs.ServiceBus
+{
+    // Binding strategy for an event hub triggers. 
+    internal class EventHubTriggerBindingStrategy : ITriggerBindingStrategy<EventData, EventHubTriggerInput>
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        public EventHubTriggerInput ConvertFromString(string input)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(input);
+            EventData eventData = new EventData(bytes);
+
+            // Return a single event. Doesn't support multiple dispatch 
+            return EventHubTriggerInput.New(eventData);            
+        }
+
+        // Single instance: Core --> EventData
+        public EventData BindSingle(EventHubTriggerInput value, ValueBindingContext context)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            return value.GetSingleEventData();
+        }
+
+        public EventData[] BindMultiple(EventHubTriggerInput value, ValueBindingContext context)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            return value.Events;
+        }
+
+        public Dictionary<string, Type> GetBindingContract(bool isSingleDispatch = true)
+        {
+            var contract = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+            contract.Add("PartitionContext", typeof(PartitionContext));
+
+            AddBindingContractMember(contract, "PartitionKey", typeof(string), isSingleDispatch);
+            AddBindingContractMember(contract, "Offset", typeof(string), isSingleDispatch);
+            AddBindingContractMember(contract, "SequenceNumber", typeof(long), isSingleDispatch);
+            AddBindingContractMember(contract, "EnqueuedTimeUtc", typeof(DateTime), isSingleDispatch);
+            AddBindingContractMember(contract, "Properties", typeof(IDictionary<string, object>), isSingleDispatch);
+            AddBindingContractMember(contract, "SystemProperties", typeof(IDictionary<string, object>), isSingleDispatch);
+
+            return contract;
+        }
+
+        private static void AddBindingContractMember(Dictionary<string, Type> contract, string name, Type type, bool isSingleDispatch)
+        {
+            if (!isSingleDispatch)
+            {
+                name += "Array";
+            }
+            contract.Add(name, isSingleDispatch ? type : type.MakeArrayType());
+        }
+
+        public Dictionary<string, object> GetBindingData(EventHubTriggerInput value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+
+            var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            SafeAddValue(() => bindingData.Add(nameof(value.PartitionContext), value.PartitionContext));
+
+            if (value.IsSingleDispatch)
+            {
+                AddBindingData(bindingData, value.GetSingleEventData());
+            }
+            else
+            {
+                AddBindingData(bindingData, value.Events);
+            }
+
+            return bindingData;
+        }
+
+        internal static void AddBindingData(Dictionary<string, object> bindingData, EventData[] events)
+        {
+            int length = events.Length;
+            var partitionKeys = new string[length];
+            var offsets = new string[length];
+            var sequenceNumbers = new long[length];
+            var enqueuedTimesUtc = new DateTime[length];
+            var properties = new IDictionary<string, object>[length];
+            var systemProperties = new IDictionary<string, object>[length];
+
+            SafeAddValue(() => bindingData.Add("PartitionKeyArray", partitionKeys));
+            SafeAddValue(() => bindingData.Add("OffsetArray", offsets));
+            SafeAddValue(() => bindingData.Add("SequenceNumberArray", sequenceNumbers));
+            SafeAddValue(() => bindingData.Add("EnqueuedTimeUtcArray", enqueuedTimesUtc));
+            SafeAddValue(() => bindingData.Add("PropertiesArray", properties));
+            SafeAddValue(() => bindingData.Add("SystemPropertiesArray", systemProperties));
+
+            for (int i = 0; i < events.Length; i++)
+            {
+                partitionKeys[i] = events[i].PartitionKey;
+                offsets[i] = events[i].Offset;
+                sequenceNumbers[i] = events[i].SequenceNumber;
+                enqueuedTimesUtc[i] = events[i].EnqueuedTimeUtc;
+                properties[i] = events[i].Properties;
+                systemProperties[i] = events[i].SystemProperties;
+            }
+        }
+
+        private static void AddBindingData(Dictionary<string, object> bindingData, EventData eventData)
+        {
+            SafeAddValue(() => bindingData.Add(nameof(eventData.PartitionKey), eventData.PartitionKey));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.Offset), eventData.Offset));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SequenceNumber), eventData.SequenceNumber));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.EnqueuedTimeUtc), eventData.EnqueuedTimeUtc));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.Properties), eventData.Properties));
+            SafeAddValue(() => bindingData.Add(nameof(eventData.SystemProperties), eventData.SystemProperties));
+        }
+
+        private static void SafeAddValue(Action addValue)
+        {
+            try
+            {
+                addValue();
+            }
+            catch
+            {
+                // some message propery getters can throw, based on the
+                // state of the message
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
+++ b/src/WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
+++ b/src/WebJobs.Extensions.EventHubs/WebJobs.Extensions.EventHubs.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.EventHubs</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.EventHubs</RootNamespace>
+    <PackageId>Microsoft.Azure.WebJobs.Extensions.EventHubs</PackageId>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
+    <Product>Microsoft.Azure.WebJobs</Product>
+    <Version>3.0.0-beta1$(VersionSuffix)</Version>
+    <Description>Microsoft Azure WebJobs SDK EventHubs Extensions</Description>
+    <Copyright>© .NET Foundation. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Azure.EventHubs.Processor" Version="1.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebJobs.Extensions\WebJobs.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/WebJobs.Extensions.Http/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Extensions.Http/Extensions/HttpRequestExtensions.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Internal;
-using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Http
 {


### PR DESCRIPTION
resolves https://github.com/Azure/azure-webjobs-sdk/issues/1291

Added code verbatim from Microsoft.Azure.WebJobs.ServiceBus in https://github.com/Azure/azure-webjobs-sdk-extensions/commit/0d0fdecae4198301444f8ff7bdcb5b204110505f

Changes to build on new event hubs nugets added in https://github.com/Azure/azure-webjobs-sdk-extensions/commit/92c82d821fd91cb04dbf8e1f6c34a4ae3acee150

The only major api change is that `PartitionManagerOptions` is no longer a thing, which doesn't have a large effect on functions.

We may want to take the opportunity to make `EventHubConfiguration` behave more like most extension configs, fix service bus duplicate namespace issue, etc. I think we could clean up pieces like `AddEventHubClient` and `AddEventHubSender`. @MikeStall any opinions on this?

Also, may consider moving this to multi-target in order to support webjobs 2.x.