### PR TITLE
Make DST test pass in all northern hemisphere time zones with DST

### DIFF
--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -369,8 +369,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
         public static IEnumerable<object[]> TimerSchedulesAfterDST => new object[][]
         {
-            new object[] { new CronSchedule(CrontabSchedule.Parse("0 0 18 * * 5", new CrontabSchedule.ParseOptions() { IncludingSeconds = true })), TimeSpan.FromHours(167) },
-            new object[] { new ConstantSchedule(TimeSpan.FromDays(7)), TimeSpan.FromDays(7) },
+            new object[] { new CronSchedule(CrontabSchedule.Parse("0 0 18 6 * *", new CrontabSchedule.ParseOptions() { IncludingSeconds = true })), TimeSpan.FromHours(671) },
+            new object[] { new ConstantSchedule(TimeSpan.FromDays(28)), TimeSpan.FromDays(28) },
         };
 
         public static IEnumerable<object[]> TimerSchedulesWithinDST => new object[][]
@@ -393,7 +393,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 throw new InvalidOperationException("This test will only pass if the time zone supports DST.");
             }
 
-            // Running on the Friday before the DST switch at 2 AM on 3/11 (Pacific Standard Time)
+            // Running on the Friday before the US DST switch at 2 AM on 3/11 (Pacific Standard Time)
+            // The EU DST switch is at 2 AM on the last Sunday of March, so is also covered by a
+            // timeframe of three weeks or more.
             // Note: this test uses Local time, so if you're running in a timezone where
             // DST doesn't transition the test might not be valid.
             // The input schedules will run after DST changes. For some (Cron), they will subtract
@@ -403,7 +405,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             var next = schedule.GetNextOccurrence(now);
             var interval = TimerListener.GetNextTimerInterval(next, now, schedule.AdjustForDST);
 
-            // One week is normally 168 hours, but it's 167 hours across DST
+            // Four weeks is normally 672 hours, but it's 671 hours across DST
             Assert.Equal(interval, expectedInterval);
         }
 


### PR DESCRIPTION
The test `GetNextInterval_NextAfterDST_ReturnsExpectedValue` fails in time zones which have DST but don't change on the same day as the USA.

#### Repro steps

1. Configure the local time zone to Madrid (UTC+01:00/+02:00 with DST).

2. Open the Visual Studio test explorer

3. Run the test `GetNextInterval_NextAfterDST_ReturnsExpectedValue` from the project `WebJobs.Extensions.Tests`

#### Expected behavior

The test should pass: it's being executed in a timezone with DST.

#### Actual behavior

The test fails.

#### Known workarounds

This pull request widens the timeframe covered by the test to four weeks (2018-03-09 to 2018-04-06) instead of one week (2018-03-09 to 2018-03-16). This covers the EU and various other countries which changed on 2018-03-25, and a handful of countries which changed on other dates ranging from 2018-03-22 to 2018-04-01, increasing the number of developers who can work on the project without having a spurious failed test.

Southern hemisphere timezones with DST and timezones without DST remain affected.

#### Related information

I discovered the problem while doing due diligence in preparation for a planned fork which will allow the timezone to be configured (in `TimersExtensionConfigProvider` or `ScheduleMonitor`) so that different job hosts running in the same process can use different timezones, which is a requirement for a project I'm working on. I anticipate that in this fork I would fix the problem by changing the test to have an explicit timezone.