### PR TITLE
consolidating extension versioning into common.props

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,15 @@
 <Project>
   <PropertyGroup>
-    <DebugType>embedded</DebugType>
+    <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
+    <ExtensionsVersion>3.0.2$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
+    <CosmosDBVersion>3.0.3$(VersionSuffix)</CosmosDBVersion>
+    <HttpVersion>3.0.3$(VersionSuffix)</HttpVersion>
+    <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
+    <SendGridVersion>3.0.1$(VersionSuffix)</SendGridVersion>
+    <TwilioVersion>3.0.1$(VersionSuffix)</TwilioVersion>
+
+    <DebugType>embedded</DebugType>    
     <LatestCommit Condition="$(LatestCommit) == ''">$(CommitHash)</LatestCommit>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>3.0.2$(VersionSuffix)</Version>
+    <Version>$(CosmosDBVersion)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.CosmosDB</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.CosmosDB</RootNamespace>

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>3.0.2$(VersionSuffix)</Version>
+    <Version>$(HttpVersion)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Http</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Http</RootNamespace>

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
+    <Version>$(MobileAppsVersion)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.MobileApps</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.MobileApps</RootNamespace>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
+    <Version>$(SendGridVersion)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.SendGrid</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.SendGrid</RootNamespace>

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
+    <Version>$(TwilioVersion)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.Twilio</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Twilio</RootNamespace>

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>3.0.1$(VersionSuffix)</Version>
+    <Version>$(ExtensionsVersion)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions</RootNamespace>


### PR DESCRIPTION
Taking the same approach that we took with https://github.com/Azure/azure-webjobs-sdk/pull/2019. Now all versions are in a single file.