### PR TITLE
Trigger attribute auth ctor

### DIFF
--- a/src/WebJobs.Extensions.Http/HttpTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.Http/HttpTriggerAttribute.cs
@@ -35,6 +35,15 @@ namespace Microsoft.Azure.WebJobs
         /// Constructs a new instance.
         /// </summary>
         /// <param name="authLevel">The <see cref="AuthorizationLevel"/> to apply.</param>
+        public HttpTriggerAttribute(AuthorizationLevel authLevel)
+        {
+            AuthLevel = authLevel;
+        }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="authLevel">The <see cref="AuthorizationLevel"/> to apply.</param>
         /// <param name="methods">The http methods to allow.</param>
         public HttpTriggerAttribute(AuthorizationLevel authLevel, params string[] methods)
         {

--- a/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerAttributeConstructionTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerAttributeConstructionTests.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.Azure.WebJobs.Extensions.Http;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http

--- a/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerAttributeConstructionTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerAttributeConstructionTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Azure.WebJobs.Extensions.Http;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http

--- a/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerAttributeConstructionTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerAttributeConstructionTests.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Azure.WebJobs.Extensions.Http;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
+{
+    public class HttpTriggerAttributeConstructionTests
+    {
+        [Fact]
+        public void HttpTriggerAuthLevelCtor_NullMethods()
+        {
+            var trigger = new HttpTriggerAttribute(AuthorizationLevel.Admin);
+
+            Assert.Null(trigger.Methods);
+        }
+    }
+}


### PR DESCRIPTION
Adding fourth constructor to take only `AuthorizationLevel` in reference to Azure/azure-functions-vs-build-sdk#163.