### PR TITLE
Migrating Twilio to .NET Core

### DIFF
--- a/WebJobs.Extensions.sln
+++ b/WebJobs.Extensions.sln
@@ -31,6 +31,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.MobileApps", "src\WebJobs.Extensions.MobileApps\WebJobs.Extensions.MobileApps.csproj", "{9C131CF2-2563-4A84-A93D-EA0E537CC031}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.SendGrid", "src\WebJobs.Extensions.SendGrid\WebJobs.Extensions.SendGrid.csproj", "{ECAE5675-D59D-436E-B25B-089CBB7165F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobs.Extensions.Twilio", "src\WebJobs.Extensions.Twilio\WebJobs.Extensions.Twilio.csproj", "{5599555A-6730-472C-B084-D0FB0ADB433C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -66,6 +67,10 @@ Global
 		{ECAE5675-D59D-436E-B25B-089CBB7165F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ECAE5675-D59D-436E-B25B-089CBB7165F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ECAE5675-D59D-436E-B25B-089CBB7165F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5599555A-6730-472C-B084-D0FB0ADB433C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5599555A-6730-472C-B084-D0FB0ADB433C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5599555A-6730-472C-B084-D0FB0ADB433C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5599555A-6730-472C-B084-D0FB0ADB433C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -78,6 +83,7 @@ Global
 		{47B3ECC3-DDDB-4C80-8A13-E6279A2EB835} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
 		{9C131CF2-2563-4A84-A93D-EA0E537CC031} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
 		{ECAE5675-D59D-436E-B25B-089CBB7165F9} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
+		{5599555A-6730-472C-B084-D0FB0ADB433C} = {1118E0AD-83C8-4B67-859B-FCDEF54338C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {821EF04F-5408-46AD-94ED-0E939B89D4B8}

--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\WebJobs.Extensions.Http\WebJobs.Extensions.Http.csproj" />
     <ProjectReference Include="..\WebJobs.Extensions.MobileApps\WebJobs.Extensions.MobileApps.csproj" />
     <ProjectReference Include="..\WebJobs.Extensions.SendGrid\WebJobs.Extensions.SendGrid.csproj" />
+    <ProjectReference Include="..\WebJobs.Extensions.Twilio\WebJobs.Extensions.Twilio.csproj" />
     <ProjectReference Include="..\WebJobs.Extensions\WebJobs.Extensions.csproj" />
   </ItemGroup>
 

--- a/src/ExtensionsSample/Program.cs
+++ b/src/ExtensionsSample/Program.cs
@@ -34,6 +34,7 @@ namespace ExtensionsSample
             config.UseTimers();
             config.UseSample();
             config.UseMobileApps();
+            config.UseTwilioSms();
             config.UseCore();
 
             var sendGridConfiguration = new SendGridConfiguration()
@@ -51,6 +52,7 @@ namespace ExtensionsSample
 
             // Add or remove types from this list to choose which functions will 
             // be indexed by the JobHost.
+            // To run some of the other samples included, add their types to this list
             config.TypeLocator = new SamplesTypeLocator(
                 typeof(ErrorMonitoringSamples),
                 typeof(FileSamples),
@@ -58,7 +60,7 @@ namespace ExtensionsSample
                 typeof(SampleSamples),
                 typeof(TableSamples),
                 typeof(TimerSamples),
-                typeof(SendGridSamples));
+                typeof(TwilioSamples));
 
             host.Call(typeof(MiscellaneousSamples).GetMethod("ExecutionContext"));
             host.Call(typeof(FileSamples).GetMethod("ReadWrite"));

--- a/src/ExtensionsSample/Samples/TwilioSamples.cs
+++ b/src/ExtensionsSample/Samples/TwilioSamples.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs;
+using Newtonsoft.Json.Linq;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Types;
+
+namespace ExtensionsSample.Samples
+{
+    // To use the TwilioSamples:
+    // 1. Configure your Twilio Account SID via the 'AzureWebJobsTwilioAccountSid' App Setting or Environment variable
+    // 2. Configure your Twilio Auth Token via the 'AzureWebJobsTwilioAuthToken' App Setting or Environment variable
+    // 3. Add typeof(TwilioSamples) to the SamplesTypeLocator in Program.cs
+    public static class TwilioSamples
+    {
+        /// <summary>
+        /// Demonstrates declaratively SMS message properties with parameter binding
+        /// to message properties.
+        /// </summary>
+        public static void ProcessOrder_Declarative(
+            [QueueTrigger(@"samples-orders")] Order order,
+            [TwilioSms(
+                From = "{StorePhoneNumber}",
+                Body = "{CustomerName}, we've received your order ({OrderId}) and have begun processing it!")]
+            out CreateMessageOptions messageOptions)
+        {
+            // You can set additional message properties here
+            messageOptions = new CreateMessageOptions(new PhoneNumber(order.CustomerPhoneNumber));
+        }
+
+        /// <summary>
+        /// Demonstrates imperatively setting SMS message properties inline in the function.
+        /// </summary>
+        [Disable]
+        public static void ProcessOrder_Imperative(
+            [QueueTrigger(@"samples-orders")] Order order,
+            [TwilioSms] out CreateMessageOptions messageOptions)
+        {
+            messageOptions = new CreateMessageOptions(new PhoneNumber(order.StorePhoneNumber))
+            {
+                From = new PhoneNumber(order.StorePhoneNumber),
+                Body = string.Format("{0}, we've received your order ({1}) and have begun processing it!", order.CustomerName, order.OrderId)
+            };
+        }
+
+        /// <summary>
+        /// Demonstrates the JObject binding (the JObject will be converted into an message)
+        /// </summary>
+        [Disable]
+        public static void ProcessOrder_JObject(
+            [QueueTrigger(@"samples-orders")] Order order,
+            [TwilioSms] out JObject message)
+        {
+            message = new JObject()
+            {
+                { "From", order.StorePhoneNumber },
+                { "To", order.CustomerPhoneNumber },
+                { "Body", string.Format("{0}, we've received your order ({1}) and have begun processing it!", order.CustomerName, order.OrderId) }
+            };
+        }
+
+        /// <summary>
+        /// Demonstrates the IAsyncCollector binding. This works with <see cref="JObject"/>
+        /// or <see cref="CreateMessageOptions"/>. Using IAsyncCollector is also a way to conditionally
+        /// send messages from a function.
+        /// </summary>
+        [Disable]
+        public static void ProcessOrder_MessageAsyncCollector(
+            [QueueTrigger(@"samples-orders")] Order order,
+            [TwilioSms] IAsyncCollector<CreateMessageOptions> messages)
+        {
+            var messageOptions = new CreateMessageOptions(new PhoneNumber(order.CustomerPhoneNumber))
+            {
+                From = new PhoneNumber(order.StorePhoneNumber),
+                Body = string.Format("{0}, we've received your order ({1}) and have begun processing it!", order.CustomerName, order.OrderId)
+            };
+
+            messages.AddAsync(messageOptions);
+        }
+
+        /// <summary>
+        /// Demonstrates the IAsyncCollector binding. This works with <see cref="JObject"/>
+        /// or <see cref="CreateMessageOptions"/>. Using IAsyncCollector is also a way to conditionally
+        /// send messages from a function.
+        /// </summary>
+        [Disable]
+        public static void ProcessOrder_JObjectAsyncCollector(
+            [QueueTrigger(@"samples-orders")] Order order,
+            [TwilioSms] IAsyncCollector<JObject> messages)
+        {
+            var message = new JObject()
+            {
+                { "From", order.StorePhoneNumber },
+                { "To", order.CustomerPhoneNumber },
+                { "Body", string.Format("{0}, we've received your order ({1}) and have begun processing it!", order.CustomerName, order.OrderId) }
+            };
+
+            messages.AddAsync(message);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Http</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Http</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Http</PackageId>
+    <Description>This package adds binding extensions for Http.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.MobileApps</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.MobileApps</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.MobileApps</PackageId>
+    <Description>This package contains binding extensions for Azure Mobile Apps.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.Twilio/Bindings/TwilioSmsMessageAsyncCollector.cs
+++ b/src/WebJobs.Extensions.Twilio/Bindings/TwilioSmsMessageAsyncCollector.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Types;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Bindings
+{
+    internal class TwilioSmsMessageAsyncCollector : IAsyncCollector<CreateMessageOptions>
+    {
+        private readonly TwilioSmsContext _context;
+        private readonly Collection<CreateMessageOptions> _messageOptionsCollection = new Collection<CreateMessageOptions>();
+
+        public TwilioSmsMessageAsyncCollector(TwilioSmsContext context)
+        {
+            _context = context;
+        }
+
+        public Task AddAsync(CreateMessageOptions messageOptions, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ApplyContextMessageSettings(messageOptions, _context);
+
+            if (messageOptions.To == null)
+            {
+                throw new InvalidOperationException("A 'To' number must be specified for the message.");
+            }
+
+            if (messageOptions.From == null)
+            {
+                throw new InvalidOperationException("A 'From' number must be specified for the message.");
+            }
+
+            if (messageOptions.Body == null)
+            {
+                throw new InvalidOperationException("A 'Body' must be specified for the message.");
+            }
+
+            _messageOptionsCollection.Add(messageOptions);
+
+            return Task.CompletedTask;
+        }
+
+        internal static void ApplyContextMessageSettings(CreateMessageOptions messageOptions, TwilioSmsContext context)
+        {
+            if (messageOptions.From == null)
+            {
+                messageOptions.From = new PhoneNumber(context.From);
+            }
+
+            if (messageOptions.Body == null)
+            {
+                messageOptions.Body = context.Body;
+            }
+        }
+
+        public async Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            foreach (var message in _messageOptionsCollection)
+            {
+                // this create will initiate the send operation
+                await MessageResource.CreateAsync(message, client: _context.Client);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Twilio/Config/TwilioJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.Twilio/Config/TwilioJobHostConfigurationExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Extensions.Twilio;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Extension methods for Twilio integration
+    /// </summary>
+    public static class TwilioJobHostConfigurationExtensions
+    {
+        /// <summary>
+        /// Enables use of the Twilio extensions
+        /// </summary>
+        /// <param name="config">The <see cref="JobHostConfiguration"/> to configure.</param>
+        /// <param name="twilioSmsConfig">The <see cref="TwilioSmsConfiguration"/> to use.</param>
+        public static void UseTwilioSms(this JobHostConfiguration config, TwilioSmsConfiguration twilioSmsConfig = null)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException("config");
+            }
+
+            if (twilioSmsConfig == null)
+            {
+                twilioSmsConfig = new TwilioSmsConfiguration();
+            }
+
+            config.RegisterExtensionConfigProvider(twilioSmsConfig);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Twilio/Config/TwilioSmsConfiguration.cs
+++ b/src/WebJobs.Extensions.Twilio/Config/TwilioSmsConfiguration.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Extensions.Bindings;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Newtonsoft.Json.Linq;
+using Twilio.Clients;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Types;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Twilio
+{
+    public class TwilioSmsConfiguration : IExtensionConfigProvider
+    {
+        internal const string AzureWebJobsTwilioAccountSidKeyName = "AzureWebJobsTwilioAccountSid";
+        internal const string AzureWebJobsTwilioAccountAuthTokenName = "AzureWebJobsTwilioAuthToken";
+
+        private readonly ConcurrentDictionary<Tuple<string, string>, TwilioRestClient> _twilioClientCache = new ConcurrentDictionary<Tuple<string, string>, TwilioRestClient>();
+
+        private string _defaultAccountSid;
+        private string _defaultAuthToken;
+
+        public string AccountSid { get; set; }
+
+        public string AuthToken { get; set; }
+
+        public string Body { get; set; }
+
+        public string From { get; set; }
+
+        public string To { get; set; }
+
+        public void Initialize(ExtensionConfigContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            INameResolver nameResolver = context.Config.GetService<INameResolver>();
+
+            _defaultAccountSid = nameResolver.Resolve(AzureWebJobsTwilioAccountSidKeyName);
+            _defaultAuthToken = nameResolver.Resolve(AzureWebJobsTwilioAccountAuthTokenName);
+
+            IConverterManager converterManager = context.Config.GetService<IConverterManager>();
+            converterManager.AddConverter<JObject, CreateMessageOptions>(CreateMessageOptions);
+
+            BindingFactory factory = new BindingFactory(nameResolver, converterManager);
+            IBindingProvider outputProvider = factory.BindToCollector<TwilioSmsAttribute, CreateMessageOptions>((attr) =>
+            {
+                return new TwilioSmsMessageAsyncCollector(CreateContext(attr));
+            });
+
+            IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
+            extensions.RegisterBindingRules<TwilioSmsAttribute>(ValidateBinding, nameResolver, outputProvider);
+        }
+
+        private void ValidateBinding(TwilioSmsAttribute attribute, Type type)
+        {
+            string accountSid = Utility.FirstOrDefault(attribute.AccountSidSetting, AccountSid, _defaultAccountSid);
+            string authToken = Utility.FirstOrDefault(attribute.AuthTokenSetting, AuthToken, _defaultAuthToken);
+            if (string.IsNullOrEmpty(accountSid))
+            {
+                ThrowMissingSettingException("AccountSID", AzureWebJobsTwilioAccountSidKeyName, "AccountSID");
+            }
+
+            if (string.IsNullOrEmpty(authToken))
+            {
+                ThrowMissingSettingException("AuthToken", AzureWebJobsTwilioAccountAuthTokenName, "AuthToken");
+            }
+        }
+
+        private TwilioSmsContext CreateContext(TwilioSmsAttribute attribute)
+        {
+            string accountSid = Utility.FirstOrDefault(attribute.AccountSidSetting, AccountSid, _defaultAccountSid);
+            string authToken = Utility.FirstOrDefault(attribute.AuthTokenSetting, AuthToken, _defaultAuthToken);
+
+            TwilioRestClient client = _twilioClientCache.GetOrAdd(new Tuple<string, string>(accountSid, authToken), t => new TwilioRestClient(t.Item1, t.Item2));
+
+            var context = new TwilioSmsContext
+            {
+                Client = client,
+                Body = Utility.FirstOrDefault(attribute.Body, Body),
+                From = Utility.FirstOrDefault(attribute.From, From),
+                To = Utility.FirstOrDefault(attribute.To, To)
+            };
+
+            return context;
+        }
+
+        internal static CreateMessageOptions CreateMessageOptions(JObject messageOptions)
+        {
+            var options = new CreateMessageOptions(new PhoneNumber(GetValueOrDefault<string>(messageOptions, "to")))
+            {
+                ProviderSid = GetValueOrDefault<string>(messageOptions, "providerSid"),
+                Body = GetValueOrDefault<string>(messageOptions, "body"),
+                ForceDelivery = GetValueOrDefault<bool?>(messageOptions, "forceDelivery"),
+                MaxRate = GetValueOrDefault<string>(messageOptions, "maxRate"),
+                ValidityPeriod = GetValueOrDefault<int?>(messageOptions, "validityPeriod"),
+                ProvideFeedback = GetValueOrDefault<bool?>(messageOptions, "provideFeedback"),
+                MaxPrice = GetValueOrDefault<decimal?>(messageOptions, "maxPrice"),
+                ApplicationSid = GetValueOrDefault<string>(messageOptions, "applicationSid"),
+                MessagingServiceSid = GetValueOrDefault<string>(messageOptions, "messagingServiceSid"),
+                PathAccountSid = GetValueOrDefault<string>(messageOptions, "pathAccountSid")
+            };
+
+            string value = GetValueOrDefault<string>(messageOptions, "from");
+            if (!string.IsNullOrEmpty(value))
+            {
+                options.From = new PhoneNumber(value);
+            }
+
+            value = GetValueOrDefault<string>(messageOptions, "statusCallback");
+            if (!string.IsNullOrEmpty(value))
+            {
+                options.StatusCallback = new Uri(value);
+            }
+
+            JArray mediaUrls = GetValueOrDefault<JArray>(messageOptions, "mediaUrl");
+            if (mediaUrls != null)
+            {
+                List<Uri> uris = new List<Uri>();
+                foreach (var url in mediaUrls)
+                {
+                    uris.Add(new Uri((string)url));
+                }
+                options.MediaUrl = uris;
+            }
+
+            return options;
+        }
+
+        private static TValue GetValueOrDefault<TValue>(JObject messageObject, string propertyName)
+        {
+            JToken result = null;
+            if (messageObject.TryGetValue(propertyName, StringComparison.OrdinalIgnoreCase, out result))
+            {
+                return result.Value<TValue>();
+            }
+
+            return default(TValue);
+        }
+
+        private static string ThrowMissingSettingException(string settingDisplayName, string settingName, string configPropertyName)
+        {
+            string message = string.Format("The Twilio {0} must be set either via a '{1}' app setting, via a '{1}' environment variable, or directly in code via TwilioSmsConfiguration.{2}.",
+                settingDisplayName, settingName, configPropertyName);
+
+            throw new InvalidOperationException(message);
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Twilio/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Extensions.Twilio/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: ComVisible(false)]
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Extensions.Tests")]

--- a/src/WebJobs.Extensions.Twilio/TwilioSMSAttribute.cs
+++ b/src/WebJobs.Extensions.Twilio/TwilioSMSAttribute.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// Attribute used to bind a parameter to a Twilio SMSMessage that will automatically be
+    /// sent when the function completes.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    [Binding]
+    public sealed class TwilioSmsAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets or sets an optional string value indicating the app setting to use as the Twilio Account SID, 
+        /// if different than the one specified in the <see cref="Extensions.Twilio.TwilioSmsConfiguration"/>.
+        /// </summary>
+        [AppSetting]
+        public string AccountSidSetting { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional string value indicating the app setting to use as the Twilio Auth Token, 
+        /// if different than the one specified in the <see cref="Extensions.Twilio.TwilioSmsConfiguration"/>.
+        /// </summary>
+        [AppSetting]
+        public string AuthTokenSetting { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message "To" field. May include binding parameters.
+        /// </summary>
+        [AutoResolve]
+        public string To { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message "From" field. May include binding parameters.
+        /// </summary>
+        [AutoResolve]
+        public string From { get; set; }
+
+        /// <summary>
+        /// Gets or sets the message "Body" field. May include binding parameters.
+        /// </summary>
+        [AutoResolve]
+        public string Body { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.Twilio/TwilioSmsContext.cs
+++ b/src/WebJobs.Extensions.Twilio/TwilioSmsContext.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Twilio.Clients;
+
+namespace Microsoft.Azure.WebJobs.Extensions
+{
+    public class TwilioSmsContext
+    {
+        public TwilioRestClient Client { get; set; }
+
+        public string From { get; set; }
+
+        public string To { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/src/WebJobs.Extensions.Twilio/Utility.cs
+++ b/src/WebJobs.Extensions.Twilio/Utility.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions
+{
+    internal static class Utility
+    {
+        internal static string FirstOrDefault(params string[] values)
+        {
+            return values.FirstOrDefault(v => !string.IsNullOrEmpty(v));
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Twilio</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Twilio</RootNamespace>
+    <PackageId>Microsoft.Azure.WebJobs.Extensions.Twilio</PackageId>
+    <Description>This package contains binding extensions for Twilio.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Twilio" Version="5.6.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebJobs.Extensions\WebJobs.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions</PackageId>
+    <Description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Extensions.Tests/Extensions/Twilio/TwilioSmsConfigurationTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Twilio/TwilioSmsConfigurationTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Extensions.Twilio;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Twilio
+{
+    public class TwilioSmsConfigurationTests
+    {
+        [Fact]
+        public static void CreateMessageOptions_ReturnsExpectedResult_Simple()
+        {
+            JObject options = new JObject
+            {
+                { "to", "+12223334444" },
+                { "from", "+12223334444" },
+                { "body", "Knock knock." }
+            };
+
+            var result = TwilioSmsConfiguration.CreateMessageOptions(options);
+            Assert.Equal(options["to"], result.To.ToString());
+            Assert.Equal(options["from"], result.From.ToString());
+            Assert.Equal(options["body"], result.Body.ToString());
+        }
+
+        [Fact]
+        public static void CreateMessageOptions_ReturnsExpectedResult_Full()
+        {
+            JObject options = new JObject
+            {
+                { "to", "+14254570421" },
+                { "from", "+14254570422" },
+                { "body", "Knock knock." },
+                { "forceDelivery", true },
+                { "maxRate", 123 },
+                { "validityPeriod", 123 },
+                { "provideFeedback", true },
+                { "maxPrice", 0.55 },
+                { "applicationSid", "aaaa" },
+                { "statusCallback", "http://aaa" },
+                { "messagingServiceSid", "bbbb" },
+                { "pathAccountSid", "ccc" },
+                { "mediaUrl", new JArray { "http://aaa", "http://bbb" } }
+            };
+
+            var result = TwilioSmsConfiguration.CreateMessageOptions(options);
+            Assert.Equal(options["to"], result.To.ToString());
+            Assert.Equal(options["from"], result.From.ToString());
+            Assert.Equal(options["body"], result.Body.ToString());
+            Assert.Equal(options["forceDelivery"], result.ForceDelivery);
+            Assert.Equal(options["maxRate"], result.MaxRate);
+            Assert.Equal(options["validityPeriod"], result.ValidityPeriod);
+            Assert.Equal(options["provideFeedback"], result.ProvideFeedback);
+            Assert.Equal(options["maxPrice"], result.MaxPrice);
+            Assert.Equal(options["applicationSid"], result.ApplicationSid);
+            Assert.Equal(new Uri((string)options["statusCallback"]), result.StatusCallback);
+            Assert.Equal(new Uri((string)options["statusCallback"]), result.StatusCallback);
+            Assert.Equal(options["messagingServiceSid"], result.MessagingServiceSid);
+            Assert.Equal(options["pathAccountSid"], result.PathAccountSid);
+            Assert.Equal(new Uri((string)options["mediaUrl"][0]), result.MediaUrl[0]);
+            Assert.Equal(new Uri((string)options["mediaUrl"][1]), result.MediaUrl[1]);
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\WebJobs.Extensions.Http\WebJobs.Extensions.Http.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Extensions.MobileApps\WebJobs.Extensions.MobileApps.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Extensions.SendGrid\WebJobs.Extensions.SendGrid.csproj" />
+    <ProjectReference Include="..\..\src\WebJobs.Extensions.Twilio\WebJobs.Extensions.Twilio.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Extensions\WebJobs.Extensions.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-webjobs-sdk-extensions/issues/242.

There were a bunch of changes required to the object model of the extension, because Twilio changed their object model quite a bit. See https://www.twilio.com/docs/libraries/csharp/migrating-your-csharp-dot-net-application-twilio-sdk-4x-5x.