### PR TITLE
Adding support for Partitioned Lease collections and monitoring

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerHealthMonitor.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerHealthMonitor.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.ChangeFeedProcessor.Monitoring;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
+{
+    internal class CosmosDBTriggerHealthMonitor : IHealthMonitor
+    {
+        private readonly ILogger _logger;
+
+        public CosmosDBTriggerHealthMonitor(ILogger logger)
+        {
+            this._logger = logger;
+        }
+
+        public Task InspectAsync(HealthMonitoringRecord record)
+        {
+            switch (record.Severity)
+            {
+                case HealthSeverity.Critical:
+                    this._logger.LogCritical($"Unhealthiness detected in the operation {record.Operation} for {record.Lease}. ", record.Exception);
+                    break;
+                case HealthSeverity.Error:
+                    this._logger.LogError($"Unhealthiness detected in the operation {record.Operation} for {record.Lease}. ", record.Exception);
+                    break;
+                default:
+                    this._logger.LogTrace($"{record.Operation} on lease {record.Lease?.Id}, partition {record.Lease?.PartitionId} for owner {record.Lease?.Owner}");
+                    break;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerObserver.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerObserver.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.ChangeFeedProcessor;
+using Microsoft.Azure.Documents.ChangeFeedProcessor.FeedProcessing;
 using Microsoft.Azure.WebJobs.Host.Executors;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             this.executor = executor;
         }
 
-        public Task CloseAsync(ChangeFeedObserverContext context, ChangeFeedObserverCloseReason reason)
+        public Task CloseAsync(IChangeFeedObserverContext context, ChangeFeedObserverCloseReason reason)
         {
             if (context == null)
             {
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return Task.CompletedTask;
         }
 
-        public Task OpenAsync(ChangeFeedObserverContext context)
+        public Task OpenAsync(IChangeFeedObserverContext context)
         {
             if (context == null)
             {
@@ -38,9 +38,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return Task.CompletedTask;
         }
 
-        public Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyList<Document> docs)
+        public Task ProcessChangesAsync(IChangeFeedObserverContext context, IReadOnlyList<Document> docs, CancellationToken cancellationToken)
         {
-            return this.executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = docs }, CancellationToken.None);
+            return this.executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = docs }, cancellationToken);
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -17,8 +17,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
     {
         private readonly ILoggerFactory _loggerFactory = new LoggerFactory();
         private static readonly IConfiguration _emptyConfig = new ConfigurationBuilder().Build();
-        private readonly CosmosDBOptions _options = CosmosDBTestUtility.InitializeOptions("AccountEndpoint=https://fromEnvironment;AccountKey=someKey;", null).Value;
+        private readonly CosmosDBOptions _options = CosmosDBTestUtility.InitializeOptions("AccountEndpoint=https://fromEnvironment;AccountKey=c29tZV9rZXk=;", null).Value;
 
         public static IEnumerable<object[]> ValidCosmosDBTriggerBindigsWithLeaseHostOptionsParameters
             => ValidCosmosDBTriggerBindigsWithLeaseHostOptions.GetParameters();
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=someKey;" }
+                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;" }
                 })
                 .Build();
 
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=someKey;" }
+                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;" }
                 })
                 .Build();
 
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
         public async Task ValidCosmosDBTriggerBindigsWithDatabaseAndCollectionSettings_Succeed(ParameterInfo parameter)
         {
             var nameResolver = new TestNameResolver();
-            nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=someKey;";
+            nameResolver.Values["CosmosDBConnectionString"] = "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;";
             nameResolver.Values["aDatabase"] = "myDatabase";
             nameResolver.Values["aCollection"] = "myCollection";
 
@@ -158,8 +158,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     // Verify we load from connection strings
-                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=someKey;" },
-                    { "ConnectionStrings:LeaseCosmosDBConnectionString", "AccountEndpoint=https://fromSettingsLease;AccountKey=someKey;" }
+                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;" },
+                    { "ConnectionStrings:LeaseCosmosDBConnectionString", "AccountEndpoint=https://fromSettingsLease;AccountKey=c29tZV9rZXk=;" }
                 })
                 .Build();
 
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=someKey;" }
+                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;" }
                 })
                 .Build();
 
@@ -265,9 +265,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     // Verify we load from connection strings first
-                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=someKey;" },
+                    { "ConnectionStrings:CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;" },
                     { "CosmosDBConnectionString", "will not work" },
-                    { "ConnectionStrings:LeaseConnectionString", "AccountEndpoint=https://overridden;AccountKey=someKey;" },
+                    { "ConnectionStrings:LeaseConnectionString", "AccountEndpoint=https://overridden;AccountKey=c29tZV9rZXk=;" },
                     { "LeaseConnectionString", "will not work" }
                 })
                 .Build();
@@ -280,9 +280,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             Assert.Equal(typeof(IReadOnlyList<Document>), binding.TriggerValueType);
             Assert.Equal(new Uri("https://fromEnvironment"), binding.DocumentCollectionLocation.Uri);
             Assert.Equal(new Uri("https://overridden"), binding.LeaseCollectionLocation.Uri);
-            Assert.Equal("someLeasePrefix", binding.ChangeFeedHostOptions.LeasePrefix);
-            Assert.Null(binding.ChangeFeedOptions.MaxItemCount);
-            Assert.False(binding.ChangeFeedOptions.StartFromBeginning);
+            Assert.Equal("someLeasePrefix", binding.ChangeFeedProcessorOptions.LeasePrefix);
+            Assert.Null(binding.ChangeFeedProcessorOptions.MaxItemCount);
+            Assert.False(binding.ChangeFeedProcessorOptions.StartFromBeginning);
         }
 
         [Theory]
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     // Verify we load from root config
-                    { "CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=someKey;" }
+                    { "CosmosDBConnectionString", "AccountEndpoint=https://fromSettings;AccountKey=c29tZV9rZXk=;" }
                 })
                 .Build();
 
@@ -304,8 +304,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             Assert.Equal(typeof(IReadOnlyList<Document>), binding.TriggerValueType);
             Assert.Equal(new Uri("https://fromSettings"), binding.DocumentCollectionLocation.Uri);
             Assert.Equal(new Uri("https://fromSettings"), binding.LeaseCollectionLocation.Uri);
-            Assert.Equal(10, binding.ChangeFeedOptions.MaxItemCount);
-            Assert.True(binding.ChangeFeedOptions.StartFromBeginning);
+            Assert.Equal(10, binding.ChangeFeedProcessorOptions.MaxItemCount);
+            Assert.True(binding.ChangeFeedProcessorOptions.StartFromBeginning);
         }
 
         private static ParameterInfo GetFirstParameter(Type type, string methodName)


### PR DESCRIPTION
This PR adds support for Partitioned leases collections, plus introduces multiple improvements:

* Uses DI to reuse existing Cosmos DB clients for the Trigger, this reduces connections when the Trigger is connecting to the same account as other Bindings or other Triggers (for example, 3 Triggers listening to the same account previously created 6 clients, now, they will all reuse the same one, unless they are connecting to different accounts or have different Preferred Locations).
* Adds the Monitoring service, so internal operational errors in the Trigger can be exposed to the external logs.
* Removes references to deprecated methods in the Change Feed SDK and uses the new builder pattern.

This PR fixes #518 