### PR TITLE
SAS work

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitor.cs
@@ -55,10 +55,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                         throw new InvalidOperationException("Unable to determine host ID.");
                     }
 
-                    CloudStorageAccount storageAccount = CloudStorageAccount.Parse(_hostConfig.StorageConnectionString);
-                    CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+                    CloudBlobContainer container;
+                    var storage = _hostConfig.InternalStorageConfiguration;
+                    if (storage != null && storage.InternalContainer != null)
+                    {
+                        container = storage.InternalContainer;
+                    }
+                    else
+                    {
+                        CloudStorageAccount storageAccount = CloudStorageAccount.Parse(_hostConfig.StorageConnectionString);
+                        CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+                        container = blobClient.GetContainerReference(HostContainerName);
+                    }
                     string timerStatusDirectoryPath = string.Format("timers/{0}", _hostConfig.HostId);
-                    _timerStatusDirectory = blobClient.GetContainerReference(HostContainerName).GetDirectoryReference(timerStatusDirectoryPath);
+                    _timerStatusDirectory = container.GetDirectoryReference(timerStatusDirectoryPath);
                 }
                 return _timerStatusDirectory;
             }

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11117" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
     <PackageReference Include="ncrontab" Version="3.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Allow timers to run purely off a SAS container and not require full connections string.

Fix https://github.com/Azure/azure-webjobs-sdk-script/issues/2209

Relies on SDK changes from: https://github.com/Azure/azure-webjobs-sdk/pull/1425