### PR TITLE
Adding CurrentLocation attribute to CosmosDB binding attribute

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings
             }
 
             string resolvedConnectionString = _configProvider.ResolveConnectionString(attribute.ConnectionStringSetting);
-            ICosmosDBService service = _configProvider.GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
+            ICosmosDBService service = _configProvider.GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.CurrentLocation, attribute.UseMultipleWriteLocations);
 
             return service.GetClient();
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         internal DocumentClient BindForClient(CosmosDBAttribute attribute)
         {
             string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
-            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
+            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.CurrentLocation, attribute.UseMultipleWriteLocations);
 
             return service.GetClient();
         }
@@ -124,10 +124,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return _options.ConnectionString;
         }
 
-        internal ICosmosDBService GetService(string connectionString, string preferredLocations = "", bool useMultipleWriteLocations = false)
+        internal ICosmosDBService GetService(string connectionString, string preferredLocations = "", string currentLocation = "", bool useMultipleWriteLocations = false)
         {
-            string cacheKey = BuildCacheKey(connectionString, preferredLocations, useMultipleWriteLocations);
-            ConnectionPolicy connectionPolicy = CosmosDBUtility.BuildConnectionPolicy(_options.ConnectionMode, _options.Protocol, preferredLocations, useMultipleWriteLocations);
+            string cacheKey = BuildCacheKey(connectionString, preferredLocations, currentLocation, useMultipleWriteLocations);
+            ConnectionPolicy connectionPolicy = CosmosDBUtility.BuildConnectionPolicy(_options.ConnectionMode, _options.Protocol, preferredLocations, currentLocation, useMultipleWriteLocations);
             return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connectionString, connectionPolicy));
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         {
             string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
 
-            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
+            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.CurrentLocation, attribute.UseMultipleWriteLocations);
 
             return new CosmosDBContext
             {
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return false;
         }
 
-        internal static string BuildCacheKey(string connectionString, string preferredLocations, bool useMultipleWriteLocations) => $"{connectionString}|{preferredLocations}|{useMultipleWriteLocations}";
+        internal static string BuildCacheKey(string connectionString, string preferredLocations, string currentLocation, bool useMultipleWriteLocations) => $"{connectionString}|{preferredLocations}|{currentLocation}|{useMultipleWriteLocations}";
 
         private class DocumentOpenType : OpenType.Poco
         {

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -119,6 +119,19 @@ namespace Microsoft.Azure.WebJobs
         [AutoResolve]
         public string PreferredLocations { get; set; }
 
+        /// <summary>
+        /// Gets or sets optional.
+        /// If set the preferred locations (regions) will automatically be set based on the current location. 
+        /// </summary>
+        /// <remarks>
+        /// If this property is set, it will ignore PreferredLocations if set.
+        /// </remarks>
+        /// <example>
+        /// CurrentLocation = "East US".
+        /// </example>
+        [AutoResolve]
+        public string CurrentLocation { get; set; }
+
         internal SqlParameterCollection SqlQueryParameters { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>
         /// Gets or sets optional.
-        /// If set the preferred locations (regions) will automatically be set based on the current location. 
+        /// If set the preferred locations (regions) will automatically be populated based on the current location. 
         /// </summary>
         /// <remarks>
         /// If this property is set, it will ignore PreferredLocations if set.

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 .Where((region) => !string.IsNullOrEmpty(region));
         }
 
-        internal static ConnectionPolicy BuildConnectionPolicy(ConnectionMode? connectionMode, Protocol? protocol, string preferredLocations, bool useMultipleWriteLocations)
+        internal static ConnectionPolicy BuildConnectionPolicy(ConnectionMode? connectionMode, Protocol? protocol, string preferredLocations, string currentLocation, bool useMultipleWriteLocations)
         {
             ConnectionPolicy connectionPolicy = new ConnectionPolicy();
             if (connectionMode.HasValue)
@@ -78,9 +78,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 connectionPolicy.UseMultipleWriteLocations = useMultipleWriteLocations;
             }
 
-            foreach (var location in ParsePreferredLocations(preferredLocations))
+            if (!string.IsNullOrEmpty(currentLocation))
             {
-                connectionPolicy.PreferredLocations.Add(location);
+                connectionPolicy.SetCurrentLocation(currentLocation);
+            }
+            else
+            {
+                foreach (var location in ParsePreferredLocations(preferredLocations))
+                {
+                    connectionPolicy.PreferredLocations.Add(location);
+                }
             }
 
             return connectionPolicy;


### PR DESCRIPTION
According to documentation:

https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.connectionpolicy.setcurrentlocation?view=azure-dotnet#Microsoft_Azure_Documents_Client_ConnectionPolicy_SetCurrentLocation_System_String_

Setting this will set preferred locations for you which is a bit more convenient then deciding preferred locations on your own.

P.S. Not sure what I need to test for this contribution so any assistance would be appreciated!