### PR TITLE
Add Warmup (trigger) extension

### DIFF
--- a/src/WebJobs.Extensions/Extensions/ExtensionsWebJobsStartup.cs
+++ b/src/WebJobs.Extensions/Extensions/ExtensionsWebJobsStartup.cs
@@ -5,7 +5,7 @@ using Microsoft.Azure.WebJobs.Extensions;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Extensions.Hosting;
 
-[assembly: WebJobsStartup(typeof(ExtensionsWebJobsStartup), "Timers and Files")]
+[assembly: WebJobsStartup(typeof(ExtensionsWebJobsStartup), "Timers, Files and Warmup")]
 
 namespace Microsoft.Azure.WebJobs.Extensions
 {
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions
         {
             builder.AddTimers();
             builder.AddFiles();
+            builder.AddWarmup();
         }
     }
 }

--- a/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupContext.cs
+++ b/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupContext.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs
+{
+    public class WarmupContext
+    {
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupTriggerAttribute.cs
+++ b/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupTriggerAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Binding]
+    public sealed class WarmupTriggerAttribute : Attribute
+    {
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupTriggerAttributeBindingProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Warmup.Trigger
+{
+    internal class WarmupTriggerAttributeBindingProvider : ITriggerBindingProvider
+    {
+        public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var parameter = context.Parameter;
+            WarmupTriggerAttribute attribute = parameter.GetCustomAttribute<WarmupTriggerAttribute>(inherit: false);
+
+            if (attribute == null)
+            {
+                return Task.FromResult<ITriggerBinding>(null);
+            }
+
+            return Task.FromResult<ITriggerBinding>(new WarmupTriggerBinding(parameter));
+        }
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Warmup/Trigger/WarmupTriggerBinding.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Warmup.Trigger
+{
+    internal class WarmupTriggerBinding : ITriggerBinding
+    {
+        private readonly ParameterInfo _parameter;
+
+        public WarmupTriggerBinding(ParameterInfo parameter)
+        {
+            _parameter = parameter;
+        }
+
+        public Type TriggerValueType
+        {
+            get { return typeof(WarmupContext); }
+        }
+
+        public IReadOnlyDictionary<string, Type> BindingDataContract => null;
+
+        public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+        {
+            return Task.FromResult<ITriggerData>(new TriggerData(null, null));
+        }
+
+        public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return Task.FromResult<IListener>(new NullListener());
+        }
+
+        public ParameterDescriptor ToParameterDescriptor()
+        {
+            return new TriggerParameterDescriptor
+            {
+                Name = _parameter.Name
+            };
+        }
+
+        private class NullListener : IListener
+        {
+            /// <summary>
+            /// WarmupTrigger does not need to listen at all.
+            /// </summary>
+            public NullListener()
+            {
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public void Cancel()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Warmup/WarmupConfigProvider.cs
+++ b/src/WebJobs.Extensions/Extensions/Warmup/WarmupConfigProvider.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Extensions.Warmup.Trigger;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Warmup
+{
+    [Extension("Warmup")]
+    internal class WarmupConfigProvider : IExtensionConfigProvider
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public WarmupConfigProvider(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+        }
+
+        public void Initialize(ExtensionConfigContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var logger = _loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Warmup"));
+            logger.LogInformation("Initializing Warmup Extension.");
+
+            context
+                .AddBindingRule<WarmupTriggerAttribute>()
+                .AddConverter<WarmupContext, JObject>((w) => JObject.FromObject(w))
+                .AddConverter<WarmupContext, string>((w) => JsonConvert.SerializeObject(w))
+                .BindToTrigger<WarmupContext>(new WarmupTriggerAttributeBindingProvider());
+        }
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Warmup/WarmupWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions/Extensions/Warmup/WarmupWebJobsBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Warmup;
+
+namespace Microsoft.Extensions.Hosting
+{
+    public static class WarmupWebJobsBuilderExtensions
+    {
+        public static IWebJobsBuilder AddWarmup(this IWebJobsBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.AddExtension<WarmupConfigProvider>();
+            return builder;
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Http.Tests/ClaimsPrincipalEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/ClaimsPrincipalEndToEndTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Host;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;

--- a/test/WebJobs.Extensions.Http.Tests/HttpTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/HttpTriggerEndToEndTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
-using Microsoft.Azure.WebJobs.Host.TestCommon;
 using Microsoft.Extensions.Hosting;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;

--- a/test/WebJobs.Extensions.Tests.Common/Helpers/Fakes/FakeActivator.cs
+++ b/test/WebJobs.Extensions.Tests.Common/Helpers/Fakes/FakeActivator.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Host;
 
-namespace Microsoft.Azure.WebJobs.Host.TestCommon
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Common
 {
     public class FakeActivator : IJobActivator
     {

--- a/test/WebJobs.Extensions.Tests.Common/Helpers/Fakes/FakeTypeLocator.cs
+++ b/test/WebJobs.Extensions.Tests.Common/Helpers/Fakes/FakeTypeLocator.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Azure.WebJobs.Host.TestCommon
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Common
 {
     public class FakeTypeLocator : ITypeLocator
     {

--- a/test/WebJobs.Extensions.Tests.Common/Helpers/JobHostTestHelpers.cs
+++ b/test/WebJobs.Extensions.Tests.Common/Helpers/JobHostTestHelpers.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Azure.WebJobs.Host.Timers;
@@ -18,7 +18,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Host.TestCommon
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Common
 {
     public static class JobHostTestHelpers
     {

--- a/test/WebJobs.Extensions.Tests.Common/Helpers/TestExceptionHandlerFactory.cs
+++ b/test/WebJobs.Extensions.Tests.Common/Helpers/TestExceptionHandlerFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Host.TestCommon
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Common
 {
     public class TestExceptionHandlerFactory : IWebJobsExceptionHandlerFactory
     {

--- a/test/WebJobs.Extensions.Tests.Common/Helpers/TestJobHost.cs
+++ b/test/WebJobs.Extensions.Tests.Common/Helpers/TestJobHost.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Indexers;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Host.TestCommon
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Common
 {
     public class TestJobHost<TProgram> : JobHost
     {

--- a/test/WebJobs.Extensions.Tests/Extensions/Warmup/WarmupTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Warmup/WarmupTriggerEndToEndTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Warmup.Tests
+{
+    public class WarmupTriggerEndToEndTests
+    {
+        private static string _functionOut = null;
+        private readonly TestLoggerProvider _loggerProvider = new TestLoggerProvider();
+
+        [Theory]
+        [InlineData("WarmupTriggerParams.TestWarmup_String")]
+        [InlineData("WarmupTriggerParams.TestWarmup_JObject")]
+        [InlineData("WarmupTriggerParams.TestWarmup_WarmupContext")]
+        public async Task WarmupTriggerTest_Success(string functionName)
+        {
+            _functionOut = null;
+            var warmupContext = new WarmupContext();
+
+            var args = new Dictionary<string, object>
+            {
+                { "warmupContext", warmupContext }
+            };
+
+            var host = NewHost(types: new Type[] { typeof(WarmupTriggerParams) });
+
+            await host.GetJobHost().CallAsync(functionName, args);
+            Assert.Equal(JsonConvert.SerializeObject(warmupContext), _functionOut);
+        }
+
+        [Fact]
+        public async Task WarmupTriggerTest_Failure()
+        {
+            _functionOut = null;
+            var warmupContext = new WarmupContext();
+
+            var args = new Dictionary<string, object>
+            {
+                { "warmupContext", warmupContext }
+            };
+
+            var host = NewHost(types: new Type[] { typeof(WarmupTriggerParams) });
+
+            // Indexing exceptions will happen in cases where data type for binding is invalid
+            host = NewHost(types: new Type[] { typeof(WarmupInvalidBindingParam) });
+            var indexException = await Assert.ThrowsAsync<FunctionIndexingException>(() => host.StartAsync());
+            Assert.Equal($"Can't bind WarmupTrigger to type '{typeof(int)}'.", indexException.InnerException.Message);
+        }
+
+        public IHost NewHost(Type[] types = null)
+        {
+            IHost host = new HostBuilder()
+                .ConfigureDefaultTestHost(builder =>
+                {
+                   builder.AddWarmup();
+                }, types: types)
+                .Build();
+
+            return host;
+        }
+
+        public class WarmupTriggerParams
+        {
+            public void TestWarmup_String([WarmupTrigger] string warmupContext)
+            {
+                _functionOut = warmupContext;
+            }
+
+            public void TestWarmup_JObject([WarmupTrigger] JObject warmupContext)
+            {
+                _functionOut = JsonConvert.SerializeObject(warmupContext);
+            }
+
+            public void TestWarmup_WarmupContext([WarmupTrigger] WarmupContext warmupContext)
+            {
+                _functionOut = JsonConvert.SerializeObject(warmupContext);
+            }
+        }
+
+        public class WarmupInvalidBindingParam
+        {
+            public void TestWarmup_Invalid([WarmupTrigger] int warmupContext)
+            {
+                _functionOut = warmupContext.ToString();
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Tests/PublicSurfaceTests.cs
+++ b/test/WebJobs.Extensions.Tests/PublicSurfaceTests.cs
@@ -37,7 +37,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests
                 "TimersOptions",
                 "TimerTriggerAttribute",
                 "WeeklySchedule",
-                "ExtensionsWebJobsStartup"
+                "ExtensionsWebJobsStartup",
+                "WarmupContext",
+                "WarmupTriggerAttribute",
+                "WarmupWebJobsBuilderExtensions"
             };
 
             AssertPublicTypes(expected, assembly);


### PR DESCRIPTION
Related issue -- https://github.com/Azure/azure-functions-host/issues/4588
See related Host PR -- https://github.com/Azure/azure-functions-host/pull/4983

Adding a new Warmup extension that can be invoked through an admin API in the host. For more details, please look at the Host PR.
