### PR TITLE
[CosmosDB] fixing connection setting fallback for leases

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -178,7 +178,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         private string ResolveAttributeLeasesConnectionString(CosmosDBTriggerAttribute attribute)
         {
-            string connectionString = ResolveConnectionString(attribute.LeaseConnectionStringSetting, nameof(CosmosDBTriggerAttribute.LeaseConnectionStringSetting));
+            // If the lease connection string is not set, use the trigger's
+            string keyToResolve = attribute.LeaseConnectionStringSetting;
+            if (string.IsNullOrEmpty(keyToResolve))
+            {
+                keyToResolve = attribute.ConnectionStringSetting;
+            }
+
+            string connectionString = ResolveConnectionString(keyToResolve, nameof(CosmosDBTriggerAttribute.LeaseConnectionStringSetting));
 
             if (string.IsNullOrEmpty(connectionString))
             {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-host/issues/3484

We had some test gaps where we didn't validate the correct `LeaseConnectionStringSetting` -> `ConnectionStringSetting` -> `ConnectionStrings:CosmosDB` fallback. 

I've beefed up those tests, which failed before the fix.