### PR TITLE
Adding support for JSON string values in Cosmos DB Trigger binding

### DIFF
--- a/CustomDictionary.xml
+++ b/CustomDictionary.xml
@@ -60,6 +60,7 @@
       <Word>DocumentDB</Word>
       <Word>DocumentDBAttribute</Word>
       <Word>DocumentDBConfiguration</Word>
+      <Word>CosmosDBTrigger</Word>
       <Word>ConnectionStringSetting</Word>
       <Word>MobileAppUriSetting</Word>
       <Word>Twilio</Word>

--- a/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
+++ b/src/WebJobs.Extensions.ApiHub/WebJobs.Extensions.ApiHub.csproj
@@ -215,13 +215,6 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -230,4 +223,11 @@
   </Target>
   -->
   <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
+  </Target>
 </Project>

--- a/src/WebJobs.Extensions.ApiHub/packages.config
+++ b/src/WebJobs.Extensions.ApiHub/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -217,10 +217,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
   </Target>
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
   <Import Project="..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\build\Microsoft.Azure.DocumentDB.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
@@ -230,4 +229,5 @@
   </Target>
   -->
   <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
 </Project>

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -194,12 +194,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
+  <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
   </Target>
-  <Import Project="..\..\tools\Clean.targets" />
 </Project>

--- a/src/WebJobs.Extensions.Http/packages.config
+++ b/src/WebJobs.Extensions.Http/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net46" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -222,9 +222,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
   </Target>
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -233,4 +232,5 @@
   </Target>
   -->
   <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
 </Project>

--- a/src/WebJobs.Extensions.MobileApps/packages.config
+++ b/src/WebJobs.Extensions.MobileApps/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
+++ b/src/WebJobs.Extensions.NotificationHubs/WebJobs.Extensions.NotificationHubs.csproj
@@ -199,13 +199,6 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -214,4 +207,11 @@
   </Target>
   -->
   <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
+  </Target>
 </Project>

--- a/src/WebJobs.Extensions.NotificationHubs/packages.config
+++ b/src/WebJobs.Extensions.NotificationHubs/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -210,13 +210,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -225,4 +218,11 @@
   </Target>
   -->
   <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
+  </Target>
 </Project>

--- a/src/WebJobs.Extensions.SendGrid/packages.config
+++ b/src/WebJobs.Extensions.SendGrid/packages.config
@@ -16,7 +16,7 @@
   <package id="Sendgrid" version="8.0.5" targetFramework="net452" />
   <package id="SendGrid.CSharp.HTTP.Client" version="3.0.0" targetFramework="net45" />
   <package id="SendGrid.SmtpApi" version="1.3.1" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net452" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -232,13 +232,6 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.55.0\build\StyleCop.MSBuild.Targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -247,4 +240,11 @@
   </Target>
   -->
   <Import Project="..\..\tools\Clean.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.targets'))" />
+  </Target>
 </Project>

--- a/src/WebJobs.Extensions/packages.config
+++ b/src/WebJobs.Extensions/packages.config
@@ -14,7 +14,7 @@
   <package id="ncrontab" version="3.3.0" targetFramework="net45" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="StyleCop.MSBuild" version="4.7.55.0" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -79,6 +79,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
             Assert.Equal(binding.LeaseCollectionLocation.Uri, new Uri("https://fromSettingsLease"));
         }
 
+        [Fact]
+        public void TryAndConvertToDocumentList_Fail()
+        {
+            IReadOnlyList<Document> convertedValue;
+            Assert.False(CosmosDBTriggerBinding.TryAndConvertToDocumentList(null, out convertedValue));
+            Assert.False(CosmosDBTriggerBinding.TryAndConvertToDocumentList("some weird string", out convertedValue));
+            Assert.False(CosmosDBTriggerBinding.TryAndConvertToDocumentList(Guid.NewGuid(), out convertedValue));
+        }
+
+        [Fact]
+        public void TryAndConvertToDocumentList_Succeed()
+        {
+            IReadOnlyList<Document> convertedValue;
+            Assert.True(CosmosDBTriggerBinding.TryAndConvertToDocumentList("[{\"id\":\"123\"}]", out convertedValue));
+            Assert.Equal("123", convertedValue[0].Id);
+
+            IReadOnlyList<Document> triggerValue = new List<Document>() { new Document() { Id="123" } };
+            Assert.True(CosmosDBTriggerBinding.TryAndConvertToDocumentList(triggerValue, out convertedValue));
+            Assert.Equal(triggerValue[0].Id, convertedValue[0].Id);
+        }
+
         public static IEnumerable<ParameterInfo[]> InvalidCosmosDBTriggerParameters
         {
             get { return InvalidCosmosDBTriggerBindigs.GetParameters(); }


### PR DESCRIPTION
This change enables executing the Trigger with a test payload from the Functions UI.