### PR TITLE
Adding SendGrid response handling

### DIFF
--- a/src/WebJobs.Extensions.SendGrid/Bindings/ISendGridResponseHandler.cs
+++ b/src/WebJobs.Extensions.SendGrid/Bindings/ISendGridResponseHandler.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using SendGrid;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Bindings
+{
+    /// <summary>
+    /// A handler of responses received from APIs call to SendGrid.
+    /// </summary>
+    public interface ISendGridResponseHandler
+    {
+        /// <summary>
+        /// Handles the response.
+        /// </summary>
+        /// <param name="response">The response to handle.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task.</returns>
+        Task HandleAsync(Response response, CancellationToken cancellationToken);
+    }
+}

--- a/src/WebJobs.Extensions.SendGrid/Client/SendGridClient.cs
+++ b/src/WebJobs.Extensions.SendGrid/Client/SendGridClient.cs
@@ -18,17 +18,9 @@ namespace Client
             _client = new SendGrid.SendGridClient(apiKey);
         }
 
-        public async Task<Response> SendMessageAsync(SendGridMessage msg, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<Response> SendMessageAsync(SendGridMessage msg, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var response = await _client.SendEmailAsync(msg, cancellationToken);
-
-            if ((int)response.StatusCode >= 300)
-            {
-                string body = await response.Body.ReadAsStringAsync();
-                throw new InvalidOperationException(body);
-            }
-
-            return response;
+            return _client.SendEmailAsync(msg, cancellationToken);
         }
     }
 }

--- a/src/WebJobs.Extensions.SendGrid/Config/DefaultSendGridResponseHandler.cs
+++ b/src/WebJobs.Extensions.SendGrid/Config/DefaultSendGridResponseHandler.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Bindings;
+using SendGrid;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Config
+{
+    /// <summary>
+    /// The default handler of responses received from APIs call to SendGrid.
+    /// </summary>
+    public class DefaultSendGridResponseHandler : ISendGridResponseHandler
+    {
+        /// <summary>
+        /// Handles the response.
+        /// </summary>
+        /// <param name="response">The response to handle.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task.</returns>
+        public async Task HandleAsync(Response response, CancellationToken cancellationToken)
+        {
+            // https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html
+            if ((int)response.StatusCode >= 400)
+            {
+                string body = await response.Body.ReadAsStringAsync();
+
+                throw new InvalidOperationException(body);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Extensions.SendGrid/Config/SendGridExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.SendGrid/Config/SendGridExtensionConfigProvider.cs
@@ -24,14 +24,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.SendGrid
         internal const string AzureWebJobsSendGridApiKeyName = "AzureWebJobsSendGridApiKey";
 
         private readonly IOptions<SendGridOptions> _options;
-        private ConcurrentDictionary<string, ISendGridClient> _sendGridClientCache = new ConcurrentDictionary<string, ISendGridClient>();
+        private readonly ISendGridResponseHandler _responseHandler;
 
+        private ConcurrentDictionary<string, ISendGridClient> _sendGridClientCache = new ConcurrentDictionary<string, ISendGridClient>();
+        
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        public SendGridExtensionConfigProvider(IOptions<SendGridOptions> options, ISendGridClientFactory clientFactory)
+        public SendGridExtensionConfigProvider(IOptions<SendGridOptions> options, ISendGridClientFactory clientFactory, ISendGridResponseHandler responseHandler)
         {
-            _options = options;
+            _options = options;        
+            _responseHandler = responseHandler;
+
             ClientFactory = clientFactory;
         }
 
@@ -58,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.SendGrid
         {
             string apiKey = FirstOrDefault(attr.ApiKey, _options.Value.ApiKey);
             ISendGridClient sendGrid = _sendGridClientCache.GetOrAdd(apiKey, a => ClientFactory.Create(a));
-            return new SendGridMessageAsyncCollector(_options.Value, attr, sendGrid);
+            return new SendGridMessageAsyncCollector(_options.Value, attr, sendGrid, _responseHandler);
         }
 
         private void ValidateBinding(SendGridAttribute attribute, Type type)

--- a/src/WebJobs.Extensions.SendGrid/Config/SendGridWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.SendGrid/Config/SendGridWebJobsBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.WebJobs.Extensions.Config;
 using Microsoft.Azure.WebJobs.Extensions.SendGrid;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -37,7 +38,8 @@ namespace Microsoft.Extensions.Hosting
                     SendGridHelpers.ApplyConfiguration(section, options);
                 });
 
-            builder.Services.AddSingleton<ISendGridClientFactory, DefaultSendGridClientFactory>();
+            builder.Services.TryAddSingleton<ISendGridClientFactory, DefaultSendGridClientFactory>();
+            builder.Services.TryAddSingleton<ISendGridResponseHandler, DefaultSendGridResponseHandler>();
 
             return builder;
         }


### PR DESCRIPTION
Per request, I have stripped down [my last pull request](https://github.com/Azure/azure-webjobs-sdk-extensions/pull/664) to exclude any additional/unrelated refactoring.

**There were several tests failing prior to my work. These tests will also fail in the automated build. They are unrelated to my work and should be ignored when evaluating my pull request.** 

This pull request contains modifications to enable extensibility through SendGrid API response handling. Previously, if a response from the SendGrid API indicated a result other than success (defined, by this extension, as status code >= 300), an exception would be thrown when the _SendGridMessageAsyncCollector_ was flushed. This implementation made it difficult to react to responses in meaningful ways.

**Additions**

1. **ISendGridResponseHandler** - This interface can be implemented to allow business logic to be executed against responses from the SendGrid API.

2. **DefaultSendGridResponseHandler** - The default implementation for the interface above. If consumers of this extension do not implement and register the _ISendGridResponseHandler_ with DI, then the _DefaultSendGridResponseHandler_ will be used. This handler implements the logic that was previously implemented when SendGrid responses were received with status codes >= 300. The status code evaluation has been changed to >= 400, per [SendGrid documentation](https://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html).
