### PR TITLE
Cosmos DB: Rewiring user agent initialization for 2.12.0

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -124,10 +124,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return _options.ConnectionString;
         }
 
-        internal ICosmosDBService GetService(string connectionString, string preferredLocations = "", bool useMultipleWriteLocations = false, bool useDefaultJsonSerialization = false)
+        internal ICosmosDBService GetService(string connectionString, string preferredLocations = "", bool useMultipleWriteLocations = false, bool useDefaultJsonSerialization = false, string userAgent = "")
         {
             string cacheKey = BuildCacheKey(connectionString, preferredLocations, useMultipleWriteLocations, useDefaultJsonSerialization);
-            ConnectionPolicy connectionPolicy = CosmosDBUtility.BuildConnectionPolicy(_options.ConnectionMode, _options.Protocol, preferredLocations, useMultipleWriteLocations);
+            ConnectionPolicy connectionPolicy = CosmosDBUtility.BuildConnectionPolicy(_options.ConnectionMode, _options.Protocol, preferredLocations, useMultipleWriteLocations, userAgent);
             return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connectionString, connectionPolicy, useDefaultJsonSerialization));
         }
 

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 .Where((region) => !string.IsNullOrEmpty(region));
         }
 
-        internal static ConnectionPolicy BuildConnectionPolicy(ConnectionMode? connectionMode, Protocol? protocol, string preferredLocations, bool useMultipleWriteLocations)
+        internal static ConnectionPolicy BuildConnectionPolicy(ConnectionMode? connectionMode, Protocol? protocol, string preferredLocations, bool useMultipleWriteLocations, string userAgent)
         {
             ConnectionPolicy connectionPolicy = new ConnectionPolicy();
             if (connectionMode.HasValue)
@@ -82,6 +82,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             {
                 connectionPolicy.PreferredLocations.Add(location);
             }
+
+            connectionPolicy.UserAgentSuffix = userAgent;
 
             return connectionPolicy;
         }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -147,8 +147,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     throw new InvalidOperationException("The monitored collection cannot be the same as the collection storing the leases.");
                 }
 
-                monitoredCosmosDBService = _configProvider.GetService(triggerConnectionString, resolvedPreferredLocations, false, attribute.UseDefaultJsonSerialization);
-                leaseCosmosDBService = _configProvider.GetService(leasesConnectionString, resolvedPreferredLocations, attribute.UseMultipleWriteLocations);
+                monitoredCosmosDBService = _configProvider.GetService(
+                    connectionString: triggerConnectionString, 
+                    preferredLocations: resolvedPreferredLocations, 
+                    useMultipleWriteLocations: false, 
+                    useDefaultJsonSerialization: attribute.UseDefaultJsonSerialization, 
+                    userAgent: CosmosDBTriggerUserAgentSuffix);
+                leaseCosmosDBService = _configProvider.GetService(
+                    connectionString: leasesConnectionString,
+                    preferredLocations: resolvedPreferredLocations,
+                    useMultipleWriteLocations: attribute.UseMultipleWriteLocations,
+                    useDefaultJsonSerialization: false, // Lease collection operations should not be affected by serialization configuration
+                    userAgent: CosmosDBTriggerUserAgentSuffix);
 
                 if (attribute.CreateLeaseCollectionIfNotExists)
                 {

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -177,14 +177,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         {
             if (this._hostBuilder == null)
             {
-                DocumentClient feedDocumentClient = this._monitoredCosmosDBService.GetClient();
-                DocumentClient leasesDocumentClient = this._leasesCosmosDBService.GetClient();
-                feedDocumentClient.ConnectionPolicy.UserAgentSuffix = this._monitorCollection.ConnectionPolicy.UserAgentSuffix;
-                leasesDocumentClient.ConnectionPolicy.UserAgentSuffix = this._leaseCollection.ConnectionPolicy.UserAgentSuffix;
                 this._hostBuilder = new ChangeFeedProcessorBuilder()
                     .WithHostName(this._hostName)
-                    .WithFeedDocumentClient(feedDocumentClient)
-                    .WithLeaseDocumentClient(leasesDocumentClient)
+                    .WithFeedDocumentClient(this._monitoredCosmosDBService.GetClient())
+                    .WithLeaseDocumentClient(this._leasesCosmosDBService.GetClient())
                     .WithFeedCollection(this._monitorCollection)
                     .WithLeaseCollection(this._leaseCollection)
                     .WithProcessorOptions(this._processorOptions)

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBUtilityTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBUtilityTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -109,6 +110,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             // Assert
             Assert.Equal(2, parsedLocations.Count());
+        }
+
+        [Fact]
+        public void BuildConnectionPolicy()
+        {
+            // Arrange
+            string preferredLocationsWithEntries = "East US, North Europe,";
+            bool useMultiMaster = true;
+            string userAgent = Guid.NewGuid().ToString();
+
+            // Act
+            var policy = CosmosDBUtility.BuildConnectionPolicy(Documents.Client.ConnectionMode.Direct, Documents.Client.Protocol.Tcp, preferredLocationsWithEntries, useMultiMaster, userAgent);
+
+            // Assert
+            Assert.Equal(userAgent, policy.UserAgentSuffix);
+            Assert.Equal(useMultiMaster, policy.UseMultipleWriteLocations);
+            Assert.Equal(Documents.Client.ConnectionMode.Direct, policy.ConnectionMode);
+            Assert.Equal(Documents.Client.Protocol.Tcp, policy.ConnectionProtocol);
+            Assert.Equal(2, policy.PreferredLocations.Count);
         }
     }
 }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
@@ -47,12 +47,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             _mockMonitoredService = new Mock<ICosmosDBService>(MockBehavior.Strict);
             _mockMonitoredService.Setup(m => m.GetClient()).Returns(new DocumentClient(new Uri("http://someurl"), "c29tZV9rZXk="));
             _monitoredInfo = new DocumentCollectionInfo { Uri = new Uri("http://someurl"), MasterKey = "c29tZV9rZXk=", DatabaseName = "MonitoredDB", CollectionName = "MonitoredCollection" };
-            _monitoredInfo.ConnectionPolicy.UserAgentSuffix = Guid.NewGuid().ToString();
 
             _mockLeasesService = new Mock<ICosmosDBService>(MockBehavior.Strict);
             _mockLeasesService.Setup(m => m.GetClient()).Returns(new DocumentClient(new Uri("http://someurl"), "c29tZV9rZXk="));
             _leasesInfo = new DocumentCollectionInfo { Uri = new Uri("http://someurl"), MasterKey = "c29tZV9rZXk=", DatabaseName = "LeasesDB", CollectionName = "LeasesCollection" };
-            _leasesInfo.ConnectionPolicy.UserAgentSuffix = Guid.NewGuid().ToString();
 
             _processorOptions = new ChangeFeedProcessorOptions();
 


### PR DESCRIPTION
Current user agent wiring is not working correctly after SDK 2.12.0