### PR TITLE
Cosmos DB: Support VALUE COUNT queries

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBJArrayBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBJArrayBuilder.cs
@@ -10,16 +10,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings
 {
     internal class CosmosDBJArrayBuilder : IAsyncConverter<CosmosDBAttribute, JArray>
     {
-        private CosmosDBEnumerableBuilder<JObject> _builder;
+        private CosmosDBEnumerableBuilder<JToken> _builder;
 
         public CosmosDBJArrayBuilder(CosmosDBExtensionConfigProvider configProvider)
         {
-            _builder = new CosmosDBEnumerableBuilder<JObject>(configProvider);
+            _builder = new CosmosDBEnumerableBuilder<JToken>(configProvider);
         }
 
         public async Task<JArray> ConvertAsync(CosmosDBAttribute attribute, CancellationToken cancellationToken)
         {
-            IEnumerable<JObject> results = await _builder.ConvertAsync(attribute, cancellationToken);
+            IEnumerable<JToken> results = await _builder.ConvertAsync(attribute, cancellationToken);
             return JArray.FromObject(results);
         }
     }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
@@ -149,13 +149,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 .ReturnsAsync(new DocumentQueryResponse<JObject>());
 
             serviceMock
-                .Setup(m => m.ExecuteNextAsync<JObject>(
+                .Setup(m => m.ExecuteNextAsync<JToken>(
                     collectionUri,
                     It.Is<SqlQuerySpec>((s) =>
                         s.QueryText == null &&
                         s.Parameters.Count() == 0),
                     null))
-                .ReturnsAsync(new DocumentQueryResponse<JObject>());
+                .ReturnsAsync(new DocumentQueryResponse<JToken>());
 
             // We only expect item2 to be updated
             serviceMock


### PR DESCRIPTION
Input binding queries when executed on other languages (not C#) use JArray as the binding type.

JArray builder assumes the query will return JSON documents, which is the most common case, but some queries, like queries with VALUE operand, do not return JSON.

Using JToken instead of JObject lets the query work for normal JSON documents and for JValues.

Closes #569