### PR TITLE
Added special conversion code for guids in Http triggers and supporting tests

### DIFF
--- a/src/WebJobs.Extensions.Http/HttpTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.Http/HttpTriggerAttributeBindingProvider.cs
@@ -403,17 +403,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
             {
                 if (value != null && !targetType.IsAssignableFrom(value.GetType()))
                 {
+                    var underlyingTargetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
                     var jObject = value as JObject;
                     if (jObject != null)
                     {
                         value = jObject.ToObject(targetType);
                     }
+                    else if (underlyingTargetType == typeof(Guid) && value.GetType() == typeof(string))
+                    {
+                        // Guids need to be converted by their own logic
+                        // Intentionally throw here on error to standardize behavior
+                        value = Guid.Parse((string)value);
+                    }
                     else
                     {
                         // if the type is nullable, we only need to convert to the
                         // correct underlying type
-                        targetType = Nullable.GetUnderlyingType(targetType) ?? targetType;
-                        value = Convert.ChangeType(value, targetType);
+                        value = Convert.ChangeType(value, underlyingTargetType);
                     }
                 }
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/2960

This addresses GUIDs not being handled properly when being bound in the http extension, resulting in a 500 error for any function that expects a Guid type. I've also added tests for all data type route constraints so we know if they break in the future.

This should fix both Guids in route constraints as well as Guids in POCOs