### PR TITLE
Fix Cosmos DB exception when using headers and query binding expressions

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBSqlResolutionPolicy.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBSqlResolutionPolicy.cs
@@ -25,9 +25,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             {
                 throw new ArgumentNullException(nameof(bindingData));
             }
-
-            CosmosDBAttribute docDbAttribute = resolvedAttribute as CosmosDBAttribute;
-            if (docDbAttribute == null)
+            
+            if (!(resolvedAttribute is CosmosDBAttribute cosmosDBAttribute))
             {
                 throw new NotSupportedException($"This policy is only supported for {nameof(CosmosDBAttribute)}.");
             }
@@ -36,11 +35,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             SqlParameterCollection paramCollection = new SqlParameterCollection();
 
             string bindingTemplatePattern = bindingTemplate.Pattern;
-
+            
             IDictionary<string, string> expandedTokens = GetExpandedTokens(bindingTemplate, bindingData);
-
-            // also build up a dictionary replacing '{token}' with '@token' 
-            IDictionary<string, string> replacements = new Dictionary<string, string>();
             foreach (var token in expandedTokens)
             {
                 string bindingExpression = $"{{{token.Key}}}";
@@ -52,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 }
             }
 
-            docDbAttribute.SqlQueryParameters = paramCollection;
+            cosmosDBAttribute.SqlQueryParameters = paramCollection;
 
             return bindingTemplatePattern;
         }

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBSqlResolutionPolicy.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBSqlResolutionPolicy.cs
@@ -43,9 +43,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             IDictionary<string, string> replacements = new Dictionary<string, string>();
             foreach (var token in expandedTokens)
             {
-                string sqlTokenName = $"@{EscapeSqlParameterName(token.Key)}";
-                paramCollection.Add(new SqlParameter(sqlTokenName, token.Value));
-                bindingTemplatePattern = bindingTemplatePattern.Replace($"{{{token.Key}}}", sqlTokenName);
+                string bindingExpression = $"{{{token.Key}}}";
+                if (bindingTemplatePattern.Contains(bindingExpression))
+                {
+                    string sqlTokenName = $"@{EscapeSqlParameterName(token.Key)}";
+                    paramCollection.Add(new SqlParameter(sqlTokenName, token.Value));
+                    bindingTemplatePattern = bindingTemplatePattern.Replace($"{{{token.Key}}}", sqlTokenName);
+                }
             }
 
             docDbAttribute.SqlQueryParameters = paramCollection;

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBSqlResolutionPolicy.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBSqlResolutionPolicy.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             string fullTokenName = GetFullTokenName(firstTokenNameSegment, secondTokenNameSegment);
             string tokenName = secondTokenNameSegment ?? firstTokenNameSegment;
 
-            string sqlToken = GetSqlParameterName(fullTokenName);
+            bool needsEscaping = !string.IsNullOrEmpty(secondTokenNameSegment);
+            string sqlToken = "@" + (needsEscaping ? EscapeSqlParameterName(fullTokenName) : fullTokenName);
+
             paramCollection.Add(new SqlParameter(sqlToken, sqlParamValue));
             tokens.Add(tokenName, sqlToken);
         }
@@ -87,10 +89,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 $"{firstTokenNameSegment}.{secondTokenNameSegment}";
         }
 
-        private string GetSqlParameterName(string name)
+        private string EscapeSqlParameterName(string name)
         {
-            const string safeSeparator = "_";
-            return "@" + name.Replace(".", safeSeparator).Replace("-", safeSeparator);
+            return Guid.NewGuid().ToString("N");
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.Azure.WebJobs.Host.Bindings.Path;
 using Xunit;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
 {
@@ -74,10 +75,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
             string result = policy.TemplateBind(propInfo, resolvedAttribute, bindingTemplate, bindingData);
 
             // Assert
-            Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@headers_x_ms_client_principal_name" && p.Value.ToString() == "username");
-            Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@id" && p.Value.ToString() == "foo");
+            var nameParameter = resolvedAttribute.SqlQueryParameters.Single(p => p.Value.ToString() == "username");
+            var idParameter = resolvedAttribute.SqlQueryParameters.Single(p => p.Value.ToString() == "foo");
             Assert.Equal(2, resolvedAttribute.SqlQueryParameters.Count); // should not contain more parameters than required
-            Assert.Equal("SELECT * FROM c WHERE c.id = @id and c.userId = @headers_x_ms_client_principal_name", result);
+            Assert.Equal($"SELECT * FROM c WHERE c.id = {idParameter.Name} and c.userId = {nameParameter.Name}", result);
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
@@ -63,7 +63,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
             BindingTemplate bindingTemplate =
                 BindingTemplate.FromString("SELECT * FROM c WHERE c.id = {headers.x-ms-client-principal-name}");
             Dictionary<string, object> bindingData = new Dictionary<string, object>();
-            bindingData.Add("headers", new Dictionary<string, string> { { "x-ms-client-principal-name", "username" } });
+            bindingData.Add("headers", new Dictionary<string, string>
+            {
+                { "x-ms-client-principal-name", "username" },
+                { "x-ms-client-principal-id", "userid" }
+            });
             CosmosDBSqlResolutionPolicy policy = new CosmosDBSqlResolutionPolicy();
 
             // Act
@@ -71,6 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
 
             // Assert
             Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@headers_x_ms_client_principal_name" && p.Value.ToString() == "username");
+            Assert.Single(resolvedAttribute.SqlQueryParameters);
             Assert.Equal("SELECT * FROM c WHERE c.id = @headers_x_ms_client_principal_name", result);
         }
     }

--- a/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
@@ -54,19 +54,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
         }
 
         [Fact]
-        public void TemplateBind_NestedParameter()
+        public void TemplateBind_StringParameterAndNestedParameter()
         {
             // Arrange
             PropertyInfo propInfo = null;
             CosmosDBAttribute resolvedAttribute = new CosmosDBAttribute();
             BindingTemplate bindingTemplate =
-                BindingTemplate.FromString("SELECT * FROM c WHERE c.id = {headers.x-ms-client-principal-name}");
+                BindingTemplate.FromString("SELECT * FROM c WHERE c.id = {id} and c.userId = {headers.x-ms-client-principal-name}");
             Dictionary<string, object> bindingData = new Dictionary<string, object>();
             bindingData.Add("headers", new Dictionary<string, string>
             {
                 { "x-ms-client-principal-name", "username" },
                 { "x-ms-client-principal-id", "userid" }
             });
+            bindingData.Add("id", "foo");
             CosmosDBSqlResolutionPolicy policy = new CosmosDBSqlResolutionPolicy();
 
             // Act
@@ -74,8 +75,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
 
             // Assert
             Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@headers_x_ms_client_principal_name" && p.Value.ToString() == "username");
-            Assert.Single(resolvedAttribute.SqlQueryParameters); // should not contain more parameters than required
-            Assert.Equal("SELECT * FROM c WHERE c.id = @headers_x_ms_client_principal_name", result);
+            Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@id" && p.Value.ToString() == "foo");
+            Assert.Equal(2, resolvedAttribute.SqlQueryParameters.Count); // should not contain more parameters than required
+            Assert.Equal("SELECT * FROM c WHERE c.id = @id and c.userId = @headers_x_ms_client_principal_name", result);
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/CosmosDB/CosmosDBSqlResolutionPolicyTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
@@ -75,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB
 
             // Assert
             Assert.Single(resolvedAttribute.SqlQueryParameters, p => p.Name == "@headers_x_ms_client_principal_name" && p.Value.ToString() == "username");
-            Assert.Single(resolvedAttribute.SqlQueryParameters);
+            Assert.Single(resolvedAttribute.SqlQueryParameters); // should not contain more parameters than required
             Assert.Equal("SELECT * FROM c WHERE c.id = @headers_x_ms_client_principal_name", result);
         }
     }


### PR DESCRIPTION
Currently this exception occurs when trying to use binding expressions that access headers and query from the HTTP trigger in Azure Functions:

`"sqlQuery": "select * from c where c.id = {headers.foo}"`

> Microsoft.Azure.WebJobs.Host: Error while accessing 'foo': property doesn't exist.

