### PR TITLE
[Http] replacing EnableRewind() with EnableBuffering()

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>3.0.3$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
     <CosmosDBVersion>3.0.5$(VersionSuffix)</CosmosDBVersion>
-    <HttpVersion>3.0.4$(VersionSuffix)</HttpVersion>
+    <HttpVersion>3.0.5$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.2$(VersionSuffix)</SendGridVersion>
     <TwilioVersion>3.0.2$(VersionSuffix)</TwilioVersion>

--- a/src/WebJobs.Extensions.Http/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Extensions.Http/Extensions/HttpRequestExtensions.cs
@@ -11,7 +11,6 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Http
 {
@@ -25,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
 
         public static async Task<string> ReadAsStringAsync(this HttpRequest request)
         {
-            request.EnableRewind();
+            request.EnableBuffering();
 
             string result = null;
             using (var reader = new StreamReader(
@@ -58,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
             string headerValue = request.Headers[EasyAuthIdentityHeader].First();
             return FromBase64EncodedJson(headerValue);
         }
-      
+
         private static ClaimsIdentity FromBase64EncodedJson(string payload)
         {
             using (var buffer = new MemoryStream(Convert.FromBase64String(payload)))


### PR DESCRIPTION
`EnableRewind()` went internal in ASP.NET Core 3.0 preview 7. But there's a direct replacement available in 2.x as well -- https://github.com/aspnet/AspNetCore/issues/12508#issuecomment-515601441.

Getting this in unblocks a bunch of .NET Core 3.0 tests in Functions.