### PR TITLE
Improve functions startup time when warmup triggers are provided.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>4.0.1$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
     <CosmosDBVersion>3.0.8$(VersionSuffix)</CosmosDBVersion>
-    <HttpVersion>3.0.8$(VersionSuffix)</HttpVersion>
+    <HttpVersion>3.0.9$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.2$(VersionSuffix)</SendGridVersion>
     <TwilioVersion>3.0.2$(VersionSuffix)</TwilioVersion>

--- a/src/WebJobs.Extensions.Http/HttpBindingApplicationBuilderExtension.cs
+++ b/src/WebJobs.Extensions.Http/HttpBindingApplicationBuilderExtension.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         /// <param name="builder">The application builder.</param>
         /// <param name="applicationLifetime">The application lifetime instance.</param>
         /// <param name="routes">A route configuration handler.</param>
-        /// <returns>The updated <see cref="IApplicationBuilder"/></returns>
+        /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
         public static IApplicationBuilder UseHttpBinding(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
             => UseHttpBindingRouting(builder, applicationLifetime, routes);
 
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         /// <param name="builder">The application builder.</param>
         /// <param name="applicationLifetime">The application lifetime instance.</param>
         /// <param name="routes">A route configuration handler.</param>
-        /// <returns>The updated <see cref="IApplicationBuilder"/></returns>
+        /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
         public static IApplicationBuilder UseHttpBindingRouting(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
         {
             var router = builder.ApplicationServices.GetRequiredService<IWebJobsRouter>();
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
                 var routeBuilder = new WebJobsRouteBuilder(builder, routeHandler);
                 routes.Invoke(routeBuilder);
 
-                router.AddFunctionRoutes(routeBuilder.Build(), null);
+                router.AddFunctionRoutes(routeBuilder.Build(), null, null);
             }
 
             builder.UseRouter(router);

--- a/src/WebJobs.Extensions.Http/HttpBindingApplicationBuilderExtension.cs
+++ b/src/WebJobs.Extensions.Http/HttpBindingApplicationBuilderExtension.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
                 var routeBuilder = new WebJobsRouteBuilder(builder, routeHandler);
                 routes.Invoke(routeBuilder);
 
-                router.AddFunctionRoutes(routeBuilder.Build(), null, null);
+                router.AddFunctionRoutes(routeBuilder.Build(), null);
             }
 
             builder.UseRouter(router);

--- a/src/WebJobs.Extensions.Http/Routing/IWebJobsRouter.cs
+++ b/src/WebJobs.Extensions.Http/Routing/IWebJobsRouter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
     {
         IInlineConstraintResolver ConstraintResolver { get; }
 
-        void AddFunctionRoutes(IRouter functionRoutes, IRouter proxyRoutes);
+        void AddFunctionRoutes(IRouter functionRoutes, IRouter proxyRoutes, IRouter warmupRoute);
 
         void ClearRoutes();
 

--- a/src/WebJobs.Extensions.Http/Routing/IWebJobsRouter.cs
+++ b/src/WebJobs.Extensions.Http/Routing/IWebJobsRouter.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
     {
         IInlineConstraintResolver ConstraintResolver { get; }
 
-        void AddFunctionRoutes(IRouter functionRoutes, IRouter proxyRoutes, IRouter warmupRoute);
+        void AddFunctionRoutes(IRouter functionRoutes, IRouter proxyRoutes);
+
+        void AddCustomRoutes(IRouter customRoutes);
 
         void ClearRoutes();
 

--- a/test/WebJobs.Extensions.Http.Tests/WebJobsRouterTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/WebJobsRouterTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http;
 using Moq;
 using Xunit;
 
@@ -21,13 +23,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http.Tests
             var builder = router.CreateBuilder(handler.Object, "api");
             builder.MapFunctionRoute("testfunction", "test/{token}", "testfunction");
 
-            router.AddFunctionRoutes(builder.Build(), null);
+            router.AddFunctionRoutes(builder.Build(), null, null);
 
             // Act
             string routeTemplate = router.GetFunctionRouteTemplate("testfunction");
 
             // Assert
             Assert.Equal("api/test/{token}", routeTemplate);
+        }
+
+        [Fact]
+        public void GetFunctionWithWarmupRoute()
+        {
+            var constraintResolver = new Mock<IInlineConstraintResolver>();
+            var handler = new Mock<IWebJobsRouteHandler>();
+            IWebJobsRouter router = new WebJobsRouter(constraintResolver.Object);
+
+            var builder = router.CreateBuilder(handler.Object, "api");
+            builder.MapFunctionRoute("warmuproute", "warmup", "warmuproute");
+
+            var warmupBuilder = router.CreateBuilder(handler.Object, "admin");
+            warmupBuilder.MapFunctionRoute("warmup", "warmup", "warmup");
+
+            router.AddFunctionRoutes(builder.Build(), null, warmupBuilder.Build());
+
+            string routeTemplate = router.GetFunctionRouteTemplate("warmuproute");
+
+            Assert.Equal("api/warmup", routeTemplate);
+
+            var req = HttpTestHelpers.CreateHttpRequest("GET", "http://functions.com/admin/host/ping");
+            RouteContext rc = new RouteContext(req.HttpContext);
+            var r = router.RouteAsync(rc);
+            Assert.True(r.IsCompletedSuccessfully == true);
+
+            req = HttpTestHelpers.CreateHttpRequest("GET", "http://functions.com/admin/warmup");
+            rc = new RouteContext(req.HttpContext);
+            r = router.RouteAsync(rc);
+            Assert.True(r.IsCompletedSuccessfully == false);
+
+            req = HttpTestHelpers.CreateHttpRequest("GET", "http://functions.com/api/warmup");
+            rc = new RouteContext(req.HttpContext);
+            r = router.RouteAsync(rc);
+            Assert.True(r.IsCompletedSuccessfully == false);
         }
     }
 }


### PR DESCRIPTION
This is the WebJobs.Extensions.Http part.
This combined with the PR for WebJobs.Script will move the
/admin/warmup call completely within the functions execution pipeline rather than being a separate controller
and will avoid all the JIT cost that incur during the first real function execution even when warmup triggers are present.