### PR TITLE
[CosmosDB] Porting leaseprefix and other options

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -72,11 +72,6 @@ namespace Microsoft.Azure.WebJobs
         public string LeaseDatabaseName { get; set; }
 
         /// <summary>
-        /// Gets or sets the lease options for this particular DocumentDB Trigger. Overrides any value defined in <see cref="DocumentDBConfiguration" /> 
-        /// </summary>
-        public ChangeFeedHostOptions LeaseOptions { get; set; }
-
-        /// <summary>
         /// Optional.
         /// Only applies to lease collection.
         /// If true, the database and collection for leases will be automatically created if it does not exist.
@@ -89,5 +84,53 @@ namespace Microsoft.Azure.WebJobs
         /// collection.
         /// </summary>
         public int LeasesCollectionThroughput { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Defines a prefix to be used within a Leases collection for this Trigger. Useful when sharing the same Lease collection among multiple Triggers
+        /// </summary>
+        public string LeaseCollectionPrefix { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the amount of milliseconds between lease checkpoints. Default is always after a Function call.
+        /// </summary>
+        public int CheckpointInterval { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the amount of documents between lease checkpoints. Default is always after a Function call.
+        /// </summary>
+        public int CheckpointDocumentCount { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the delay in milliseconds in between polling a partition for new changes on the feed, after all current changes are drained.  Default is 5000 (5 seconds).
+        /// </summary>
+        public int FeedPollDelay { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the renew interval in milliseconds for all leases for partitions currently held by the Trigger. Default is 17000 (17 seconds).
+        /// </summary>
+        public int LeaseRenewInterval { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the interval in milliseconds to kick off a task to compute if partitions are distributed evenly among known host instances. Default is 13000 (13 seconds).
+        /// </summary>
+        public int LeaseAcquireInterval { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the interval in milliseconds for which the lease is taken on a lease representing a partition. If the lease is not renewed within this interval, it will cause it to expire and ownership of the partition will move to another Trigger instance. Default is 60000 (60 seconds).
+        /// </summary>
+        public int LeaseExpirationInterval { get; set; }
+        
+        /// <summary>
+        /// Optional.
+        /// Customizes the maximum amount of items received in an invocation
+        /// </summary>
+        public int MaxItemsPerInvocation { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
@@ -23,13 +23,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly ChangeFeedHostOptions _leaseHostOptions;
         private readonly IReadOnlyDictionary<string, Type> _emptyBindingContract = new Dictionary<string, Type>();
         private readonly IReadOnlyDictionary<string, object> _emptyBindingData = new Dictionary<string, object>();
+        private readonly int? _maxItemsPerCall;
 
-        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions)
+        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemsPerCall)
         {
             _documentCollectionLocation = documentCollectionLocation;
             _leaseCollectionLocation = leaseCollectionLocation;
             _leaseHostOptions = leaseHostOptions;
             _parameter = parameter;
+            _maxItemsPerCall = maxItemsPerCall;
         }
 
         /// <summary>
@@ -40,6 +42,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         internal DocumentCollectionInfo DocumentCollectionLocation => _documentCollectionLocation;
 
         internal DocumentCollectionInfo LeaseCollectionLocation => _leaseCollectionLocation;
+
+        internal ChangeFeedHostOptions ChangeFeedHostOptions => _leaseHostOptions;
 
         public IReadOnlyDictionary<string, Type> BindingDataContract
         {
@@ -59,7 +63,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             {
                 throw new ArgumentNullException("context", "Missing listener context");
             }
-            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions));
+
+            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions, this._maxItemsPerCall));
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly DocumentCollectionInfo monitorCollection;
         private readonly DocumentCollectionInfo leaseCollection;
 
-        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions)
+        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemCount)
         {
             this.executor = executor;
             string hostName = Guid.NewGuid().ToString();
@@ -28,7 +28,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             monitorCollection = documentCollectionLocation;
             leaseCollection = leaseCollectionLocation;
 
-            this.host = new ChangeFeedEventHost(hostName, documentCollectionLocation, leaseCollectionLocation, new ChangeFeedOptions(), leaseHostOptions);
+            ChangeFeedOptions changeFeedOptions = new ChangeFeedOptions();
+            if (maxItemCount.HasValue)
+            {
+                changeFeedOptions.MaxItemCount = maxItemCount;
+            }
+            
+            this.host = new ChangeFeedEventHost(hostName, documentCollectionLocation, leaseCollectionLocation, changeFeedOptions, leaseHostOptions);
         }
 
         public void Cancel()


### PR DESCRIPTION
This PR fills the gap between V1 and V2 by adding `LeaseCollectionPrefix` and other options to the `CosmosDBTrigger`.

Fixes https://github.com/Azure/azure-webjobs-sdk-extensions/issues/423
