### PR TITLE
Fix for CosmosDbTrigger to honor UseDefaultJsonSerialization setting

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     throw new InvalidOperationException("The monitored collection cannot be the same as the collection storing the leases.");
                 }
 
-                monitoredCosmosDBService = _configProvider.GetService(triggerConnectionString, resolvedPreferredLocations, attribute.UseDefaultJsonSerialization);
+                monitoredCosmosDBService = _configProvider.GetService(triggerConnectionString, resolvedPreferredLocations, false, attribute.UseDefaultJsonSerialization);
                 leaseCosmosDBService = _configProvider.GetService(leasesConnectionString, resolvedPreferredLocations, attribute.UseMultipleWriteLocations);
 
                 if (attribute.CreateLeaseCollectionIfNotExists)


### PR DESCRIPTION
As reported in issue #600, the UseDefaultJsonSerialization setting is not correctly passed by CosmosDbTriggerAttributeBindingProvider - it incorrectly passes the setting UseMultipleWriteLocations instead, which is irrelevant on the monitoring collection as this is only read from.

This means that using custom json serialization settings is not currently possible.

Fix is very small, unit test included which checks that the JsonConverter.DefaultSettings is actually accessed. This is a bit sneaky, but does accurately check the desired outcome and avoids having to change the code to be able to inspect the passed setting.