### PR TITLE
Add auth information as an optional parameter in HttpTrigger functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bin
 obj
 csx
-.vs/config/
+.vs
 
 *.user
 *.suo

--- a/src/WebJobs.Extensions.Http/AuthenticatedUser.cs
+++ b/src/WebJobs.Extensions.Http/AuthenticatedUser.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs
+{
+    /// <summary>
+    /// A class containing information about the current authenticated user.
+    /// </summary>
+    public class AuthenticatedUser
+    {
+        /// <summary>
+        /// The JWT access token for the user
+        /// </summary>
+        [JsonProperty("access_token")]
+        public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// The datetime that the user's access token expires
+        /// </summary>
+        [JsonProperty("expires_on")]
+        public DateTime ExpiresOn { get; private set; }
+
+        /// <summary>
+        /// The JWT token that represents the identity of the user.
+        /// </summary>
+        [JsonProperty("id_token")]
+        public string IdToken { get; private set; }
+
+        /// <summary>
+        /// The string representation of the identity provider for the authenticated user.
+        /// </summary>
+        [JsonProperty("provider_name")]
+        public string ProviderName { get; private set; }
+
+        /// <summary>
+        /// The datetime that the user's access token expires
+        /// </summary>
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; private set; }
+
+        [JsonProperty("user_claims")]
+        internal List<Claim> _userClaims { get; set; }
+
+        /// <summary>
+        /// An array of claims that apply to the authenticated user.
+        /// </summary>
+        [JsonIgnoreAttribute]
+        public IReadOnlyList<Claim> UserClaims
+        {
+            get
+            {
+                return this._userClaims.AsReadOnly();
+            }
+        } 
+
+        internal static AuthenticatedUser DeserializeJson(string json)
+        {
+            return JsonConvert.DeserializeObject<List<AuthenticatedUser>>(json, new JsonConverter[] { new ClaimConverter() })[0];
+        }
+
+        private class ClaimConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(Claim);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                JObject jObject = JObject.Load(reader);
+                return new Claim(jObject["typ"].Value<string>(), jObject["val"].Value<string>());
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Http/AuthenticatedUserBindingProvider.cs
+++ b/src/WebJobs.Extensions.Http/AuthenticatedUserBindingProvider.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Http
+{
+    internal class AuthenticatedUserBindingProvider : IBindingProvider
+    {
+        public Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (context.Parameter.ParameterType != typeof(AuthenticatedUser))
+            {
+                return Task.FromResult<IBinding>(null);
+            }
+
+            return Task.FromResult<IBinding>(new AuthenticatedUserBinding(context.Parameter));
+        }
+
+        private class AuthenticatedUserBinding : IBinding
+        {
+            private readonly ParameterInfo _parameter;
+
+            public AuthenticatedUserBinding(ParameterInfo parameter)
+            {
+                _parameter = parameter;
+            }
+
+            public bool FromAttribute => false;
+
+            public Task<IValueProvider> BindAsync(object value, ValueBindingContext context)
+            {
+                // TODO: Don't know what to do with this without binding data, or if it 
+                // is even needed in our use case.
+                throw new NotImplementedException("This method doesn't have binding data.");
+            }
+
+            public Task<IValueProvider> BindAsync(BindingContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException("context");
+                }
+
+                return BindAsync(context.BindingData);
+            }
+
+            private static Task<IValueProvider> BindAsync(IReadOnlyDictionary<string, object> bindingData)
+            {
+                return Task.FromResult<IValueProvider>(new AuthenticatedUserValueProvider(bindingData));
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                return new ParameterDescriptor
+                {
+                    Name = _parameter.Name,
+                    DisplayHints = new ParameterDisplayHints
+                    {
+                        Description = "AuthenticatedUser"
+                    }
+                };
+            }
+
+            private class AuthenticatedUserValueProvider : IValueProvider
+            {
+                private static HttpClient _client = new HttpClient();
+                private IReadOnlyDictionary<string, object> _bindingData;
+
+                public AuthenticatedUserValueProvider(IReadOnlyDictionary<string, object> bindingData)
+                {
+                    _bindingData = bindingData;
+                }
+
+                public Type Type => typeof(AuthenticatedUser);
+
+                public async Task<object> GetValueAsync()
+                {
+                    var initialRequest = _bindingData.Values.FirstOrDefault(val => val.GetType() == typeof(HttpRequestMessage)) as HttpRequestMessage;
+                    if (initialRequest == null)
+                    {
+                        throw new InvalidOperationException("Cannot determine authenticated user without HttpTrigger.");
+                    }
+
+                    var authorizationHeader = GetAuthorizationHeaderValue(initialRequest);
+                    if (authorizationHeader != null)
+                    {
+                        return await GetAuthenticatedUserFromEasyAuth(authorizationHeader);
+                    }
+                    else
+                    {
+                        return GetAuthenticatedUserFromFunctionKey();
+                    }   
+                }
+
+                private static string GetAuthorizationHeaderValue(HttpRequestMessage initialRequest)
+                {
+                    var idTokenHeaders = initialRequest.Headers.Where(header => header.Key.EndsWith("id-token", StringComparison.OrdinalIgnoreCase));
+                    if (!idTokenHeaders.Any())
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        var idTokenHeader = idTokenHeaders.First();
+                        var idTokenValue = idTokenHeader.Value.First();
+                        return "Bearer " + idTokenValue;
+                    }
+                }
+
+                private async Task<AuthenticatedUser> GetAuthenticatedUserFromEasyAuth(string authorizationHeader)
+                {
+                    string hostname = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME");
+                    var authUri = "https://" + hostname + "/.auth/me";
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, authUri);
+                    request.Headers.Add("Authorization", authorizationHeader);
+                    HttpResponseMessage response = await _client.SendAsync(request);
+
+                    if (response.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        // TODO: Determine if an exception is the most appropriate use case here
+                        // especially once we start dealing with AND/OR of multiple AuthLevel enums
+                        throw new InvalidOperationException("No user was authenticated.");
+                    }
+                    else if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        //Same concern as the unauthorized case
+                        throw new InvalidOperationException("Authentication/Authorization is not enabled.");
+                    }
+                    else if (response.IsSuccessStatusCode)
+                    {
+                        string authenticatedUserJson = await response.Content.ReadAsStringAsync();
+                        return AuthenticatedUser.DeserializeJson(authenticatedUserJson);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Do not know how to handle response status code {response.StatusCode} from {authUri}");
+                    }
+                }
+
+                private static AuthenticatedUser GetAuthenticatedUserFromFunctionKey()
+                {
+                    throw new NotImplementedException("TODO: Have not worked out what information I can/should populate here.");
+                }
+
+                public string ToInvokeString()
+                {
+                    //TODO: what goes here?
+                    return string.Empty;
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Http/AuthorizationLevel.cs
+++ b/src/WebJobs.Extensions.Http/AuthorizationLevel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         Anonymous = 0,
 
         /// <summary>
-        /// Allow access to requests that include a valid authentication token
+        /// Allow access to requests that include a valid user authentication token
         /// </summary>
         User,
 

--- a/src/WebJobs.Extensions.Http/ClaimsIdentityBindingProvider.cs
+++ b/src/WebJobs.Extensions.Http/ClaimsIdentityBindingProvider.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Http
+{
+    /// <summary>
+    /// This provider provides a binding to Type <see cref="ClaimsIdentity"/>.
+    /// </summary>
+    /// <remarks>
+    /// Attempts to bind to an identity in precedence order based on <see cref="AuthorizationLevel"/> levels.
+    /// I.e. if the request is key authenticated (Function/System/Admin) that identity is returned, if the
+    /// request is user authenticated (User) that identity is returned.
+    /// </remarks>
+    internal class ClaimsIdentityBindingProvider : IBindingProvider
+    {
+        public Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (context.Parameter.ParameterType != typeof(ClaimsIdentity))
+            {
+                return Task.FromResult<IBinding>(null);
+            }
+
+            return Task.FromResult<IBinding>(new ClaimsIdentityBinding(context.Parameter));
+        }
+
+        private class ClaimsIdentityBinding : IBinding
+        {
+            private readonly ParameterInfo _parameter;
+
+            public ClaimsIdentityBinding(ParameterInfo parameter)
+            {
+                _parameter = parameter;
+            }
+
+            public bool FromAttribute
+            {
+                get { return false; }
+            }
+
+            public async Task<IValueProvider> BindAsync(BindingContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException("context");
+                }
+
+                // if the request is EasyAuth authenticated, get the identity provider type
+                object value = null;
+                string identityProvider = null;
+                if (context.BindingData.TryGetValue(HttpTriggerAttributeBindingProvider.HttpHeadersKey, out value))
+                {
+                    IDictionary<string, string> headers = (IDictionary<string, string>)value;
+                    if (headers != null)
+                    {
+                        headers.TryGetValue(HttpConstants.AntaresEasyAuthProviderHeaderName, out identityProvider);
+                    }  
+                }
+
+                var identity = GetPrimaryIdentity(ClaimsPrincipal.Current, identityProvider);
+                return await BindInternalAsync(identity);
+            }
+
+            public Task<IValueProvider> BindAsync(object value, ValueBindingContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException("context");
+                }
+
+                var identity = GetPrimaryIdentity(ClaimsPrincipal.Current);
+
+                return BindInternalAsync(identity);
+            }
+
+            private static Task<IValueProvider> BindInternalAsync(ClaimsIdentity identity)
+            {
+                return Task.FromResult<IValueProvider>(new ClaimsIdentityValueProvider(identity));
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                return new ParameterDescriptor
+                {
+                    Name = _parameter.Name,
+                    DisplayHints = new ParameterDisplayHints
+                    {
+                        Description = "ClaimsIdentity"
+                    }
+                };
+            }
+
+            private static ClaimsIdentity GetPrimaryIdentity(ClaimsPrincipal claimsPrincipal, string identityProvider = null)
+            {
+                // if the principal contains a key based identity that will take precedence
+                // over any other identity
+                var identity = claimsPrincipal.Identities.LastOrDefault(p => p.IsAuthenticated && string.Compare(p.AuthenticationType, "key", StringComparison.OrdinalIgnoreCase) == 0);
+                if (identity != null)
+                {
+                    return identity;
+                }
+
+                if (identityProvider != null)
+                {
+                    foreach (var currIdentity in claimsPrincipal.Identities.Where(p => p.IsAuthenticated))
+                    {
+                        // if a specific identity provider is specified, look for a match
+                        if (string.Compare(currIdentity.AuthenticationType, identityProvider, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            return currIdentity;
+                        }
+
+                        // in client flow scenarios the AuthenticationType will be "Federated", so we must look into the
+                        // specific claims for the original identity provider
+                        var identityProviderClaim = currIdentity.FindFirst(HttpConstants.AntaresEasyAuthIdentityProviderClaimName);
+                        if (identityProviderClaim != null && string.Compare(identityProviderClaim.Value, identityProvider, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            return currIdentity;
+                        }
+                    }
+                }
+
+                // otherwise default to the base primary identity
+                return (ClaimsIdentity)claimsPrincipal.Identity;
+            }
+
+            private class ClaimsIdentityValueProvider : IValueProvider
+            {
+                private ClaimsIdentity _identity;
+
+                public ClaimsIdentityValueProvider(ClaimsIdentity identity)
+                {
+                    _identity = identity;
+                }
+
+                public Type Type
+                {
+                    get { return typeof(ClaimsIdentity); }
+                }
+
+                public Task<object> GetValueAsync()
+                {
+                    return Task.FromResult<object>(_identity);
+                }
+
+                public string ToInvokeString()
+                {
+                    // TODO: figure out right value here
+                    return ClaimsPrincipal.Current.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Http/ClaimsPrincipalBindingProvider.cs
+++ b/src/WebJobs.Extensions.Http/ClaimsPrincipalBindingProvider.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Http
+{
+    /// <summary>
+    /// This provider provides a binding to Type <see cref="ClaimsPrincipal"/>.
+    /// </summary>
+    internal class ClaimsPrincipalBindingProvider : IBindingProvider
+    {
+        public Task<IBinding> TryCreateAsync(BindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (context.Parameter.ParameterType != typeof(ClaimsPrincipal))
+            {
+                return Task.FromResult<IBinding>(null);
+            }
+
+            return Task.FromResult<IBinding>(new ClaimsIdentityBinding(context.Parameter));
+        }
+
+        private class ClaimsIdentityBinding : IBinding
+        {
+            private readonly ParameterInfo _parameter;
+
+            public ClaimsIdentityBinding(ParameterInfo parameter)
+            {
+                _parameter = parameter;
+            }
+
+            public bool FromAttribute
+            {
+                get { return false; }
+            }
+
+            public Task<IValueProvider> BindAsync(BindingContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException("context");
+                }
+
+                return BindInternalAsync();
+            }
+
+            public Task<IValueProvider> BindAsync(object value, ValueBindingContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException("context");
+                }
+
+                return BindInternalAsync();
+            }
+            
+            private static Task<IValueProvider> BindInternalAsync()
+            {
+                return Task.FromResult<IValueProvider>(new ClaimsPrincipalValueProvider());
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                return new ParameterDescriptor
+                {
+                    Name = _parameter.Name,
+                    DisplayHints = new ParameterDisplayHints
+                    {
+                        Description = "ClaimsPrincipal"
+                    }
+                };
+            }
+
+            private class ClaimsPrincipalValueProvider : IValueProvider
+            {
+                public ClaimsPrincipalValueProvider()
+                {
+                }
+
+                public Type Type
+                {
+                    get { return typeof(ClaimsPrincipal); }
+                }
+
+                public Task<object> GetValueAsync()
+                {
+                    return Task.FromResult<object>(ClaimsPrincipal.Current);
+                }
+
+                public string ToInvokeString()
+                {
+                    // TODO: figure out right value here
+                    return ClaimsPrincipal.Current.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.Http/Config/HttpExtensionConfiguration.cs
+++ b/src/WebJobs.Extensions.Http/Config/HttpExtensionConfiguration.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
             context.Config.RegisterBindingExtension(new HttpDirectRequestBindingProvider());
             context.Config.RegisterBindingExtensions(
                 new ClaimsIdentityBindingProvider(),
-                new ClaimsPrincipalBindingProvider());
+                new ClaimsPrincipalBindingProvider(),
+                new AuthenticatedUserBindingProvider());
         }
     }
 }

--- a/src/WebJobs.Extensions.Http/Config/HttpExtensionConfiguration.cs
+++ b/src/WebJobs.Extensions.Http/Config/HttpExtensionConfiguration.cs
@@ -70,6 +70,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
 
             context.Config.RegisterBindingExtension(new HttpTriggerAttributeBindingProvider(this.SetResponse));
             context.Config.RegisterBindingExtension(new HttpDirectRequestBindingProvider());
+            context.Config.RegisterBindingExtensions(
+                new ClaimsIdentityBindingProvider(),
+                new ClaimsPrincipalBindingProvider());
         }
     }
 }

--- a/src/WebJobs.Extensions.Http/HttpConstants.cs
+++ b/src/WebJobs.Extensions.Http/HttpConstants.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.Http
+{
+    internal static class HttpConstants
+    {
+        public const string AntaresEasyAuthProviderHeaderName = "X-MS-CLIENT-PRINCIPAL-IDP";
+        public const string AntaresEasyAuthIdentityProviderClaimName = "http://schemas.microsoft.com/identity/claims/identityprovider";
+    }
+}

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -164,6 +164,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuthenticatedUser.cs" />
+    <Compile Include="AuthenticatedUserBindingProvider.cs" />
     <Compile Include="AuthorizationLevel.cs" />
     <Compile Include="ClaimsIdentityBindingProvider.cs" />
     <Compile Include="ClaimsPrincipalBindingProvider.cs" />

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -165,9 +165,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthorizationLevel.cs" />
+    <Compile Include="ClaimsIdentityBindingProvider.cs" />
+    <Compile Include="ClaimsPrincipalBindingProvider.cs" />
     <Compile Include="Config\HttpExtensionConfiguration.cs" />
     <Compile Include="Config\HttpJobHostConfigurationExtensions.cs" />
     <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
+    <Compile Include="HttpConstants.cs" />
     <Compile Include="HttpDirectRequestBindingProvider.cs" />
     <Compile Include="HttpExtensionConstants.cs" />
     <Compile Include="Extensions\IDictionaryExtensions.cs" />

--- a/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Http/HttpTriggerEndToEndTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
@@ -105,6 +106,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
         }
 
         [Fact]
+        public void ClaimsPrincipalBinding()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://functions.com/api/TestIdentityBindings");
+
+            var method = typeof(TestFunctions).GetMethod("TestIdentityBindings");
+            _host.Call(method, new { req = request });
+        }
+
+        [Fact]
         public async Task QueryHeaderBindingParameters()
         {
             string testId = Guid.NewGuid().ToString();
@@ -173,12 +183,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             {
                 blob = headers["testValue"];
             }
-                        
+
             public static Task<string> TestResponse(
                 [HttpTrigger("get", "post")] HttpRequestMessage req)
             {
                 // Return value becomes the HttpResponseMessage.
-                return Task.FromResult("test-response"); 
+                return Task.FromResult("test-response");
+            }
+
+            public static void TestIdentityBindings(
+                [HttpTrigger("get")] HttpRequestMessage req,
+                ClaimsPrincipal principal,
+                ClaimsIdentity identity)
+            {
+                Assert.Same(ClaimsPrincipal.Current, principal);
+                Assert.Same(principal.Identity, identity);
             }
 
             // Test that we can bind to both a Poco and the direct request message


### PR DESCRIPTION
A prototype to access the information that can be found at the /.auth/me endpoint easily as a parameter of the function.

NOTE: The current PR is for v2.x (Functions V1) only. Most of the code I have added in the second commit should work in dev (Functions V2) as well, but the folder structure was different, so files may need to be located in different places, and testing still needs to be done to ensure it works on Functions V2.

Current limitations:

- Doesn't grab information from the key-based authentication that Functions already has
- Requires the function to reference the Microsoft.Azure.WebJobs.Extensions.Http.dll to get access to the new type
- Not robust in handling "mixed" authorization methods (i.e. allowing AND/OR of key-based and EasyAuth-based authorization)