### PR TITLE
[TimerTrigger] improving logs

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
             {
                 throw new ArgumentNullException("context");
             }
-            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _config, context.Executor, _trace));
+            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _config, context.Executor, _trace, context.Descriptor?.ShortName));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
@@ -61,13 +61,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 // no more occurrences for today, so start back at the beginning of the
                 // the schedule tomorrow
                 TimeSpan nextTime = schedule[0];
-                DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds);
+                DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds, now.Kind);
                 return nextOccurrence.AddDays(1);
             }
             else
             {
                 TimeSpan nextTime = schedule[idx];
-                return new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds);
+                return new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds, now.Kind);
             }
         }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleStatus.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleStatus.cs
@@ -11,17 +11,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     public class ScheduleStatus
     {
         /// <summary>
-        /// The last recorded schedule occurrence
+        /// Gets or sets the last recorded schedule occurrence
         /// </summary>
         public DateTime Last { get; set; }
 
         /// <summary>
-        /// The expected next schedule occurrence
+        /// Gets or sets the expected next schedule occurrence
         /// </summary>
         public DateTime Next { get; set; }
 
         /// <summary>
-        /// The last time this record was updated. This is used to re-calculate Next
+        /// Gets or sets the last time this record was updated. This is used to re-calculate Next
         /// with the current Schedule after a host restart.
         /// </summary>
         public DateTime LastUpdated { get; set; }

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
 
             // construct the next occurrence date
             int deltaDays = day - (int)now.DayOfWeek;
-            DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds);
+            DateTime nextOccurrence = new DateTime(now.Year, now.Month, now.Day, nextTime.Hours, nextTime.Minutes, nextTime.Seconds, now.Kind);
             nextOccurrence = nextOccurrence.AddDays(deltaDays);
 
             return nextOccurrence;

--- a/src/WebJobs.Extensions/Extensions/Timers/TimerInfo.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/TimerInfo.cs
@@ -10,12 +10,14 @@ namespace Microsoft.Azure.WebJobs
 {
     /// <summary>
     /// Provides access to timer schedule information for jobs triggered 
-    /// by <see cref="TimerTriggerAttribute"/>
+    /// by <see cref="TimerTriggerAttribute"/>.
     /// </summary>
     public class TimerInfo
     {
+        internal const string DateTimeFormat = "MM'/'dd'/'yyyy HH':'mm':'ssK";
+
         /// <summary>
-        /// Constructs a new instance
+        /// Constructs a new instance.
         /// </summary>
         /// <param name="schedule">The timer trigger schedule.</param>
         /// <param name="status">The current schedule status.</param>
@@ -33,14 +35,14 @@ namespace Microsoft.Azure.WebJobs
         public TimerSchedule Schedule { get; private set; }
 
         /// <summary>
-        /// Gets or sets the current schedule status for this timer.
+        /// Gets the current schedule status for this timer.
         /// If schedule monitoring is not enabled for this timer (see <see cref="TimerTriggerAttribute.UseMonitor"/>)
         /// this property will return null.
         /// </summary>
         public ScheduleStatus ScheduleStatus { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this timer invocation
+        /// Gets a value indicating whether this timer invocation
         /// is due to a missed schedule occurrence.
         /// </summary>
         public bool IsPastDue { get; private set; }
@@ -57,19 +59,33 @@ namespace Microsoft.Azure.WebJobs
             return FormatNextOccurrences(Schedule, count, now);
         }
 
-        internal static string FormatNextOccurrences(TimerSchedule schedule, int count, DateTime? now = null)
+        internal static string FormatNextOccurrences(TimerSchedule schedule, int count, DateTime? now = null, string functionShortName = null)
         {
             if (schedule == null)
             {
                 throw new ArgumentNullException("schedule");
             }
 
+            // If we've got a timer name, format it
+            if (functionShortName != null)
+            {
+                functionShortName = $"'{functionShortName}' ";
+            }
+
+            bool isUtc = TimeZoneInfo.Local.HasSameRules(TimeZoneInfo.Utc);
             IEnumerable<DateTime> nextOccurrences = schedule.GetNextOccurrences(count, now);
             StringBuilder builder = new StringBuilder();
-            builder.AppendLine(string.Format("The next {0} occurrences of the schedule will be:", count));
+            builder.AppendLine($"The next {count} occurrences of the {functionShortName}schedule ({schedule}) will be:");
             foreach (DateTime occurrence in nextOccurrences)
             {
-                builder.AppendLine(occurrence.ToString());
+                if (isUtc)
+                {
+                    builder.AppendLine(occurrence.ToUniversalTime().ToString(DateTimeFormat));
+                }
+                else
+                {
+                    builder.AppendLine($"{occurrence.ToString(DateTimeFormat)} ({occurrence.ToUniversalTime().ToString(DateTimeFormat)})");
+                }
             }
 
             return builder.ToString();

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
     [Trait("Category", "E2E")]
     public class TimerTriggerEndToEndTests
     {
+        TestTraceWriter _testTrace = new TestTraceWriter(TraceLevel.Error);
+
         [Fact]
         public async Task CronScheduleJobTest()
         {
@@ -62,14 +64,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
         private async Task RunTimerJobTest(Type jobClassType, Func<bool> condition)
         {
-            TestTraceWriter testTrace = new TestTraceWriter(TraceLevel.Error);
             ExplicitTypeLocator locator = new ExplicitTypeLocator(jobClassType);
             JobHostConfiguration config = new JobHostConfiguration
             {
                 TypeLocator = locator
             };
             config.UseTimers();
-            config.Tracing.Tracers.Add(testTrace);
+            config.Tracing.Tracers.Add(_testTrace);
             JobHost host = new JobHost(config);
 
             await host.StartAsync();
@@ -82,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             await host.StopAsync();
 
             // ensure there were no errors
-            Assert.Equal(0, testTrace.Events.Count);
+            Assert.Equal(0, _testTrace.Events.Count);
         }
 
         public static class CronScheduleTestJobs


### PR DESCRIPTION
Cherry-pick of https://github.com/Azure/azure-webjobs-sdk-extensions/pull/553, but targeting `v2.x`. 

One difference is that v2.x does not support `TriggerDetails` so the `UnscheduledInvocationReason` logs do not exist here.