### PR TITLE
Fixing CosmosDBTrigger ConnectionStringSetting binding

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
             extensions.RegisterBindingRules<DocumentDBAttribute>(ValidateConnection, nameResolver, outputProvider, clientProvider, jArrayProvider, enumerableProvider, inputProvider);
 
-            context.Config.RegisterBindingExtensions(new CosmosDBTriggerAttributeBindingProvider(ResolveConnectionString(null), ResolveConnectionString(null), LeaseOptions));
+            context.Config.RegisterBindingExtensions(new CosmosDBTriggerAttributeBindingProvider(nameResolver, LeaseOptions));
         }
 
         internal static void ValidateInputBinding(DocumentDBAttribute attribute, Type parameterType)

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
@@ -36,6 +36,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         /// </summary>
         public Type TriggerValueType => typeof(IReadOnlyList<Document>);
 
+        internal DocumentCollectionInfo DocumentCollectionLocation => _documentCollectionLocation;
+
+        internal DocumentCollectionInfo LeaseCollectionLocation => _leaseCollectionLocation;
+
         public IReadOnlyDictionary<string, Type> BindingDataContract
         {
             get { return _bindingDataProvider.Contract; }
@@ -50,10 +54,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("Unable to convert trigger to DocumentDBTrigger:" + ex.Message);
+                throw new InvalidOperationException("Unable to convert trigger to CosmosDBTrigger:" + ex.Message);
             }
 
-            var valueBinder = new CosmosDBTriggerValueBinder(_parameter.ParameterType, triggerValue);            
+            var valueBinder = new CosmosDBTriggerValueBinder(_parameter.ParameterType, triggerValue);
             return Task.FromResult<ITriggerData>(new TriggerData(valueBinder, _bindingDataProvider.GetBindingData(valueBinder.GetValue())));
         }
 

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerConstants.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerConstants.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
     {
         public const string DefaultLeaseCollectionName = "leases";
 
-        public const string TriggerName = "DocumentDBTrigger";
+        public const string TriggerName = "CosmosDBTrigger";
 
         public const string TriggerDescription = "New changes on collection {0} at {1}";
 

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.WebJobs.Extensions.DocumentDB;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -21,22 +22,61 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData("InvalidCosmosDBTriggerParameters")]
         public async Task InvalidParameters_Fail(ParameterInfo parameter)
         {
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider("notAConnectionString", string.Empty);
-            
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(new DefaultNameResolver());
+
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None)));
 
-            Assert.NotNull(ex);            
+            Assert.NotNull(ex);
         }
 
         [Theory]
-        [MemberData("ValidCosmosDBTriggerParameters")]
-        public async Task ValidParameters_Succeed(ParameterInfo parameter)
+        [MemberData("ValidCosmosDBTriggerBindigsWithEnvironmentParameters")]
+        public async Task ValidParametersWithEnvironment_Succeed(ParameterInfo parameter)
         {
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider("AccountEndpoint=https://someEndpoint;AccountKey=someKey;", string.Empty);
+            var nameResolver = new TestNameResolver();
+            nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
+            nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
 
-            ITriggerBinding binding = await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver);
+
+            CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
             Assert.Equal(binding.TriggerValueType, typeof(IReadOnlyList<Document>));
+            Assert.Equal(binding.DocumentCollectionLocation.Uri, new Uri("https://fromEnvironment"));
+        }
+
+        [Theory]
+        [MemberData("ValidCosmosDBTriggerBindigsWithAppSettingsParameters")]
+        public async Task ValidParametersWithAppSettings_Succeed(ParameterInfo parameter)
+        {
+            var nameResolver = new TestNameResolver();
+            nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
+            nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
+
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver);
+
+            CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.Equal(binding.TriggerValueType, typeof(IReadOnlyList<Document>));
+            Assert.Equal(binding.DocumentCollectionLocation.Uri, new Uri("https://fromSettings"));
+        }
+
+        [Theory]
+        [MemberData("ValidCosmosDBTriggerBindigsDifferentConnectionsParameters")]
+        public async Task ValidCosmosDBTriggerBindigsDifferentConnections_Succeed(ParameterInfo parameter)
+        {
+            var nameResolver = new TestNameResolver();
+            nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
+            nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
+            nameResolver.Values["LeaseCosmosDBConnectionString"] = "AccountEndpoint=https://fromSettingsLease;AccountKey=someKey;";
+
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver);
+
+            CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.Equal(binding.TriggerValueType, typeof(IReadOnlyList<Document>));
+            Assert.Equal(binding.DocumentCollectionLocation.Uri, new Uri("https://fromSettings"));
+            Assert.Equal(binding.LeaseCollectionLocation.Uri, new Uri("https://fromSettingsLease"));
         }
 
         public static IEnumerable<ParameterInfo[]> InvalidCosmosDBTriggerParameters
@@ -44,9 +84,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
             get { return InvalidCosmosDBTriggerBindigs.GetParameters(); }
         }
 
-        public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerParameters
+        public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerBindigsWithAppSettingsParameters
         {
-            get { return ValidCosmosDBTriggerBindigs.GetParameters(); }
+            get { return ValidCosmosDBTriggerBindigsWithAppSettings.GetParameters(); }
+        }
+
+        public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerBindigsDifferentConnectionsParameters
+        {
+            get { return ValidCosmosDBTriggerBindigsDifferentConnections.GetParameters(); }
+        }
+
+        public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerBindigsWithEnvironmentParameters
+        {
+            get { return ValidCosmosDBTriggerBindigsWithEnvironment.GetParameters(); }
         }
 
         private static ParameterInfo GetFirstParameter(Type type, string methodName)
@@ -61,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         {
             public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString")] IReadOnlyList<Document> docs)
             {
-                
+
             }
 
             public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString", LeaseConnectionStringSetting = "notAConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
@@ -69,22 +119,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
 
             }
 
-            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection")] IReadOnlyList<Document> docs)
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "CosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
             {
 
             }
 
-            public static void Func4([CosmosDBTrigger("aDatabase", "aCollection", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
-            {
-
-            }
-
-            public static void Func5([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString")] object docs)
-            {
-
-            }
-
-            public static void Func6([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<Document> docs)
+            public static void Func4([CosmosDBTrigger("aDatabase", "leases", ConnectionStringSetting = "CosmosDBConnectionString")] IReadOnlyList<Document> docs)
             {
 
             }
@@ -98,45 +138,92 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
                     new[] { GetFirstParameter(type, "Func1") },
                     new[] { GetFirstParameter(type, "Func2") },
                     new[] { GetFirstParameter(type, "Func3") },
-                    new[] { GetFirstParameter(type, "Func4") },
-                    new[] { GetFirstParameter(type, "Func5") },
-                    new[] { GetFirstParameter(type, "Func6") }
+                    new[] { GetFirstParameter(type, "Func4") }
                 };
             }
         }
 
-        private static class ValidCosmosDBTriggerBindigs
+        private static class ValidCosmosDBTriggerBindigsWithAppSettings
         {
-            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;")] IReadOnlyList<Document> docs)
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString")] IReadOnlyList<Document> docs)
             {
 
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "CosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
             {
 
             }
+            
 
-            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
-            {
-
-            }
-
-            public static void Func4([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "AccountEndpoint=https://someEndpoint;AccountKey=someKey;")] JArray docs)
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString")] JArray docs)
             {
 
             }
 
             public static IEnumerable<ParameterInfo[]> GetParameters()
             {
-                var type = typeof(ValidCosmosDBTriggerBindigs);
+                var type = typeof(ValidCosmosDBTriggerBindigsWithAppSettings);
 
                 return new[]
                 {
                     new[] { GetFirstParameter(type, "Func1") },
                     new[] { GetFirstParameter(type, "Func2") },
-                    new[] { GetFirstParameter(type, "Func3") },
-                    new[] { GetFirstParameter(type, "Func4") }
+                    new[] { GetFirstParameter(type, "Func3") }
+                };
+            }
+        }
+
+        private static class ValidCosmosDBTriggerBindigsDifferentConnections
+        {
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "LeaseCosmosDBConnectionString")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "LeaseCosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static IEnumerable<ParameterInfo[]> GetParameters()
+            {
+                var type = typeof(ValidCosmosDBTriggerBindigsDifferentConnections);
+
+                return new[]
+                {
+                    new[] { GetFirstParameter(type, "Func1") },
+                    new[] { GetFirstParameter(type, "Func2") }
+                };
+            }
+        }
+
+        private static class ValidCosmosDBTriggerBindigsWithEnvironment
+        {
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection")] JArray docs)
+            {
+
+            }
+
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static IEnumerable<ParameterInfo[]> GetParameters()
+            {
+                var type = typeof(ValidCosmosDBTriggerBindigsWithEnvironment);
+
+                return new[]
+                {
+                    new[] { GetFirstParameter(type, "Func1") },
+                    new[] { GetFirstParameter(type, "Func2") },
+                    new[] { GetFirstParameter(type, "Func3") }
                 };
             }
         }


### PR DESCRIPTION
CosmosDBTrigger was not correctly reading ConnectionStringSetting from AppSettings and was treating it as a normal string.