### PR TITLE
Suggested Code Cleanups

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
         private readonly TimersOptions _options;
         private readonly ILogger _logger;
         private readonly ScheduleMonitor _scheduleMonitor;
-        private IReadOnlyDictionary<string, Type> _bindingContract;
-        private string _timerName;
+        private readonly IReadOnlyDictionary<string, Type> _bindingContract;
+        private readonly string _timerName;
 
         public TimerTriggerBinding(ParameterInfo parameter, TimerTriggerAttribute attribute, TimerSchedule schedule, TimersOptions options, ILogger logger, ScheduleMonitor scheduleMonitor)
         {
@@ -60,7 +60,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
                 ScheduleStatus status = null;
                 if (_attribute.UseMonitor && _scheduleMonitor != null)
                 {
-                    status = await _scheduleMonitor.GetStatusAsync(_timerName);
+                    status = await _scheduleMonitor.GetStatusAsync(_timerName)
+                        .ConfigureAwait(false);
                 }
                 timerInfo = new TimerInfo(_schedule, status);
             }
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
             return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor));
         }
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
                 Name = _parameter.Name,
                 DisplayHints = new ParameterDisplayHints
                 {
-                    Description = string.Format("Timer executed on schedule ({0})", _schedule.ToString())
+                    Description = string.Format("Timer executed on schedule ({0})", _schedule)
                 }
             };
             return descriptor;

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <param name="times">The daily schedule times.</param>
         public DailySchedule(params string[] times)
         {
-            schedule = times.Select(p => TimeSpan.Parse(p)).OrderBy(p => p).ToList();
+            schedule = times.Select(TimeSpan.Parse).OrderBy(p => p).ToList();
         }
 
         /// <summary>

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         {
             if (count < 0)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
 
             if (now == null)


### PR DESCRIPTION
Some suggested code clean ups

### TimerTriggerBinding 
- Members can be readonly as they only are modified in ctor
- ConfigureAwait false can be used to avoid run code as there is no need to current context synchronization.
- In the string format object will be called with ToString so the ToString is not neccesary.
- Use Group method for Parse

### TimerSchedule
Just use name of instead

Feel free to ignore changes in case you consider they does not make any sense. :) 