### PR TITLE
[Cosmos DB] Adding tracing and retry fix for Trigger

### DIFF
--- a/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Config/DocumentDBConfiguration.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             IExtensionRegistry extensions = context.Config.GetService<IExtensionRegistry>();
             extensions.RegisterBindingRules<DocumentDBAttribute>(ValidateConnection, nameResolver, outputProvider, clientProvider, jArrayProvider, enumerableProvider, inputProvider);
 
-            context.Config.RegisterBindingExtensions(new CosmosDBTriggerAttributeBindingProvider(nameResolver, this, LeaseOptions));
+            context.Config.RegisterBindingExtensions(new CosmosDBTriggerAttributeBindingProvider(nameResolver, _trace, this, LeaseOptions));
         }
 
         internal static void ValidateInputBinding(DocumentDBAttribute attribute, Type parameterType)

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -20,12 +20,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         private readonly INameResolver _nameResolver;
         private string _monitorConnectionString;
         private string _leasesConnectionString;
+        private TraceWriter _trace;
         private DocumentDBConfiguration _config;
 
-        public CosmosDBTriggerAttributeBindingProvider(INameResolver nameResolver, DocumentDBConfiguration config, ChangeFeedHostOptions leasesOptions = null)
+        public CosmosDBTriggerAttributeBindingProvider(INameResolver nameResolver, TraceWriter trace, DocumentDBConfiguration config, ChangeFeedHostOptions leasesOptions = null)
         {
             _nameResolver = nameResolver;
             _config = config;
+            _trace = trace;
             _leasesOptions = leasesOptions ?? new ChangeFeedHostOptions();
         }
 
@@ -142,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 throw new InvalidOperationException(string.Format("Cannot create Collection Information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.CollectionName, attribute.DatabaseName, attribute.LeaseCollectionName, attribute.LeaseDatabaseName, ex.Message), ex);
             }
 
-            return new CosmosDBTriggerBinding(parameter, documentCollectionLocation, leaseCollectionLocation, leaseHostOptions, maxItemCount);
+            return new CosmosDBTriggerBinding(parameter, documentCollectionLocation, leaseCollectionLocation, leaseHostOptions, maxItemCount, _trace);
         }
 
         internal static TimeSpan ResolveTimeSpanFromMilliseconds(string nameOfProperty, TimeSpan baseTimeSpan, int? attributeValue)

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerBinding.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.ChangeFeedProcessor;
+    using Microsoft.Azure.WebJobs.Host;
     using Microsoft.Azure.WebJobs.Host.Bindings;
     using Microsoft.Azure.WebJobs.Host.Listeners;
     using Microsoft.Azure.WebJobs.Host.Protocols;
@@ -21,16 +22,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
         private readonly DocumentCollectionInfo _documentCollectionLocation;
         private readonly DocumentCollectionInfo _leaseCollectionLocation;
         private readonly ChangeFeedHostOptions _leaseHostOptions;
+        private readonly TraceWriter _trace;
         private readonly IBindingDataProvider _bindingDataProvider;
         private readonly int? _maxItemsPerCall;
 
-        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemsPerCall)
+        public CosmosDBTriggerBinding(ParameterInfo parameter, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemsPerCall, TraceWriter trace)
         {
             _bindingDataProvider = BindingDataProvider.FromType(parameter.ParameterType);
             _documentCollectionLocation = documentCollectionLocation;
             _leaseCollectionLocation = leaseCollectionLocation;
             _leaseHostOptions = leaseHostOptions;
             _parameter = parameter;
+            _trace = trace;
             _maxItemsPerCall = maxItemsPerCall;
         }
 
@@ -69,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
             {
                 throw new ArgumentNullException("context", "Missing listener context");
             }
-            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions, this._maxItemsPerCall));
+            return Task.FromResult<IListener>(new CosmosDBTriggerListener(context.Executor, this._documentCollectionLocation, this._leaseCollectionLocation, this._leaseHostOptions, this._maxItemsPerCall, this._trace));
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.DocumentDB/Trigger/CosmosDBTriggerListener.cs
@@ -10,23 +10,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.ChangeFeedProcessor;
     using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.WebJobs.Host;
     using Microsoft.Azure.WebJobs.Host.Executors;
     using Microsoft.Azure.WebJobs.Host.Listeners;
 
     internal class CosmosDBTriggerListener : IListener, IChangeFeedObserverFactory
     {
         private readonly ITriggeredFunctionExecutor executor;
-        private readonly ChangeFeedEventHost host;
+        private readonly TraceWriter trace;
         private readonly DocumentCollectionInfo monitorCollection;
         private readonly DocumentCollectionInfo leaseCollection;
+        private readonly string hostName;
+        private readonly ChangeFeedOptions changeFeedOptions;
+        private readonly ChangeFeedHostOptions leaseHostOptions;
+        private ChangeFeedEventHost host;
+        private bool listenerStarted = false;
 
-        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemCount)
+        public CosmosDBTriggerListener(ITriggeredFunctionExecutor executor, DocumentCollectionInfo documentCollectionLocation, DocumentCollectionInfo leaseCollectionLocation, ChangeFeedHostOptions leaseHostOptions, int? maxItemCount, TraceWriter trace)
         {
+            this.trace = trace;
             this.executor = executor;
-            string hostName = Guid.NewGuid().ToString();
+            this.hostName = Guid.NewGuid().ToString();
 
-            monitorCollection = documentCollectionLocation;
-            leaseCollection = leaseCollectionLocation;
+            this.monitorCollection = documentCollectionLocation;
+            this.leaseCollection = leaseCollectionLocation;
+            this.leaseHostOptions = leaseHostOptions;
 
             ChangeFeedOptions changeFeedOptions = new ChangeFeedOptions();
             if (maxItemCount.HasValue)
@@ -34,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
                 changeFeedOptions.MaxItemCount = maxItemCount;
             }
 
-            this.host = new ChangeFeedEventHost(hostName, documentCollectionLocation, leaseCollectionLocation, changeFeedOptions, leaseHostOptions);
+            this.changeFeedOptions = changeFeedOptions;
         }
 
         public void Cancel()
@@ -54,21 +62,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.DocumentDB
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            if (this.listenerStarted)
+            {
+                throw new InvalidOperationException("The listener has already been started.");
+            }
+
+            this.InitializeHost();
+
             try
             {
-                await host.RegisterObserverFactoryAsync(this);
+                await this.host.RegisterObserverFactoryAsync(this);
+                this.listenerStarted = true;
             }
             catch (DocumentClientException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {
                 // Throw a custom error so that it's easier to decipher.
                 string message = $"Either the source collection '{monitorCollection.CollectionName}' (in database '{monitorCollection.DatabaseName}')  or the lease collection '{leaseCollection.CollectionName}' (in database '{leaseCollection.DatabaseName}') does not exist. Both collections must exist before the listener starts. To automatically create the lease collection, set '{nameof(CosmosDBTriggerAttribute.CreateLeaseCollectionIfNotExists)}' to 'true'.";
+                this.host = null;
                 throw new InvalidOperationException(message, ex);
             }
         }
 
-        public Task StopAsync(CancellationToken cancellationToken)
+        public async Task StopAsync(CancellationToken cancellationToken)
         {
-            return host.UnregisterObserversAsync();
+            try
+            {
+                if (this.host != null && this.listenerStarted)
+                {
+                    await this.host.UnregisterObserversAsync();
+                    this.listenerStarted = false;
+                }
+            }
+            catch (Exception ex)
+            {
+                this.trace.Warning($"Stopping the observer failed, potentially it was never started. Exception: {ex.Message}.");
+            }
+        }
+
+        private void InitializeHost()
+        {
+            if (this.host == null)
+            {
+                this.host = new ChangeFeedEventHost(this.hostName, this.monitorCollection, this.leaseCollection, this.changeFeedOptions, leaseHostOptions);
+            }
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -23,7 +24,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(InvalidCosmosDBTriggerParameters))]
         public async Task InvalidParameters_Fail(ParameterInfo parameter)
         {
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(new DefaultNameResolver(), CreateConfiguration());
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
+
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(new DefaultNameResolver(), testTrace, CreateConfiguration());
 
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None)));
 
@@ -34,11 +37,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(ValidCosmosDBTriggerBindingsWithEnvironmentParameters))]
         public async Task ValidParametersWithEnvironment_Succeed(ParameterInfo parameter)
         {
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
             var nameResolver = new TestNameResolver();
             nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
             nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
 
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfiguration());
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, testTrace, CreateConfiguration());
 
             CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -50,11 +54,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(ValidCosmosDBTriggerBindingsWithEnvironmentParameters))]
         public async Task ValidParametersWithEnvironment_ConnectionMode_Succeed(ParameterInfo parameter)
         {
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
             var nameResolver = new TestNameResolver();
             nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
             nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
 
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfigurationWithConnectionMode());
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, testTrace, CreateConfigurationWithConnectionMode());
 
             CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -68,13 +73,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(ValidCosmosDBTriggerBindingsWithAppSettingsParameters))]
         public async Task ValidParametersWithAppSettings_Succeed(ParameterInfo parameter)
         {
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
             var nameResolver = new TestNameResolver();
             nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
             nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
             nameResolver.Values["aDatabase"] = "myDatabase";
             nameResolver.Values["aCollection"] = "myCollection";
 
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfiguration());
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, testTrace, CreateConfiguration());
 
             CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -90,13 +96,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(ValidCosmosDBTriggerBindingsWithDatabaseAndCollectionSettingsParameters))]
         public async Task ValidCosmosDBTriggerBindigsWithDatabaseAndCollectionSettings_Succeed(ParameterInfo parameter)
         {
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
             var nameResolver = new TestNameResolver();
             nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
             nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
             nameResolver.Values["aDatabase"] = "myDatabase";
             nameResolver.Values["aCollection"] = "myCollection";
 
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfiguration());
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, testTrace, CreateConfiguration());
 
             CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -112,12 +119,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(ValidCosmosDBTriggerBindingsDifferentConnectionsParameters))]
         public async Task ValidCosmosDBTriggerBindigsDifferentConnections_Succeed(ParameterInfo parameter)
         {
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
             var nameResolver = new TestNameResolver();
             nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
             nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
             nameResolver.Values["LeaseCosmosDBConnectionString"] = "AccountEndpoint=https://fromSettingsLease;AccountKey=someKey;";
 
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfiguration());
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, testTrace, CreateConfiguration());
 
             CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -130,12 +138,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
         [MemberData(nameof(ValidCosmosDBTriggerBindigsWithLeaseHostOptionsParameters))]
         public async Task ValidLeaseHostOptions_Succeed(ParameterInfo parameter)
         {
+            var testTrace = new TestTraceWriter(TraceLevel.Verbose);
             var nameResolver = new TestNameResolver();
             nameResolver.Values[DocumentDBConfiguration.AzureWebJobsDocumentDBConnectionStringName] = "AccountEndpoint=https://fromEnvironment;AccountKey=someKey;";
             nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
             nameResolver.Values["dynamicLeasePrefix"] = "someLeasePrefix";
 
-            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, CreateConfiguration());
+            CosmosDBTriggerAttributeBindingProvider provider = new CosmosDBTriggerAttributeBindingProvider(nameResolver, testTrace, CreateConfiguration());
 
             CosmosDBTriggerBinding binding = (CosmosDBTriggerBinding)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 

--- a/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/DocumentDB/Trigger/CosmosDBTriggerAttributeTests.cs
@@ -16,8 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.DocumentDB.Trigger
 
             ArgumentException missingDatabase = Assert.Throws<ArgumentException>(() => new CosmosDBTriggerAttribute(null, "someCollection"));
             Assert.Equal(missingDatabase.ParamName, "databaseName");
-
-            }
+        }
 
         [Fact]
         public void CompleteArguments_Succeed()


### PR DESCRIPTION
This change adds tracing inside the CosmosDBTrigger and handles the case where StopAsync might be called before Start.

It also fixes the null-ref that comes from the automatic retry when a a Function fails to load.

This PR fixes #379
This PR fixes #432 