### PR TITLE
[Cosmos DB] Implementing Multi Master and PreferredLocations

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings
             }
 
             string resolvedConnectionString = _configProvider.ResolveConnectionString(attribute.ConnectionStringSetting);
-            ICosmosDBService service = _configProvider.GetService(resolvedConnectionString);
+            ICosmosDBService service = _configProvider.GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
 
             return service.GetClient();
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
     internal class DefaultCosmosDBServiceFactory : ICosmosDBServiceFactory
     {
-        public ICosmosDBService CreateService(string connectionString, ConnectionMode? connectionMode, Protocol? protocol)
+        public ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy)
         {
-            return new CosmosDBService(connectionString, connectionMode, protocol);
+            return new CosmosDBService(connectionString, connectionPolicy);
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Config/ICosmosDBServiceFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/ICosmosDBServiceFactory.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
     internal interface ICosmosDBServiceFactory
     {
-        ICosmosDBService CreateService(string connectionString, ConnectionMode? connectionMode, Protocol? protocol);
+        ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy);
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -102,6 +102,23 @@ namespace Microsoft.Azure.WebJobs
         [AutoResolve(ResolutionPolicyType = typeof(CosmosDBSqlResolutionPolicy))]
         public string SqlQuery { get; set; }
 
+        /// <summary>
+        /// Optional.
+        /// Enable to use with Multi Master accounts.
+        /// </summary>
+        public bool UseMultipleWriteLocations { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service.
+        /// Values should be comma-separated.
+        /// </summary>
+        /// <example>
+        /// PreferredLocations = "East US,South Central US,North Europe"
+        /// </example>
+        [AutoResolve]
+        public string PreferredLocations { get; set; }
+
         internal SqlParameterCollection SqlQueryParameters { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Services/CosmosDBService.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Services/CosmosDBService.cs
@@ -15,21 +15,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private bool _isDisposed;
         private DocumentClient _client;
 
-        public CosmosDBService(string connectionString, ConnectionMode? connectionMode, Protocol? protocol)
+        public CosmosDBService(string connectionString, ConnectionPolicy connectionPolicy)
         {
             CosmosDBConnectionString connection = new CosmosDBConnectionString(connectionString);
-            _client = new DocumentClient(connection.ServiceEndpoint, connection.AuthKey);
-            if (connectionMode.HasValue)
+            if (connectionPolicy == null)
             {
-                // Default is Gateway
-                // Source: https://docs.microsoft.com/dotnet/api/microsoft.azure.documents.client.connectionpolicy.connectionmode
-                _client.ConnectionPolicy.ConnectionMode = connectionMode.Value;
+                connectionPolicy = new ConnectionPolicy();
             }
 
-            if (protocol.HasValue)
-            {
-                _client.ConnectionPolicy.ConnectionProtocol = protocol.Value;
-            }
+            _client = new DocumentClient(connection.ServiceEndpoint, connection.AuthKey, connectionPolicy);
         }
 
         public DocumentClient GetClient()

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -137,5 +137,15 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets whether change feed in the Azure Cosmos DB service should start from beginning (true) or from current (false). By default it's start from current (false).
         /// </summary>
         public bool StartFromBeginning { get; set; } = false;
+
+        /// <summary>
+        /// Optional.
+        /// Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service.
+        /// Values should be comma-separated.
+        /// </summary>
+        /// <example>
+        /// PreferredLocations = "East US,South Central US,North Europe"
+        /// </example>
+        public string PreferredLocations { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -119,6 +119,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     leaseCollectionLocation.ConnectionPolicy.ConnectionProtocol = desiredConnectionProtocol.Value;
                 }
 
+                string resolvedPreferredLocations = ResolveAttributeValue(attribute.PreferredLocations);
+                foreach (var location in CosmosDBUtility.ParsePreferredLocations(resolvedPreferredLocations))
+                {
+                    documentCollectionLocation.ConnectionPolicy.PreferredLocations.Add(location);
+                    leaseCollectionLocation.ConnectionPolicy.PreferredLocations.Add(location);
+                }
+
                 if (string.IsNullOrEmpty(documentCollectionLocation.DatabaseName)
                     || string.IsNullOrEmpty(documentCollectionLocation.CollectionName)
                     || string.IsNullOrEmpty(leaseCollectionLocation.DatabaseName)
@@ -137,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 if (attribute.CreateLeaseCollectionIfNotExists)
                 {
                     // Not disposing this because it might be reused on other Trigger since Triggers could share lease collection
-                    ICosmosDBService service = _configProvider.GetService(leasesConnectionString);
+                    ICosmosDBService service = _configProvider.GetService(leasesConnectionString, resolvedPreferredLocations);
                     await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(service, leaseCollectionLocation.DatabaseName, leaseCollectionLocation.CollectionName, null, attribute.LeasesCollectionThroughput);
                 }
             }

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             Mock<ICosmosDBServiceFactory> mockServiceFactory = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
 
             mockServiceFactory
-                .Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<ConnectionMode?>(), It.IsAny<Protocol?>()))
+                .Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>()))
                 .Returns(mockService.Object);
 
             var options = new OptionsWrapper<CosmosDBOptions>(new CosmosDBOptions

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
@@ -57,14 +57,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(ConfigConnStr, null, null))
+                .Setup(f => f.CreateService(ConfigConnStr, It.IsAny<ConnectionPolicy>()))
                 .Returns(serviceMock.Object);
 
             //Act
             await RunTestAsync("Outputs", factoryMock.Object);
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(ConfigConnStr, null, null), Times.Once());
+            factoryMock.Verify(f => f.CreateService(ConfigConnStr, It.IsAny<ConnectionPolicy>()), Times.Once());
             serviceMock.Verify(m => m.UpsertDocumentAsync(It.IsAny<Uri>(), It.IsAny<object>()), Times.Exactly(8));
             Assert.Equal("Outputs", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
@@ -75,15 +75,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             // Arrange
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(DefaultConnStr, null, null))
-                .Returns<string, ConnectionMode?, Protocol?>((connectionString, connectionMode, protocol) => new CosmosDBService(connectionString, connectionMode, protocol));
+                .Setup(f => f.CreateService(DefaultConnStr, It.IsAny<ConnectionPolicy>()))
+                .Returns<string, ConnectionPolicy>((connectionString, connectionPolicy) => new CosmosDBService(connectionString, connectionPolicy));
 
             // Act
             // Also verify that this falls back to the default by setting the config connection string to null
             await RunTestAsync("Client", factoryMock.Object, configConnectionString: null);
 
             //Assert
-            factoryMock.Verify(f => f.CreateService(DefaultConnStr, null, null), Times.Once());
+            factoryMock.Verify(f => f.CreateService(DefaultConnStr, It.IsAny<ConnectionPolicy>()), Times.Once());
             Assert.Equal("Client", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
 
@@ -164,14 +164,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(It.IsAny<string>(), null, null))
+                .Setup(f => f.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>()))
                 .Returns(serviceMock.Object);
 
             // Act
             await RunTestAsync(nameof(CosmosDBEndToEndFunctions.Inputs), factoryMock.Object, item1Id);
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(It.IsAny<string>(), null, null), Times.Once());
+            factoryMock.Verify(f => f.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>()), Times.Once());
             Assert.Equal("Inputs", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
             serviceMock.VerifyAll();
         }
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(AttributeConnStr, null, null))
+                .Setup(f => f.CreateService(AttributeConnStr, It.IsAny<ConnectionPolicy>()))
                 .Returns(serviceMock.Object);
 
             var jobject = JObject.FromObject(new QueueData { DocumentId = "docid1", PartitionKey = "partkey1" });
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             await RunTestAsync(nameof(CosmosDBEndToEndFunctions.TriggerObject), factoryMock.Object, jobject.ToString());
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(AttributeConnStr, null, null), Times.Once());
+            factoryMock.Verify(f => f.CreateService(AttributeConnStr, It.IsAny<ConnectionPolicy>()), Times.Once());
             Assert.Equal("TriggerObject", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBUtilityTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBUtilityTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
@@ -79,6 +80,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             // Assert            
             mockService.VerifyAll();
+        }
+
+        [Fact]
+        public void ParsePreferredLocations_WhenEmpty()
+        {
+            // Arrange
+            string preferredLocationsEmpty = string.Empty;
+            string preferredLocationsNull = null;
+
+            // Act
+            var parsedLocationsEmpty = CosmosDBUtility.ParsePreferredLocations(preferredLocationsEmpty);
+            var parsedLocationsNull = CosmosDBUtility.ParsePreferredLocations(preferredLocationsNull);
+
+            // Assert
+            Assert.Empty(parsedLocationsEmpty);
+            Assert.Empty(parsedLocationsNull);
+        }
+
+        [Fact]
+        public void ParsePreferredLocations_WithEntries()
+        {
+            // Arrange
+            string preferredLocationsWithEntries = "East US, North Europe,";
+
+            // Act
+            var parsedLocations = CosmosDBUtility.ParsePreferredLocations(preferredLocationsWithEntries);
+
+            // Assert
+            Assert.Equal(2, parsedLocations.Count());
         }
     }
 }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/TestCosmosDBServiceFactory.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/TestCosmosDBServiceFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 {
@@ -15,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             _service = service;
         }
 
-        public ICosmosDBService CreateService(string connectionString, ConnectionMode? connectionMode, Protocol? protocol)
+        public ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy)
         {
             return _service;
         }


### PR DESCRIPTION
This PR aims at allowing users to interact with [Multi Master accounts](https://aka.ms/multimasterdocs) by exposing the `UseMultipleWriteLocations` flag.

To be able to use Multi Master effectively, users should be able to set the `PreferredLocations` list and define region priorities, so we expose that setting too.

`PreferredLocations` is not only beneficial for Multi Master accounts, but Non-Multi-Master accounts can benefit from it as explained in #363 

For this PR we are enabling  `UseMultipleWriteLocations` and  `PreferredLocations` for the Input/Output bindings and  `PreferredLocations` for the Trigger (the trigger reads the Change Feed, enabling Multi Master there has no real effect).

New tests were added to cover the new attributes.

The `Microsoft.Azure.DocumentDB.Core` package is bumped to version `2.1.1` to support Multi Master.

This PR fixes #363, and fixes #415