### PR TITLE
[Cosmos DB] Updating Change Feed Library to 2.0.6

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -9,7 +9,7 @@
     <Description>This package contains binding extensions for Azure Cosmos DB.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="1.3.3" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.0.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>

--- a/test/WebJobs.Extensions.CosmosDB.Tests/WebJobs.Extensions.CosmosDB.Tests.csproj
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/WebJobs.Extensions.CosmosDB.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="1.3.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.145" />


### PR DESCRIPTION
This PR updates to the latest Change Feed Library version and increases the Cosmos DB SQL dependency tree to the latest (Core 1.9.1) as a side effect.