### PR TITLE
Remove cross language support for identities bindings

### DIFF
--- a/src/WebJobs.Extensions.Http/HttpTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.Http/HttpTriggerAttributeBindingProvider.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
     {
         internal const string HttpQueryKey = "Query";
         internal const string HttpHeadersKey = "Headers";
-        internal const string IdentitiesKey = "Identities";
 
         // Name of binding data slot where we place the full HttpRequestMessage
         internal const string RequestBindingName = "$request";
@@ -284,11 +283,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
                     aggregateDataContract.Add(HttpQueryKey, typeof(IDictionary<string, string>));
                 }
 
-                if (!aggregateDataContract.ContainsKey(IdentitiesKey))
-                {
-                    aggregateDataContract.Add(IdentitiesKey, typeof(JObject[]));
-                }
-
                 return aggregateDataContract;
             }
 
@@ -346,14 +340,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
                 if (!bindingData.ContainsKey(HttpHeadersKey))
                 {
                     bindingData[HttpHeadersKey] = request.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToString(), StringComparer.OrdinalIgnoreCase);
-                }
-
-                if (!bindingData.ContainsKey(IdentitiesKey))
-                {
-                    bindingData[IdentitiesKey] = request.HttpContext.User
-                        .Identities
-                        .Select(identity => ClaimsIdentitySlim.FromClaimsIdentity(identity).ToJObject())
-                        .ToArray();
                 }
 
                 return bindingData;

--- a/test/WebJobs.Extensions.Http.Tests/ClaimsPrincipalEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/ClaimsPrincipalEndToEndTests.cs
@@ -84,24 +84,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
         }
 
         [Fact]
-        public async Task HttpTrigger_WithClaimsPrincipal_HasIdentitiesBindingData()
-        {
-            var request = HttpTestHelpers.CreateHttpRequest("GET", "http://functions.com/api/TestIdentityBindings");
-            request.HttpContext.User = GetSamplePrincipal();
-            var method = typeof(TestFunctions).GetMethod(nameof(TestFunctions.HttpRequestWithIdentitiesBindingData));
-            await GetJobHost().CallAsync(method, new { req = request });
-
-            JObject[] identities = GetBindingDataResult(request);
-            
-            Assert.Equal(UserAuthType, identities[0]["authenticationType"]);
-            var claims = identities[0]["claims"] as JArray;
-            var nameClaim = claims.FirstOrDefault(claim => string.Equals(claim["type"].Value<string>(), UserNameClaimType));
-            Assert.Equal(UserNameClaimValue, nameClaim["value"]);
-            var roleCLaim = claims.FirstOrDefault(claim => string.Equals(claim["type"].Value<string>(), UserRoleClaimType));
-            Assert.Equal(UserRoleClaimValue, roleCLaim["value"]);
-        }
-
-        [Fact]
         public async Task NonHttpTrigger_WithClaimsPrincipal_ExceptionIsThrown()
         {
             var method = typeof(TestFunctions).GetMethod(nameof(TestFunctions.TimerTrigger));
@@ -143,13 +125,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
                 ClaimsPrincipal principal)
             {
                 return principal;
-            }
-
-            public static JObject[] HttpRequestWithIdentitiesBindingData(
-                [HttpTrigger("get")] HttpRequestMessage req,
-                JObject[] identities)
-            {
-                return identities;
             }
 
             public static void TimerTrigger(

--- a/test/WebJobs.Extensions.Http.Tests/HttpTriggerBindingTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/HttpTriggerBindingTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             HttpRequest request = HttpTestHelpers.CreateHttpRequest("POST", "http://functions/test", null, input);
             var bindingData = await HttpTriggerAttributeBindingProvider.HttpTriggerBinding.GetRequestBindingDataAsync(request);
 
-            Assert.Equal(6, bindingData.Count);
+            Assert.Equal(5, bindingData.Count);
             Assert.Equal("testing", bindingData["test"]);
             Assert.Equal("123", bindingData["baz"]);
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
 
             var bindingData = await HttpTriggerAttributeBindingProvider.HttpTriggerBinding.GetRequestBindingDataAsync(request);
 
-            Assert.Equal(5, bindingData.Count);
+            Assert.Equal(4, bindingData.Count);
             Assert.Equal("Mathew Charles", bindingData["name"]);
             Assert.Equal("Seattle", bindingData["location"]);
 
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
 
             var bindingData = await HttpTriggerAttributeBindingProvider.HttpTriggerBinding.GetRequestBindingDataAsync(request);
 
-            Assert.Equal(5, bindingData.Count);
+            Assert.Equal(4, bindingData.Count);
             Assert.Equal("Mathew Charles", bindingData["Name"]);
             Assert.Equal("Seattle", bindingData["Location"]);
         }
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(10, triggerData.BindingData.Count);
+            Assert.Equal(9, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
             Assert.Equal("(425) 555-6666", triggerData.BindingData["Phone"]);
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -387,7 +387,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Equal(5, triggerData.BindingData.Count);
             Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
             Assert.Equal("Seattle", triggerData.BindingData["Location"]);
 
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(4, triggerData.BindingData.Count);
+            Assert.Equal(3, triggerData.BindingData.Count);
 
             string result = (string)(await triggerData.ValueProvider.GetValueAsync());
             Assert.Equal("This is a test", result);
@@ -429,7 +429,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(5, triggerData.BindingData.Count);
+            Assert.Equal(4, triggerData.BindingData.Count);
 
             var result = (JObject)(await triggerData.ValueProvider.GetValueAsync());
             Assert.Equal("This is a test", result["value"].ToString());


### PR DESCRIPTION
This part of the identities bindings would have been a breaking change. We will have to reevaluate our approach for other languages, likely by adding this directly to the HttpContext object of the GRPC protocol.