### PR TITLE
Add Default JsonSerializerSettings to DocumentClient to fix DateTimeOffset parsing

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings
             }
 
             string resolvedConnectionString = _configProvider.ResolveConnectionString(attribute.ConnectionStringSetting);
-            ICosmosDBService service = _configProvider.GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
+            ICosmosDBService service = _configProvider.GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations, attribute.UseDefaultJsonSerialization);
 
             return service.GetClient();
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         internal DocumentClient BindForClient(CosmosDBAttribute attribute)
         {
             string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
-            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
+            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations, attribute.UseDefaultJsonSerialization);
 
             return service.GetClient();
         }
@@ -124,18 +124,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return _options.ConnectionString;
         }
 
-        internal ICosmosDBService GetService(string connectionString, string preferredLocations = "", bool useMultipleWriteLocations = false)
+        internal ICosmosDBService GetService(string connectionString, string preferredLocations = "", bool useMultipleWriteLocations = false, bool useDefaultJsonSerialization = false)
         {
-            string cacheKey = BuildCacheKey(connectionString, preferredLocations, useMultipleWriteLocations);
+            string cacheKey = BuildCacheKey(connectionString, preferredLocations, useMultipleWriteLocations, useDefaultJsonSerialization);
             ConnectionPolicy connectionPolicy = CosmosDBUtility.BuildConnectionPolicy(_options.ConnectionMode, _options.Protocol, preferredLocations, useMultipleWriteLocations);
-            return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connectionString, connectionPolicy));
+            return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connectionString, connectionPolicy, useDefaultJsonSerialization));
         }
 
         internal CosmosDBContext CreateContext(CosmosDBAttribute attribute)
         {
             string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
 
-            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations);
+            ICosmosDBService service = GetService(resolvedConnectionString, attribute.PreferredLocations, attribute.UseMultipleWriteLocations, attribute.UseDefaultJsonSerialization);
 
             return new CosmosDBContext
             {
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return false;
         }
 
-        internal static string BuildCacheKey(string connectionString, string preferredLocations, bool useMultipleWriteLocations) => $"{connectionString}|{preferredLocations}|{useMultipleWriteLocations}";
+        internal static string BuildCacheKey(string connectionString, string preferredLocations, bool useMultipleWriteLocations, bool useDefaultJsonSerialization) => $"{connectionString}|{preferredLocations}|{useMultipleWriteLocations}|{useDefaultJsonSerialization}";
 
         private class DocumentOpenType : OpenType.Poco
         {

--- a/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
     internal class DefaultCosmosDBServiceFactory : ICosmosDBServiceFactory
     {
-        public ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy)
+        public ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy, bool useDefaultJsonSerialization)
         {
-            return new CosmosDBService(connectionString, connectionPolicy);
+            return new CosmosDBService(connectionString, connectionPolicy, useDefaultJsonSerialization);
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Config/ICosmosDBServiceFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/ICosmosDBServiceFactory.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
     internal interface ICosmosDBServiceFactory
     {
-        ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy);
+        ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy, bool useDefaultJsonSerialization);
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -110,6 +110,18 @@ namespace Microsoft.Azure.WebJobs
 
         /// <summary>
         /// Optional.
+        /// Enables the use of JsonConvert.DefaultSettings in the monitored Azure Cosmos DB collection.
+        /// <remarks>
+        /// This setting only applies to the monitored collection and the consumer to setup the serialization used in the monitored collection.
+        /// The JsonConvert.DefaultSettings must be set during the initialization process.
+        /// This is achieved by deriving a class from <see cref="CosmosDBWebJobsStartup"/> and adding a <see cref="WebJobsStartupAttribute"/>
+        /// to the assembly that specifies the derived class
+        /// </remarks>
+        /// </summary>
+        public bool UseDefaultJsonSerialization { get; set; }
+
+        /// <summary>
+        /// Optional.
         /// Defines preferred locations (regions) for geo-replicated database accounts in the Azure Cosmos DB service.
         /// Values should be comma-separated.
         /// </summary>

--- a/src/WebJobs.Extensions.CosmosDB/Services/CosmosDBService.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Services/CosmosDBService.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Linq;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Config;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private bool _isDisposed;
         private DocumentClient _client;
 
-        public CosmosDBService(string connectionString, ConnectionPolicy connectionPolicy)
+        public CosmosDBService(string connectionString, ConnectionPolicy connectionPolicy, bool useDefaultJsonSerialization)
         {
             CosmosDBConnectionString connection = new CosmosDBConnectionString(connectionString);
             if (connectionPolicy == null)
@@ -23,7 +24,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 connectionPolicy = new ConnectionPolicy();
             }
 
-            _client = new DocumentClient(connection.ServiceEndpoint, connection.AuthKey, connectionPolicy);
+            if (useDefaultJsonSerialization)
+            {
+                if (JsonConvert.DefaultSettings == null)
+                {
+                    throw new ArgumentNullException("If UseDefaultJsonSerialization is enabled, JsonConvert.DefaultSettings should be configured.");
+                }
+
+                _client = new DocumentClient(connection.ServiceEndpoint, connection.AuthKey, connectionPolicy, null, JsonConvert.DefaultSettings.Invoke());
+            }
+            else
+            {
+                _client = new DocumentClient(connection.ServiceEndpoint, connection.AuthKey, connectionPolicy);
+            }
         }
 
         public DocumentClient GetClient()

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -156,5 +156,15 @@ namespace Microsoft.Azure.WebJobs
         /// This setting only applies to the Leases collection, as there are no write operations done to the monitored collection.
         /// </remarks>
         public bool UseMultipleWriteLocations { get; set; }
+
+        /// <summary>
+        /// Optional.
+        /// Enables the use of JsonConvert.DefaultSettings in the monitored Azure Cosmos DB collection.
+        /// <remarks>
+        /// This setting only applies to the monitored collection and the consumer to setup the serialization used in the monitored collection.
+        /// The JsonConvert.DefaultSettings must be set in a class derived from CosmosDBWebJobsStartup.
+        /// </remarks>
+        /// </summary>
+        public bool UseDefaultJsonSerialization { get; set; }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     throw new InvalidOperationException("The monitored collection cannot be the same as the collection storing the leases.");
                 }
 
-                monitoredCosmosDBService = _configProvider.GetService(triggerConnectionString, resolvedPreferredLocations);
+                monitoredCosmosDBService = _configProvider.GetService(triggerConnectionString, resolvedPreferredLocations, attribute.UseDefaultJsonSerialization);
                 leaseCosmosDBService = _configProvider.GetService(leasesConnectionString, resolvedPreferredLocations, attribute.UseMultipleWriteLocations);
 
                 if (attribute.CreateLeaseCollectionIfNotExists)

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             Mock<ICosmosDBServiceFactory> mockServiceFactory = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
 
             mockServiceFactory
-                .Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>()))
+                .Setup(m => m.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()))
                 .Returns(mockService.Object);
 
             var options = new OptionsWrapper<CosmosDBOptions>(new CosmosDBOptions

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
@@ -57,14 +57,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(ConfigConnStr, It.IsAny<ConnectionPolicy>()))
+                .Setup(f => f.CreateService(ConfigConnStr, It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()))
                 .Returns(serviceMock.Object);
 
             //Act
             await RunTestAsync("Outputs", factoryMock.Object);
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(ConfigConnStr, It.IsAny<ConnectionPolicy>()), Times.Once());
+            factoryMock.Verify(f => f.CreateService(ConfigConnStr, It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()), Times.Once());
             serviceMock.Verify(m => m.UpsertDocumentAsync(It.IsAny<Uri>(), It.IsAny<object>()), Times.Exactly(8));
             Assert.Equal("Outputs", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
@@ -75,15 +75,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             // Arrange
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(DefaultConnStr, It.IsAny<ConnectionPolicy>()))
-                .Returns<string, ConnectionPolicy>((connectionString, connectionPolicy) => new CosmosDBService(connectionString, connectionPolicy));
+                .Setup(f => f.CreateService(DefaultConnStr, It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()))
+                .Returns<string, ConnectionPolicy, bool>((connectionString, connectionPolicy, useDefaultDeserialization) => new CosmosDBService(connectionString, connectionPolicy, useDefaultDeserialization));
 
             // Act
             // Also verify that this falls back to the default by setting the config connection string to null
             await RunTestAsync("Client", factoryMock.Object, configConnectionString: null);
 
             //Assert
-            factoryMock.Verify(f => f.CreateService(DefaultConnStr, It.IsAny<ConnectionPolicy>()), Times.Once());
+            factoryMock.Verify(f => f.CreateService(DefaultConnStr, It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()), Times.Once());
             Assert.Equal("Client", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
 
@@ -164,14 +164,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>()))
+                .Setup(f => f.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()))
                 .Returns(serviceMock.Object);
 
             // Act
             await RunTestAsync(nameof(CosmosDBEndToEndFunctions.Inputs), factoryMock.Object, item1Id);
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>()), Times.Once());
+            factoryMock.Verify(f => f.CreateService(It.IsAny<string>(), It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()), Times.Once());
             Assert.Equal("Inputs", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
             serviceMock.VerifyAll();
         }
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(AttributeConnStr, It.IsAny<ConnectionPolicy>()))
+                .Setup(f => f.CreateService(AttributeConnStr, It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()))
                 .Returns(serviceMock.Object);
 
             var jobject = JObject.FromObject(new QueueData { DocumentId = "docid1", PartitionKey = "partkey1" });
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             await RunTestAsync(nameof(CosmosDBEndToEndFunctions.TriggerObject), factoryMock.Object, jobject.ToString());
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(AttributeConnStr, It.IsAny<ConnectionPolicy>()), Times.Once());
+            factoryMock.Verify(f => f.CreateService(AttributeConnStr, It.IsAny<ConnectionPolicy>(), It.IsAny<bool>()), Times.Once());
             Assert.Equal("TriggerObject", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/TestCosmosDBServiceFactory.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/TestCosmosDBServiceFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             _service = service;
         }
 
-        public ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy)
+        public ICosmosDBService CreateService(string connectionString, ConnectionPolicy connectionPolicy, bool useDefaultJsonSerialization)
         {
             return _service;
         }


### PR DESCRIPTION
[See bug 574](https://github.com/Azure/azure-webjobs-sdk-extensions/issues/574)

DateTimeOffset are having their Offset changed from the value stored to server local time