### PR TITLE
Enabling Multi Master for leases in Cosmos DB Trigger

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>3.0.2$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>3.0.3$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>3.0.4$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.0.3$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.1$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -144,8 +144,17 @@ namespace Microsoft.Azure.WebJobs
         /// Values should be comma-separated.
         /// </summary>
         /// <example>
-        /// PreferredLocations = "East US,South Central US,North Europe"
+        /// PreferredLocations = "East US,South Central US,North Europe".
         /// </example>
         public string PreferredLocations { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Enable to use with Multi Master accounts.
+        /// </summary>
+        /// <remarks>
+        /// This setting only applies to the Leases collection, as there are no write operations done to the monitored collection.
+        /// </remarks>
+        public bool UseMultipleWriteLocations { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -130,6 +130,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     leaseCollectionLocation.ConnectionPolicy.PreferredLocations.Add(location);
                 }
 
+                leaseCollectionLocation.ConnectionPolicy.UseMultipleWriteLocations = attribute.UseMultipleWriteLocations;
+
                 if (string.IsNullOrEmpty(documentCollectionLocation.DatabaseName)
                     || string.IsNullOrEmpty(documentCollectionLocation.CollectionName)
                     || string.IsNullOrEmpty(leaseCollectionLocation.DatabaseName)
@@ -146,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 }
 
                 monitoredCosmosDBService = _configProvider.GetService(triggerConnectionString, resolvedPreferredLocations);
-                leaseCosmosDBService = _configProvider.GetService(leasesConnectionString, resolvedPreferredLocations);
+                leaseCosmosDBService = _configProvider.GetService(leasesConnectionString, resolvedPreferredLocations, attribute.UseMultipleWriteLocations);
 
                 if (attribute.CreateLeaseCollectionIfNotExists)
                 {

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -17,8 +17,8 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.2.6" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.3.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds support for the Cosmos DB Trigger to use Multi Master for the leases container. Previously, while the users could use PreferredLocations to specify reads from a particular region, writes for the leases state was being sent to the main hub region.

For users with Multi Master accounts, they can leverage local writes on any region, so this new attribute exposed in the Trigger can help them take advantage of that.

Additionally, bumping the version of Cosmos DB SDK and Change Feed SDK to get the latest fixes/improvements.