### PR TITLE
Fixing Package metadata

### DIFF
--- a/src/Packages/Packages.csproj
+++ b/src/Packages/Packages.csproj
@@ -22,6 +22,9 @@
     <NuGetProject Include="..\WebJobs.Extensions.SendGrid.NuGet\WebJobs.Extensions.SendGrid.nuproj">
       <Link>WebJobs.Extensions.SendGrid\WebJobs.Extensions.SendGrid.nuproj</Link>
     </NuGetProject>
+    <NuGetProject Include="..\WebJobs.Extensions.Twilio.NuGet\WebJobs.Extensions.Twilio.nuproj">
+      <Link>WebJobs.Extensions.Twilio\WebJobs.Extensions.Twilio.nuproj</Link>
+    </NuGetProject>
   </ItemGroup>
   <ItemGroup>
     <NuGetSpec Include="..\WebJobs.Extensions.NuGet\WebJobs.Extensions.nuspec">
@@ -29,6 +32,9 @@
     </NuGetSpec>
     <NuGetSpec Include="..\WebJobs.Extensions.SendGrid.NuGet\WebJobs.Extensions.SendGrid.nuspec">
       <Link>WebJobs.Extensions.SendGrid\WebJobs.Extensions.SendGrid.nuspec</Link>
+    </NuGetSpec>
+    <NuGetSpec Include="..\WebJobs.Extensions.Twilio.NuGet\WebJobs.Extensions.Twilio.nuspec">
+      <Link>WebJobs.Extensions.Twilio\WebJobs.Extensions.Twilio.nuspec</Link>
     </NuGetSpec>
   </ItemGroup>
   <ItemGroup>

--- a/src/WebJobs.Extensions.ApiHub.NuGet/WebJobs.Extensions.ApiHub.nuspec
+++ b/src/WebJobs.Extensions.ApiHub.NuGet/WebJobs.Extensions.ApiHub.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.ApiHub</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.ApiHub adds ApiHub triggers and bindings to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.ApiHub. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions ApiHub windowsazureofficial Web</tags>

--- a/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
+++ b/src/WebJobs.Extensions.DocumentDB.Nuget/WebJobs.Extensions.DocumentDB.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.DocumentDB</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.DocumentDB adds DocumentDB binders to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.DocumentDB. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions DocumentDB document windowsazureofficial Web</tags>

--- a/src/WebJobs.Extensions.Http.Nuget/WebJobs.Extensions.Http.nuspec
+++ b/src/WebJobs.Extensions.Http.Nuget/WebJobs.Extensions.Http.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.Http</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.Http adds Http binders to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.Http. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions Http windowsazureofficial Web</tags>

--- a/src/WebJobs.Extensions.MobileApps.Nuget/WebJobs.Extensions.MobileApps.nuspec
+++ b/src/WebJobs.Extensions.MobileApps.Nuget/WebJobs.Extensions.MobileApps.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.MobileApps</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.MobileApps adds Mobile App binders to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.MobileApps. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions MobileTable MobileApps Mobile Tables Apps windowsazureofficial Web</tags>

--- a/src/WebJobs.Extensions.NotificationHubs.Nuget/WebJobs.Extensions.NotificationHubs.nuspec
+++ b/src/WebJobs.Extensions.NotificationHubs.Nuget/WebJobs.Extensions.NotificationHubs.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.NotificationHubs</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.NotificationHubs adds NotificationHub binders to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.NotificationHubs. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions NotificationHubs windowsazureofficial Push</tags>

--- a/src/WebJobs.Extensions.NuGet/WebJobs.Extensions.nuspec
+++ b/src/WebJobs.Extensions.NuGet/WebJobs.Extensions.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions adds additional triggers, binders and extensions to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions Files Scheduler Cron Storage Table Blob Queue windowsazureofficial Web</tags>

--- a/src/WebJobs.Extensions.SendGrid.Nuget/WebJobs.Extensions.SendGrid.nuspec
+++ b/src/WebJobs.Extensions.SendGrid.Nuget/WebJobs.Extensions.SendGrid.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.SendGrid</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.SendGrid adds SendGrid binders to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.SendGrid. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions SendGrid Email windowsazureofficial Web</tags>

--- a/src/WebJobs.Extensions.Twilio.Nuget/WebJobs.Extensions.Twilio.nuspec
+++ b/src/WebJobs.Extensions.Twilio.Nuget/WebJobs.Extensions.Twilio.nuspec
@@ -5,11 +5,11 @@
     <title>Microsoft.Azure.WebJobs.Extensions.Twilio</title>
     <version>$NuGetPackageVersion$</version>
     <authors>Microsoft</authors>
-    <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <summary>Microsoft.Azure.WebJobs.Extensions.Twilio adds Twilio binders to the WebJobs SDK.</summary>
     <description>This package contains the runtime assemblies for Microsoft.Azure.WebJobs.Extensions.Twilio. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</description>
     <language>en-US</language>
-    <projectUrl>https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources</projectUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkID=320972</projectUrl>
     <licenseUrl>$PackageEULA$</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>Microsoft Azure WebJobs Jobs Extensions Twilio Email windowsazureofficial Web</tags>

--- a/tools/NuGetProj.settings.targets
+++ b/tools/NuGetProj.settings.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <WebJobsRootPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\'))</WebJobsRootPath>
     <WebJobsToolsPath>$(MSBuildThisFileDirectory)</WebJobsToolsPath>
-    <WebJobsPackageEULA>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</WebJobsPackageEULA>
+    <WebJobsPackageEULA>https://go.microsoft.com/fwlink/?linkid=2028464</WebJobsPackageEULA>
     <Version>2.3.0</Version>
     <MobileAppsVersion>1.3.0</MobileAppsVersion>
     <DocDBVersion>1.3.0</DocDBVersion>


### PR DESCRIPTION
Fixes required to conform to new rules [here](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki?wikiVersion=GBwikiMaster&pagePath=%2FProduct%20Development%20Reference%2FNuGet%2FPublishing%20a%20NuGet%20package&anchor=troubleshooting-package-publishing-errors). We've already made these changes for v3.