### PR TITLE
Initialize the schedule monitor based on the config's TimerMode. 

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Config/TimerJobHostConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Config/TimerJobHostConfigurationExtensions.cs
@@ -19,7 +19,27 @@ namespace Microsoft.Azure.WebJobs
         /// <param name="config">The <see cref="JobHostConfiguration"/> to configure.</param>
         public static void UseTimers(this JobHostConfiguration config)
         {
-            UseTimers(config, new TimersConfiguration());
+            TimersConfiguration timersConfig = null;
+            switch (config.TimerMode)
+            {
+                case TimerMode.File:
+                    timersConfig = new TimersConfiguration()
+                    {
+                        ScheduleMonitor = new FileSystemScheduleMonitor()
+                    };
+
+                    break;
+                case TimerMode.Storage:
+                    timersConfig = new TimersConfiguration()
+                    {
+                        // TimersExtensionConfig will initialize the schedule monitor with context
+                        ScheduleMonitor = null
+                    };
+
+                    break;
+            }
+
+            UseTimers(config, timersConfig);
         }
 
         /// <summary>
@@ -33,6 +53,7 @@ namespace Microsoft.Azure.WebJobs
             {
                 throw new ArgumentNullException("config");
             }
+
             if (timersConfig == null)
             {
                 throw new ArgumentNullException("timersConfig");


### PR DESCRIPTION
The standalone host will need the FileSystemScheduleMonitor to avoid the AzureStorage dependency.
NOTE: This is part of a bigger change that needs changes on this repo and in azure-webjobs-sdk and azure-webjobs-sdk-script to create a custom host for standalone workloads.
IMPORTANT: This change has a dependency on https://github.com/Azure/azure-webjobs-sdk/pull/1384