### PR TITLE
[Cosmos DB] Updating CFP to 2.1.0

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -9,7 +9,7 @@
     <Description>This package contains binding extensions for Azure Cosmos DB.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-rc1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBTestUtility.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBTestUtility.cs
@@ -81,9 +81,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
         public static DocumentClientException CreateDocumentClientException(HttpStatusCode status)
         {
-            var headers = new NameValueCollection();
-            var parameters = new object[] { null, null, headers, status, null };
-            return Activator.CreateInstance(typeof(DocumentClientException), BindingFlags.NonPublic | BindingFlags.Instance, null, parameters, null) as DocumentClientException;
+            Type t = typeof(DocumentClientException);
+
+            var constructor = t.GetConstructor(
+               BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic,
+               null, new[] { typeof(string), typeof(Exception), typeof(HttpStatusCode?), typeof(Uri), typeof(string) }, null);
+
+            object ex = constructor.Invoke(new object[] { string.Empty, new Exception(), status, null, string.Empty });
+            return ex as DocumentClientException;
         }
 
         public static ParameterInfo GetInputParameter<T>()


### PR DESCRIPTION
This PR addresses https://github.com/Azure/azure-functions-host/issues/3419 by updating the CFP library to the latest version, and updating the Cosmos DB SDK dependency to 2.0.0.