### PR TITLE
Add documentation to make it clear that TimersOptions is currently unnecessary

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Config/TimerWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Config/TimerWebJobsBuilderExtensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The <see cref="IWebJobsBuilder"/> to configure.</param>
         /// <param name="configure">An <see cref="Action{TimersOptions}"/> to configure the provided <see cref="TimersOptions"/>.</param>
+        /// <remarks>Currently there are no configurable options on <see cref="TimersOptions"/> so this overload does not provide any utility.</remarks>
         public static IWebJobsBuilder AddTimers(this IWebJobsBuilder builder, Action<TimersOptions> configure)
         {
             if (builder == null)

--- a/src/WebJobs.Extensions/Extensions/Timers/Config/TimersOptions.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Config/TimersOptions.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Azure.WebJobs.Extensions.Timers
 {
     /// <summary>
-    /// Options object for <see cref="TimerTriggerAttribute"/> decorated job functions.
+    /// Options object for <see cref="TimerTriggerAttribute"/> decorated job functions. Currently this type is just a placeholder and presents no configurable options.
     /// </summary>
     public class TimersOptions
     {


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-webjobs-sdk-extensions/issues/625