### PR TITLE
moving timer logs to use structured logging and EventIds

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
                 throw new ArgumentNullException("context");
             }
 
-            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor, context.Descriptor?.ShortName));
+            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor, context.Descriptor?.LogName));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.Logger.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.Logger.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
+{
+    internal sealed partial class TimerListener
+    {
+        private static class Logger
+        {
+            private static readonly Action<ILogger, string, TimerSchedule, string, Exception> _scheduleAndTimeZone =
+                LoggerMessage.Define<string, TimerSchedule, string>(LogLevel.Debug, new EventId(1, nameof(ScheduleAndTimeZone)),
+                    "The '{functionName}' timer is using the schedule '{schedule}' and the local time zone: '{timeZone}'");
+
+            private static readonly Action<ILogger, string, string, string, string, Exception> _initialStatus =
+                LoggerMessage.Define<string, string, string, string>(LogLevel.Debug, new EventId(2, nameof(InitialStatus)),
+                    "Function '{functionName}' initial status: Last='{lastInvoke}', Next='{nextInvoke}', LastUpdated='{lastUpdated}'");
+
+            private static readonly Action<ILogger, string, Exception> _pastDue =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(3, nameof(PastDue)),
+                    "Function '{functionName}' is past due on startup. Executing now.");
+
+            private static readonly Action<ILogger, string, Exception> _runOnStartup =
+               LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, nameof(RunOnStartup)),
+                   "Function '{functionName}' is configured to run on startup. Executing now.");
+
+            private static readonly Action<ILogger, string, TimerSchedule, string, Exception> _nextOccurrences =
+               LoggerMessage.Define<string, TimerSchedule, string>(LogLevel.Information, new EventId(5, nameof(NextOccurrences)),
+                   "The next 5 occurrences of the '{functionName}' schedule ({schedule}) will be:{occurrences}");
+
+            private static readonly Action<ILogger, string, TimeSpan, Exception> _timerStarted =
+                LoggerMessage.Define<string, TimeSpan>(LogLevel.Debug, new EventId(6, nameof(TimerStarted)),
+                    "Timer for '{functionName}' started with interval '{interval}'.");
+
+            public static void ScheduleAndTimeZone(ILogger logger, string functionName, TimerSchedule schedule, string timeZone) =>
+                _scheduleAndTimeZone(logger, functionName, schedule, timeZone, null);
+
+            public static void InitialStatus(ILogger logger, string functionName, string lastInvoke, string nextInvoke, string lastUpdated) =>
+                _initialStatus(logger, functionName, lastInvoke, nextInvoke, lastUpdated, null);
+
+            public static void PastDue(ILogger logger, string functionName) =>
+                _pastDue(logger, functionName, null);
+
+            public static void RunOnStartup(ILogger logger, string functionName) =>
+                _runOnStartup(logger, functionName, null);
+
+            public static void NextOccurrences(ILogger logger, string functionName, TimerSchedule schedule, string occurrences) =>
+                _nextOccurrences(logger, functionName, schedule, Environment.NewLine + occurrences, null);
+
+            public static void TimerStarted(ILogger logger, string functionName, TimeSpan interval) =>
+                _timerStarted(logger, functionName, interval, null);
+        }
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Timers/TimerInfo.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/TimerInfo.cs
@@ -59,23 +59,16 @@ namespace Microsoft.Azure.WebJobs
             return FormatNextOccurrences(Schedule, count, now);
         }
 
-        internal static string FormatNextOccurrences(TimerSchedule schedule, int count, DateTime? now = null, string functionShortName = null)
+        internal static string FormatNextOccurrences(TimerSchedule schedule, int count, DateTime? now = null)
         {
             if (schedule == null)
             {
                 throw new ArgumentNullException("schedule");
             }
 
-            // If we've got a timer name, format it
-            if (functionShortName != null)
-            {
-                functionShortName = $"'{functionShortName}' ";
-            }
-
             bool isUtc = TimeZoneInfo.Local.HasSameRules(TimeZoneInfo.Utc);
             IEnumerable<DateTime> nextOccurrences = schedule.GetNextOccurrences(count, now);
             StringBuilder builder = new StringBuilder();
-            builder.AppendLine($"The next {count} occurrences of the {functionShortName}schedule ({schedule}) will be:");
             foreach (DateTime occurrence in nextOccurrences)
             {
                 if (isUtc)

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -343,8 +343,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             await _listener.StartAsync(CancellationToken.None);
             await _listener.StopAsync(CancellationToken.None);
 
-            string actualMessage = _logger.GetLogMessages().Single(m => m.Level == LogLevel.Information).FormattedMessage;
-            Assert.StartsWith($"The next 5 occurrences of the '{_functionShortName}' schedule ({_schedule}) will be:", actualMessage);
+            LogMessage actualMessage = _logger.GetLogMessages().Single(m => m.Level == LogLevel.Information);
+            Assert.StartsWith($"The next 5 occurrences of the '{_functionShortName}' schedule ({_schedule}) will be:", actualMessage.FormattedMessage);
+
+            // make sure we're logging function name.
+            Assert.Equal(_functionShortName, actualMessage.State.Single(p => p.Key == "functionName").Value);
         }
 
         [Fact]
@@ -364,7 +367,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         [Fact]
         public async Task Listener_LogsInitialNullStatus_WhenUsingMonitor()
         {
-            await RunInitialStatusTestAsync(null, $"Function '{_functionShortName}' initial status: Last='', Next='', LastUpdated=''");
+            await RunInitialStatusTestAsync(null, $"Function '{_functionShortName}' initial status: Last='(null)', Next='(null)', LastUpdated='(null)'");
         }
 
         public static IEnumerable<object[]> TimerSchedulesAfterDST => new object[][]

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerInfoTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerInfoTests.cs
@@ -49,25 +49,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 .Select(dateTime => $"{DateFormatter(dateTime)}\r\n")
                 .ToArray();
 
-            string expected =
-                $"The next 10 occurrences of the schedule ({cronSchedule}) will be:\r\n" +
-                string.Join(string.Empty, expectedDates);
+            string expected = string.Join(string.Empty, expectedDates);
 
             Assert.Equal(expected, result);
 
             // Test the internal method with timer name specified
-            string timerName = "TestTimer";
             TimerSchedule schedule = new DailySchedule("2:00:00");
-            result = TimerInfo.FormatNextOccurrences(schedule, 5, now, timerName);
+            result = TimerInfo.FormatNextOccurrences(schedule, 5, now);
 
             expectedDates = Enumerable.Range(17, 5)
                 .Select(day => new DateTime(2015, 09, day, 02, 00, 00, DateTimeKind.Local))
                 .Select(dateTime => $"{DateFormatter(dateTime)}\r\n")
                 .ToArray();
 
-            expected =
-                    $"The next 5 occurrences of the 'TestTimer' schedule ({schedule}) will be:\r\n" +
-                    string.Join(string.Empty, expectedDates);
+            expected = string.Join(string.Empty, expectedDates);
             Assert.Equal(expected, result);
 
             WeeklySchedule weeklySchedule = new WeeklySchedule();
@@ -78,10 +73,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
             schedule = weeklySchedule;
 
-            result = TimerInfo.FormatNextOccurrences(schedule, 5, now, timerName);
+            result = TimerInfo.FormatNextOccurrences(schedule, 5, now);
 
             expected =
-                $"The next 5 occurrences of the 'TestTimer' schedule ({weeklySchedule}) will be:\r\n" +
                 DateFormatter(new DateTime(2015, 09, 16, 21, 30, 00, DateTimeKind.Local)) + "\r\n" +
                 DateFormatter(new DateTime(2015, 09, 18, 10, 00, 00, DateTimeKind.Local)) + "\r\n" +
                 DateFormatter(new DateTime(2015, 09, 21, 08, 00, 00, DateTimeKind.Local)) + "\r\n" +


### PR DESCRIPTION
Another piece to https://github.com/Azure/azure-functions-host/issues/4113. This will light up with https://github.com/Azure/azure-functions-host/pull/5114.

Not all of this was strictly necessary, but wanted to clean it up while I was in here. Now all of these will emit an event name for easier querying. And using the "functionName" key will allow us to extract that value in kusto (and shoebox) for the FunctionName column.