### PR TITLE
Cosmos DB: Fixing user agent

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.ChangeFeedProcessor;
 using Microsoft.Azure.Documents.ChangeFeedProcessor.Monitoring;
 using Microsoft.Azure.Documents.ChangeFeedProcessor.PartitionManagement;
+using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
@@ -176,10 +177,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         {
             if (this._hostBuilder == null)
             {
+                DocumentClient feedDocumentClient = this._monitoredCosmosDBService.GetClient();
+                DocumentClient leasesDocumentClient = this._leasesCosmosDBService.GetClient();
+                feedDocumentClient.ConnectionPolicy.UserAgentSuffix = this._monitorCollection.ConnectionPolicy.UserAgentSuffix;
+                leasesDocumentClient.ConnectionPolicy.UserAgentSuffix = this._leaseCollection.ConnectionPolicy.UserAgentSuffix;
                 this._hostBuilder = new ChangeFeedProcessorBuilder()
                     .WithHostName(this._hostName)
-                    .WithFeedDocumentClient(this._monitoredCosmosDBService.GetClient())
-                    .WithLeaseDocumentClient(this._leasesCosmosDBService.GetClient())
+                    .WithFeedDocumentClient(feedDocumentClient)
+                    .WithLeaseDocumentClient(leasesDocumentClient)
                     .WithFeedCollection(this._monitorCollection)
                     .WithLeaseCollection(this._leaseCollection)
                     .WithProcessorOptions(this._processorOptions)

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
@@ -47,10 +47,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             _mockMonitoredService = new Mock<ICosmosDBService>(MockBehavior.Strict);
             _mockMonitoredService.Setup(m => m.GetClient()).Returns(new DocumentClient(new Uri("http://someurl"), "c29tZV9rZXk="));
             _monitoredInfo = new DocumentCollectionInfo { Uri = new Uri("http://someurl"), MasterKey = "c29tZV9rZXk=", DatabaseName = "MonitoredDB", CollectionName = "MonitoredCollection" };
+            _monitoredInfo.ConnectionPolicy.UserAgentSuffix = Guid.NewGuid().ToString();
 
             _mockLeasesService = new Mock<ICosmosDBService>(MockBehavior.Strict);
             _mockLeasesService.Setup(m => m.GetClient()).Returns(new DocumentClient(new Uri("http://someurl"), "c29tZV9rZXk="));
             _leasesInfo = new DocumentCollectionInfo { Uri = new Uri("http://someurl"), MasterKey = "c29tZV9rZXk=", DatabaseName = "LeasesDB", CollectionName = "LeasesCollection" };
+            _leasesInfo.ConnectionPolicy.UserAgentSuffix = Guid.NewGuid().ToString();
 
             _processorOptions = new ChangeFeedProcessorOptions();
 


### PR DESCRIPTION
User agent was not correctly flowing inside the CFP and being used.