### PR TITLE
Sending 400 RUs as default

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/DocumentDBUtility.cs
+++ b/src/WebJobs.Extensions.DocumentDB/DocumentDBUtility.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 {
     internal static class DocumentDBUtility
     {
+        private const int CosmosDBMinimumCollectionRU = 400;
+
         internal static bool TryGetDocumentClientException(Exception originalEx, out DocumentClientException documentClientEx)
         {
             documentClientEx = originalEx as DocumentClientException;
@@ -58,16 +60,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 documentCollection.PartitionKey.Paths.Add(partitionKey);
             }
 
+            if (throughput == 0)
+            {
+                throughput = CosmosDBMinimumCollectionRU;
+            }
+
             // If there is any throughput specified, pass it on. DocumentClient will throw with a 
             // descriptive message if the value does not meet the collection requirements.
-            RequestOptions collectionOptions = null;
-            if (throughput != 0)
+            RequestOptions collectionOptions = new RequestOptions
             {
-                collectionOptions = new RequestOptions
-                {
-                    OfferThroughput = throughput
-                };
-            }
+                OfferThroughput = throughput
+            };
 
             return await service.CreateDocumentCollectionIfNotExistsAsync(databaseUri, documentCollection, collectionOptions);
         }

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBTestUtility.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/DocumentDBTestUtility.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
         public const string DatabaseName = "ItemDB";
         public const string CollectionName = "ItemCollection";
 
-        public static void SetupCollectionMock(Mock<IDocumentDBService> mockService, string partitionKeyPath = null, int throughput = 0)
+        public static void SetupCollectionMock(Mock<IDocumentDBService> mockService, string partitionKeyPath = null, int throughput = 400)
         {
             Uri databaseUri = UriFactory.CreateDatabaseUri(DatabaseName);
 
@@ -33,22 +33,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB
                 expectedPaths.Add(partitionKeyPath);
             }
 
-            if (throughput == 0)
-            {
-                mockService
-                    .Setup(m => m.CreateDocumentCollectionIfNotExistsAsync(databaseUri,
-                        It.Is<DocumentCollection>(d => d.Id == CollectionName && Enumerable.SequenceEqual(d.PartitionKey.Paths, expectedPaths)),
-                        null))
-                    .ReturnsAsync(new DocumentCollection());
-            }
-            else
-            {
-                mockService
+            mockService
                     .Setup(m => m.CreateDocumentCollectionIfNotExistsAsync(databaseUri,
                         It.Is<DocumentCollection>(d => d.Id == CollectionName && Enumerable.SequenceEqual(d.PartitionKey.Paths, expectedPaths)),
                         It.Is<RequestOptions>(r => r.OfferThroughput == throughput)))
                     .ReturnsAsync(new DocumentCollection());
-            }
         }
 
         public static void SetupDatabaseMock(Mock<IDocumentDBService> mockService)


### PR DESCRIPTION
This change sends 400 RU as the default Throughput when creating a Cosmos DB collection instead of not sending anything.

The reason for this is that the default can vary between Subscription Types at this point and people were expecting 400 RU collections (the minimum) and saw 1000 RU collections being created.