### PR TITLE
Fixing binding data bug

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.3.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
+++ b/src/WebJobs.Extensions.MobileApps/WebJobs.Extensions.MobileApps.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Include="SendGrid" Version="9.10.0" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Include="Twilio" Version="5.6.3" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.22" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.1" />
     <PackageReference Include="ncrontab.signed" Version="3.3.2" />
   </ItemGroup>

--- a/test/WebJobs.Extensions.Http.Tests/HttpTestHelpers.cs
+++ b/test/WebJobs.Extensions.Http.Tests/HttpTestHelpers.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
 {
@@ -14,8 +15,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
     {
         public static HttpRequest CreateHttpRequest(string method, string uriString, IHeaderDictionary headers = null, string body = null)
         {
+            var context = new DefaultHttpContext();
+            var services = new ServiceCollection();
+            var sp = services.BuildServiceProvider();
+            context.RequestServices = sp;
+
             var uri = new Uri(uriString);
-            var request = new DefaultHttpContext().Request;
+            var request = context.Request;
             var requestFeature = request.HttpContext.Features.Get<IHttpRequestFeature>();
             requestFeature.Method = method;
             requestFeature.Scheme = uri.Scheme;


### PR DESCRIPTION
Another issue discovered when trying to pull the updated http extension into Functions host, related to the lazy binding data changes. If a poco is being bound to, we must evaluate binding data immediately and apply it to the poco. In all other cases, the lazy binding data will be evaluated on demand correctly. I added a missing repro test for this scenario.