### PR TITLE
Exposing router API to retrieve function route template

### DIFF
--- a/src/WebJobs.Extensions.Http/HttpExtensionConstants.cs
+++ b/src/WebJobs.Extensions.Http/HttpExtensionConstants.cs
@@ -30,5 +30,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         /// </summary>
         public const string AzureWebJobsUseReverseRoutesKey = "MS_AzureWebJobs_UseReverseRoutes";
 
+        /// <summary>
+        /// Key used to set the function name on a route.
+        /// </summary>
+        public const string FunctionNameRouteTokenKey = "AZUREWEBJOBS_FUNCTIONNAME";
     }
 }

--- a/src/WebJobs.Extensions.Http/Routing/IWebJobsRouter.cs
+++ b/src/WebJobs.Extensions.Http/Routing/IWebJobsRouter.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         void ClearRoutes();
 
         WebJobsRouteBuilder CreateBuilder(IWebJobsRouteHandler routeHandler, string routePrefix);
+
+        string GetFunctionRouteTemplate(string functionName);
     }
 }

--- a/src/WebJobs.Extensions.Http/Routing/WebJobsRouteBuilder.cs
+++ b/src/WebJobs.Extensions.Http/Routing/WebJobsRouteBuilder.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         {
             var tokens = new RouteValueDictionary(dataTokens)
             {
-                { "AZUREWEBJOBS_FUNCTIONNAME", functionName }
+                { HttpExtensionConstants.FunctionNameRouteTokenKey, functionName }
             };
 
             template = BuildRouteTemplate(_routePrefix, template);

--- a/test/WebJobs.Extensions.Http.Tests/WebJobsRouterTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/WebJobsRouterTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Http.Tests
+{
+    public class WebJobsRouterTests
+    {
+        [Fact]
+        public void GetFunctionRoutes()
+        {
+            // Arrange
+            var constraintResolver = new Mock<IInlineConstraintResolver>();
+            var handler = new Mock<IWebJobsRouteHandler>();
+            IWebJobsRouter router = new WebJobsRouter(constraintResolver.Object);
+
+            var builder = router.CreateBuilder(handler.Object, "api");
+            builder.MapFunctionRoute("testfunction", "test/{token}", "testfunction");
+
+            router.AddFunctionRoutes(builder.Build(), null);
+
+            // Act
+            string routeTemplate = router.GetFunctionRouteTemplate("testfunction");
+
+            // Assert
+            Assert.Equal("api/test/{token}", routeTemplate);
+        }
+    }
+}


### PR DESCRIPTION
Same changes made in #443 , but targeting a patch branch without DI changes so we can consume this in the current version of the script host.