### PR TITLE
[TimerTrigger] improving logs

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.5" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="SendGrid" Version="9.10.0" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Twilio" Version="5.6.3" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
@@ -22,8 +22,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
         private readonly TimersOptions _options;
         private readonly ILogger _logger;
         private readonly ScheduleMonitor _scheduleMonitor;
+        private readonly string _timerName;
+
         private IReadOnlyDictionary<string, Type> _bindingContract;
-        private string _timerName;
 
         public TimerTriggerBinding(ParameterInfo parameter, TimerTriggerAttribute attribute, TimerSchedule schedule, TimersOptions options, ILogger logger, ScheduleMonitor scheduleMonitor)
         {
@@ -77,7 +78,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
             {
                 throw new ArgumentNullException("context");
             }
-            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor));
+
+            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor, context.Descriptor?.ShortName));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
@@ -61,13 +61,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 // no more occurrences for today, so start back at the beginning of the
                 // the schedule tomorrow
                 TimeSpan nextTime = schedule[0];
-                DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds);
+                DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds, now.Kind);
                 return nextOccurrence.AddDays(1);
             }
             else
             {
                 TimeSpan nextTime = schedule[idx];
-                return new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds);
+                return new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds, now.Kind);
             }
         }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
 
             // construct the next occurrence date
             int deltaDays = day - (int)now.DayOfWeek;
-            DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds);
+            DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds, now.Kind);
             nextOccurrence = nextOccurrence.AddDays(deltaDays);
 
             return nextOccurrence;

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="3.0.2" />
     <PackageReference Include="ncrontab.signed" Version="3.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #550

### Using function's name in startup logs when [FunctionName] is used
```
namespace WebJobsSandbox.One.Two.Three
{
    public static class TimerSamples
    {    
        [FunctionName("MyTimer")]
        public static void CronJob([TimerTrigger("*/15 * * * * *")] TimerInfo timerInfo)
        {
        }
    }
}
```
Before: `The next 5 occurrences of the 'WebJobsSandbox.One.Two.Three.TimerSamples.CronJob' schedule`...
After: `The next 5 occurrences of the 'MyTimer' schedule`...


### Using function's short name in startup logs if [FunctionName] is *not* used
```
namespace WebJobsSandbox.One.Two.Three
{
    public static class TimerSamples
    {
        public static void CronJob([TimerTrigger("*/15 * * * * *")] TimerInfo timerInfo)
        {
        }
    }
}
```
Before: `The next 5 occurrences of the 'WebJobsSandbox.One.Two.Three.TimerSamples.CronJob' schedule`...
After: `The next 5 occurrences of the 'TimerSamples.CronJob' schedule`...

### Logging "schedule" changes
The schedule has been changed to be more easily parse-able and include more information:
- Including Schedule information in string. Note that the Cron library we use automatically evaluates the string so "*/15" -> "0,15,30,45".
- Using 2-digit months, days, and hours
- Using 24-hour clock
- Using UTC offset (if necessary)
- Including UTC time for schedule (if necessary)

Before:
```
The next 5 occurrences of the 'WebJobsSandbox.One.Two.Three.TimerSamples.CronJob' schedule will be:
2/13/2019 9:17:15 AM
2/13/2019 9:17:30 AM
2/13/2019 9:17:45 AM
2/13/2019 9:18:00 AM
2/13/2019 9:18:15 AM
```

After, not UTC:
```
The next 5 occurrences of the 'MyTimer' schedule (Cron: '0,15,30,45 * * * * *') will be:
02/13/2019 08:57:45-08:00 (02/13/2019 16:57:45Z)
02/13/2019 08:58:00-08:00 (02/13/2019 16:58:00Z)
02/13/2019 08:58:15-08:00 (02/13/2019 16:58:15Z)
02/13/2019 08:58:30-08:00 (02/13/2019 16:58:30Z)
02/13/2019 08:58:45-08:00 (02/13/2019 16:58:45Z)
```

After, UTC:
```
The next 5 occurrences of the 'MyTimer' schedule (Cron: '0,15,30,45 * * * * *') will be:
02/13/2019 17:07:00Z
02/13/2019 17:07:15Z
02/13/2019 17:07:30Z
02/13/2019 17:07:45Z
02/13/2019 17:08:00Z
```

~~### Logging warning if RunOnStartup (`Warning` level)
New: `Function 'MyTimer' has 'RunOnStartup' set to 'true'. This property is intended for testing purposes only and may result in unintended behavior if used in production.`~~

### Logging details at *execution time* if RunOnStartup or IsPastDue (`Information` level)
These TriggerDetail log have the proper `FunctionName` and `FunctionInvocationId` set so they will be returned via AppInsights queries looking for traces on this invocation. This functionality is already built into the host, we're just going to start using it now to provide more context.

New: `Trigger Details: UnscheduledInvocationReason: RunOnStartup`
New: `Trigger Details: UnscheduledInvocationReason: IsPastDue, OriginalSchedule: 2019-02-13T08:55:56.0531482-08:00`

### Logging .NET timer creation (`Debug` level)
New: `Timer for 'MyTimer' started with interval '00:00:14.9854675'.`

### Adding schedule to "time zone" logging at startup (`Debug` level)
Admittedly this isn't as important now that it's also logged with the future schedule, but...

Before: `The 'WebJobsSandbox.One.Two.Three.TimerSamples.CronJob' timer is using the local time zone: '(UTC-08:00) Pacific Time (US & Canada)'`
After:  `The 'MyTimer' timer is using the schedule 'Cron: '0,15,30,45 * * * * *'' and the local time zone: '(UTC-08:00) Pacific Time (US & Canada)'`
