### PR TITLE
Resolving Cosmos DB Trigger attribute values with NameResolver

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -46,13 +46,11 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Name of the collection to monitor for changes
         /// </summary>
-        [AutoResolve]
         public string CollectionName { get; private set; }
 
         /// <summary>
         /// Name of the database containing the collection to monitor for changes
         /// </summary>
-        [AutoResolve]
         public string DatabaseName { get; private set; }
 
         /// <summary>
@@ -64,13 +62,11 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Name of the lease collection. Default value is "leases"
         /// </summary>
-        [AutoResolve]
         public string LeaseCollectionName { get; set; }
 
         /// <summary>
         /// Name of the database containing the lease collection
         /// </summary>
-        [AutoResolve]
         public string LeaseDatabaseName { get; set; }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -68,17 +68,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 {
                     Uri = triggerConnection.ServiceEndpoint,
                     MasterKey = triggerConnection.AuthKey,
-                    DatabaseName = attribute.DatabaseName,
-                    CollectionName = attribute.CollectionName
+                    DatabaseName = ResolveAttributeValue(attribute.DatabaseName),
+                    CollectionName = ResolveAttributeValue(attribute.CollectionName)
                 };
 
                 leaseCollectionLocation = new DocumentCollectionInfo
                 {
                     Uri = leasesConnection.ServiceEndpoint,
                     MasterKey = leasesConnection.AuthKey,
-                    DatabaseName = attribute.LeaseDatabaseName,
-                    CollectionName = attribute.LeaseCollectionName
+                    DatabaseName = ResolveAttributeValue(attribute.LeaseDatabaseName),
+                    CollectionName = ResolveAttributeValue(attribute.LeaseCollectionName)
                 };
+
+                if (string.IsNullOrEmpty(documentCollectionLocation.DatabaseName)
+                    || string.IsNullOrEmpty(documentCollectionLocation.CollectionName)
+                    || string.IsNullOrEmpty(leaseCollectionLocation.DatabaseName)
+                    || string.IsNullOrEmpty(leaseCollectionLocation.CollectionName))
+                {
+                    throw new InvalidOperationException("Cannot establish database and collection values. If you are using environment and configuration values, please ensure these are correctly set.");
+                }
 
                 if (documentCollectionLocation.Uri.Equals(leaseCollectionLocation.Uri)
                     && documentCollectionLocation.DatabaseName.Equals(leaseCollectionLocation.DatabaseName)
@@ -153,6 +161,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             }
             settingsValue = _nameResolver.Resolve(settingsKey);
             return !string.IsNullOrEmpty(settingsValue);
+        }
+
+        private string ResolveAttributeValue(string attributeValue)
+        {
+            return _nameResolver.Resolve(attributeValue) ?? attributeValue;
         }
     }
 }


### PR DESCRIPTION
Fixes #316 

This change will try to pull the values of the `DatabaseName`, `CollectionName`, `LeaseDatabaseName` and `LeaseCollectionName` using the NameResolver first before using the input values.