### PR TITLE
Update SendGrid package to 9.10.0

### DIFF
--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
-    <PackageReference Include="SendGrid" Version="9.9.0" />
+    <PackageReference Include="SendGrid" Version="9.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While putting together a project, I noticed that in order to use SendGrid's dynamic templates, you have to add a reference to the SendGrid 9.10.0 package into your Functions project ([sample repo here](https://github.com/burkeholland/serverless-sendgrid-report/blob/master/extensions.csproj)). 

Updating the dependency here should add support for dynamic templates (transactional templates).