### PR TITLE
Exposing Change Feed options on Trigger

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
+++ b/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency id="Microsoft.Azure.WebJobs.Extensions" version="$WebJobsPackageVersion$" />
       <dependency id="Microsoft.Azure.DocumentDB" version="1.13.2" />
-      <dependency id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" />
+      <dependency id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.1.1" />
     </dependencies>
   </metadata>
 </package>

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -70,11 +70,6 @@ namespace Microsoft.Azure.WebJobs
         public string LeaseDatabaseName { get; set; }
 
         /// <summary>
-        /// Gets or sets the lease options for this particular DocumentDB Trigger. Overrides any value defined in <see cref="DocumentDBConfiguration" /> 
-        /// </summary>
-        public ChangeFeedHostOptions LeaseOptions { get; set; }
-
-        /// <summary>
         /// Optional.
         /// Only applies to lease collection.
         /// If true, the database and collection for leases will be automatically created if it does not exist.
@@ -87,5 +82,53 @@ namespace Microsoft.Azure.WebJobs
         /// collection.
         /// </summary>
         public int LeasesCollectionThroughput { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Defines a prefix to be used within a Leases collection for this Trigger. Useful when sharing the same Lease collection among multiple Triggers
+        /// </summary>
+        public string LeaseCollectionPrefix { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the amount of milliseconds between lease checkpoints. Default is always after a Function call.
+        /// </summary>
+        public int CheckpointInterval { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the amount of documents between lease checkpoints. Default is always after a Function call.
+        /// </summary>
+        public int CheckpointDocumentCount { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the delay in milliseconds in between polling a partition for new changes on the feed, after all current changes are drained.  Default is 5000 (5 seconds).
+        /// </summary>
+        public int FeedPollDelay { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the renew interval in milliseconds for all leases for partitions currently held by the Trigger. Default is 17000 (17 seconds).
+        /// </summary>
+        public int LeaseRenewInterval { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the interval in milliseconds to kick off a task to compute if partitions are distributed evenly among known host instances. Default is 13000 (13 seconds).
+        /// </summary>
+        public int LeaseAcquireInterval { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the interval in milliseconds for which the lease is taken on a lease representing a partition. If the lease is not renewed within this interval, it will cause it to expire and ownership of the partition will move to another Trigger instance. Default is 60000 (60 seconds).
+        /// </summary>
+        public int LeaseExpirationInterval { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Customizes the maximum amount of items received in an invocation
+        /// </summary>
+        public int MaxItemsPerInvocation { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
     internal class CosmosDBTriggerAttributeBindingProvider : ITriggerBindingProvider
     {
+        private const string CosmosDBTriggerUserAgentSuffix = "CosmosDBTriggerFunctions";
         private readonly ChangeFeedHostOptions _leasesOptions;
         private readonly INameResolver _nameResolver;
         private string _monitorConnectionString;
@@ -48,6 +49,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             DocumentCollectionInfo documentCollectionLocation;
             DocumentCollectionInfo leaseCollectionLocation;
             ChangeFeedHostOptions leaseHostOptions = ResolveLeaseOptions(attribute);
+            int? maxItemCount = null;
+            if (attribute.MaxItemsPerInvocation > 0)
+            {
+                maxItemCount = attribute.MaxItemsPerInvocation;
+            }
 
             try
             {
@@ -73,6 +79,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                     CollectionName = ResolveAttributeValue(attribute.CollectionName)
                 };
 
+                documentCollectionLocation.ConnectionPolicy.UserAgentSuffix = CosmosDBTriggerUserAgentSuffix;
+
                 leaseCollectionLocation = new DocumentCollectionInfo
                 {
                     Uri = leasesConnection.ServiceEndpoint,
@@ -80,6 +88,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                     DatabaseName = ResolveAttributeValue(attribute.LeaseDatabaseName),
                     CollectionName = ResolveAttributeValue(attribute.LeaseCollectionName)
                 };
+
+                leaseCollectionLocation.ConnectionPolicy.UserAgentSuffix = CosmosDBTriggerUserAgentSuffix;
 
                 if (string.IsNullOrEmpty(documentCollectionLocation.DatabaseName)
                     || string.IsNullOrEmpty(documentCollectionLocation.CollectionName)
@@ -108,7 +118,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 throw new InvalidOperationException(string.Format("Cannot create Collection Information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.CollectionName, attribute.DatabaseName, attribute.LeaseCollectionName, attribute.LeaseDatabaseName, ex.Message), ex);
             }
 
-            return new CosmosDBTriggerBinding(parameter, documentCollectionLocation, leaseCollectionLocation, leaseHostOptions);
+            return new CosmosDBTriggerBinding(parameter, documentCollectionLocation, leaseCollectionLocation, leaseHostOptions, maxItemCount);
+        }
+
+        internal static TimeSpan ResolveTimeSpanFromMilliseconds(string nameOfProperty, TimeSpan baseTimeSpan, int? attributeValue)
+        {
+            if (!attributeValue.HasValue || attributeValue.Value == 0)
+            {
+                return baseTimeSpan;
+            }
+
+            if (attributeValue.Value < 0)
+            {
+                throw new InvalidOperationException($"'{nameOfProperty}' must be greater than 0.");
+            }
+
+            return TimeSpan.FromMilliseconds(attributeValue.Value);
         }
 
         private string ResolveAttributeConnectionString(CosmosDBTriggerAttribute attribute)
@@ -150,7 +175,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
         private ChangeFeedHostOptions ResolveLeaseOptions(CosmosDBTriggerAttribute attribute)
         {
-            return attribute.LeaseOptions ?? _leasesOptions;
+            ChangeFeedHostOptions triggerChangeFeedHostOptions = new ChangeFeedHostOptions();
+            triggerChangeFeedHostOptions.LeasePrefix = ResolveAttributeValue(attribute.LeaseCollectionPrefix) ?? _leasesOptions.LeasePrefix;
+            triggerChangeFeedHostOptions.FeedPollDelay = ResolveTimeSpanFromMilliseconds(nameof(CosmosDBTriggerAttribute.FeedPollDelay), _leasesOptions.FeedPollDelay, attribute.FeedPollDelay);
+            triggerChangeFeedHostOptions.LeaseAcquireInterval = ResolveTimeSpanFromMilliseconds(nameof(CosmosDBTriggerAttribute.LeaseAcquireInterval), _leasesOptions.LeaseAcquireInterval, attribute.LeaseAcquireInterval);
+            triggerChangeFeedHostOptions.LeaseExpirationInterval = ResolveTimeSpanFromMilliseconds(nameof(CosmosDBTriggerAttribute.LeaseExpirationInterval), _leasesOptions.LeaseExpirationInterval, attribute.LeaseExpirationInterval);
+            triggerChangeFeedHostOptions.LeaseRenewInterval = ResolveTimeSpanFromMilliseconds(nameof(CosmosDBTriggerAttribute.LeaseRenewInterval), _leasesOptions.LeaseRenewInterval, attribute.LeaseRenewInterval);
+            triggerChangeFeedHostOptions.CheckpointFrequency = _leasesOptions.CheckpointFrequency ?? new CheckpointFrequency();
+            if (attribute.CheckpointInterval > 0)
+            {
+                triggerChangeFeedHostOptions.CheckpointFrequency.TimeInterval = TimeSpan.FromMilliseconds(attribute.CheckpointInterval);
+            }
+
+            if (attribute.CheckpointDocumentCount > 0)
+            {
+                triggerChangeFeedHostOptions.CheckpointFrequency.ProcessedDocumentCount = attribute.CheckpointDocumentCount;
+            }
+
+            return triggerChangeFeedHostOptions;
         }
 
         private bool TryReadFromSettings(string settingsKey, string defaultValue, out string settingsValue)

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
@@ -22,14 +22,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         private readonly DocumentCollectionInfo _leaseCollectionLocation;
         private readonly ChangeFeedHostOptions _leaseHostOptions;
         private readonly IBindingDataProvider _bindingDataProvider;
+        private readonly int? _maxItemsPerCall;
 
-        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions)
+        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemsPerCall)
         {
             _bindingDataProvider = BindingDataProvider.FromType(parameter.ParameterType);
             _documentCollectionLocation = documentCollectionLocation;
             _leaseCollectionLocation = leaseCollectionLocation;
             _leaseHostOptions = leaseHostOptions;
             _parameter = parameter;
+            _maxItemsPerCall = maxItemsPerCall;
         }
 
         /// <summary>
@@ -40,6 +42,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         internal DocumentCollectionInfo DocumentCollectionLocation => _documentCollectionLocation;
 
         internal DocumentCollectionInfo LeaseCollectionLocation => _leaseCollectionLocation;
+
+        internal ChangeFeedHostOptions ChangeFeedHostOptions => _leaseHostOptions;
 
         public IReadOnlyDictionary<string, Type> BindingDataContract
         {
@@ -65,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             {
                 throw new ArgumentNullException("context", "Missing listener context");
             }
-            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions));
+            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions, this._maxItemsPerCall));
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerListener.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         private readonly DocumentCollectionInfo monitorCollection;
         private readonly DocumentCollectionInfo leaseCollection;
 
-        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions)
+        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemCount)
         {
             this.executor = executor;
             string hostName = Guid.NewGuid().ToString();
@@ -28,7 +28,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             monitorCollection = documentCollectionLocation;
             leaseCollection = leaseCollectionLocation;
 
-            this.host = new ChangeFeedEventHost(hostName, documentCollectionLocation, leaseCollectionLocation, new ChangeFeedOptions(), leaseHostOptions);
+            ChangeFeedOptions changeFeedOptions = new ChangeFeedOptions();
+            if (maxItemCount.HasValue)
+            {
+                changeFeedOptions.MaxItemCount = maxItemCount;
+            }
+
+            this.host = new ChangeFeedEventHost(hostName, documentCollectionLocation, leaseCollectionLocation, changeFeedOptions, leaseHostOptions);
         }
 
         public void Cancel()

--- a/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
+++ b/src/WebJobs.Extensions.DocumentDB/WebJobs.Extensions.DocumentDB.csproj
@@ -40,8 +40,8 @@
     <DocumentationFile>bin\Release\Microsoft.Azure.WebJobs.Extensions.DocumentDB.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.0.0\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.17.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.1.1\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>

--- a/src/WebJobs.Extensions.DocumentDB/packages.config
+++ b/src/WebJobs.Extensions.DocumentDB/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net46" />
-  <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.WebJobs" version="2.1.0" targetFramework="net46" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.1.0" targetFramework="net46" />

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -107,6 +107,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
             Assert.Equal(binding.LeaseCollectionLocation.Uri, new Uri("https://fromSettingsLease"));
         }
 
+        [Theory]
+        [MemberData(nameof(ValidCosmosDBTriggerBindigsWithLeaseHostOptionsParameters))]
+        public async Task ValidLeaseHostOptions_Succeed(ParameterInfo parameter)
+        {
+            var nameResolver = new TestNameResolver();
+            nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
+            nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
+            nameResolver.Values["dynamicLeasePrefix"] = "someLeasePrefix";
+
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfiguration());
+
+            CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.Equal(binding.TriggerValueType, typeof(IReadOnlyList<Document>));
+            Assert.Equal(binding.DocumentCollectionLocation.Uri, new Uri("https://fromSettings"));
+            Assert.Equal(binding.ChangeFeedHostOptions.LeasePrefix, "someLeasePrefix");
+        }
+
         [Fact]
         public void TryAndConvertToDocumentList_Fail()
         {
@@ -126,6 +144,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
             IReadOnlyList<Document> triggerValue = new List<Document>() { new Document() { Id = "123" } };
             Assert.True(CosmosDBTriggerBinding.TryAndConvertToDocumentList(triggerValue, out convertedValue));
             Assert.Equal(triggerValue[0].Id, convertedValue[0].Id);
+        }
+
+        [Fact]
+        public void ResolveTimeSpanFromMilliseconds_Succeed()
+        {
+            TimeSpan baseTimeSpan = TimeSpan.FromMilliseconds(10);
+            Assert.Equal(CosmosDBTriggerAttributeBindingProvider.ResolveTimeSpanFromMilliseconds("SomeAttribute", baseTimeSpan, null), baseTimeSpan);
+            int otherMilliseconds = 20;
+            TimeSpan otherTimeSpan = TimeSpan.FromMilliseconds(otherMilliseconds);
+            Assert.Equal(CosmosDBTriggerAttributeBindingProvider.ResolveTimeSpanFromMilliseconds("SomeAttribute", baseTimeSpan, otherMilliseconds), otherTimeSpan);
+        }
+
+        [Fact]
+        public void ResolveTimeSpanFromMilliseconds_Fail()
+        {
+            int otherMilliseconds = -1;
+            TimeSpan baseTimeSpan = TimeSpan.FromMilliseconds(10);
+            Assert.Throws<InvalidOperationException>(() => CosmosDBTriggerAttributeBindingProvider.ResolveTimeSpanFromMilliseconds("SomeAttribute", baseTimeSpan, otherMilliseconds));
         }
 
         public static IEnumerable<ParameterInfo[]> InvalidCosmosDBTriggerParameters
@@ -151,6 +187,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerBindingsWithEnvironmentParameters
         {
             get { return ValidCosmosDBTriggerBindigsWithEnvironment.GetParameters(); }
+        }
+
+        public static IEnumerable<ParameterInfo[]> ValidCosmosDBTriggerBindigsWithLeaseHostOptionsParameters
+        {
+            get { return ValidCosmosDBTriggerBindigsWithLeaseHostOptions.GetParameters(); }
         }
 
         private static ParameterInfo GetFirstParameter(Type type, string methodName)
@@ -224,6 +265,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
                     new[] { GetFirstParameter(type, "Func1") },
                     new[] { GetFirstParameter(type, "Func2") },
                     new[] { GetFirstParameter(type, "Func3") }
+                };
+            }
+        }
+
+        private static class ValidCosmosDBTriggerBindigsWithLeaseHostOptions
+        {
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseCollectionPrefix = "someLeasePrefix")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseCollectionPrefix = "%dynamicLeasePrefix%")] IReadOnlyList<Document> docs)
+            {
+
+            }
+
+            public static IEnumerable<ParameterInfo[]> GetParameters()
+            {
+                var type = typeof(ValidCosmosDBTriggerBindigsWithLeaseHostOptions);
+
+                return new[]
+                {
+                    new[] { GetFirstParameter(type, "Func1") },
+                    new[] { GetFirstParameter(type, "Func2") }
                 };
             }
         }

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\Microsoft.Azure.ApiHub.Sdk.0.7.2-alpha\lib\net45\Microsoft.Azure.ApiHub.Sdk.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.0.0\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Documents.ChangeFeedProcessor, Version=1.17.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.ChangeFeedProcessor.1.1.1\lib\net45\Microsoft.Azure.Documents.ChangeFeedProcessor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.Documents.Client, Version=1.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.13.2\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>

--- a/test/WebJobs.Extensions.Tests/packages.config
+++ b/test/WebJobs.Extensions.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ApiHub.Sdk" version="0.7.2-alpha" targetFramework="net452" />
   <package id="Microsoft.Azure.DocumentDB" version="1.13.2" targetFramework="net46" />
-  <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" version="1.1.1" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net452" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net45" />


### PR DESCRIPTION
This change exposes a number of Change Feed Host options to the `CosmosDBTrigger`:

- Lease Preffix: This is used when the user wants to share the Lease collection among several Triggers and reduces operational costs.
- Polling intervals: Exposing different interval options that allow the user to customize the frequency on which the Trigger will check for changes and other time-related features.

Additionally, `UserAgentSuffix` was added to the `DocumentClient` initializations in the trigger to identify traffic coming from the Trigger in the account's analytics.