### PR TITLE
Migrating StorageScheduleMonitor to use Track2

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
-    <ExtensionsVersion>4.0.3$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
+    <ExtensionsVersion>4.1.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
     <CosmosDBVersion>3.0.10$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.0.12$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>

--- a/src/ExtensionsSample/ExtensionsSample.csproj
+++ b/src/ExtensionsSample/ExtensionsSample.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Config/TimerWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Config/TimerWebJobsBuilderExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Extensions.Hosting
                 .BindOptions<TimersOptions>();
             builder.Services.AddSingleton<ScheduleMonitor, StorageScheduleMonitor>();
 
+            // TODO: should we register StorageScheduleMonitorV2 here or overwrite in the Host?
             return builder;
         }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitor.cs
@@ -90,8 +90,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                     }
                     else
                     {
-                        var connectionString = _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
-                        var blobServiceClient = _hostStorageProvider.GetBlobServiceClient(connectionString);
+                        // TODO: Should we throw if we can't create the client?
+                        if (!_hostStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
+                        {
+                            throw new InvalidOperationException($"Could not create BlobServiceClient with connection {ConnectionStringNames.Storage}");
+                        }
                         _containerClient = blobServiceClient.GetBlobContainerClient(HostContainerName);
                     }
                 }

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitor.cs
@@ -3,11 +3,10 @@
 
 using System;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
-using Azure.Storage.Blobs;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Configuration;
@@ -27,9 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         private readonly ILogger _logger;
         private readonly IHostIdProvider _hostIdProvider;
         private readonly IConfiguration _configuration;
-        private readonly HostStorageProvider _hostStorageProvider;
-        private string _timerStatusPath;
-        private BlobContainerClient _containerClient;
+        private CloudBlobDirectory _timerStatusDirectory;
 
         /// <summary>
         /// Constructs a new instance.
@@ -38,14 +35,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <param name="hostIdProvider"></param>
         /// <param name="configuration"></param>
         /// <param name="loggerFactory"></param>
-        public StorageScheduleMonitor(DistributedLockManagerContainerProvider lockContainerProvider, IHostIdProvider hostIdProvider, 
-            IConfiguration configuration, ILoggerFactory loggerFactory, HostStorageProvider hostStorageProvider)
+        public StorageScheduleMonitor(DistributedLockManagerContainerProvider lockContainerProvider, IHostIdProvider hostIdProvider,
+            IConfiguration configuration, ILoggerFactory loggerFactory)
         {
             _lockContainerProvider = lockContainerProvider ?? throw new ArgumentNullException(nameof(lockContainerProvider));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
             _logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Timer"));
-            _hostStorageProvider = hostStorageProvider ?? throw new ArgumentNullException(nameof(hostStorageProvider));
 
             JsonSerializerSettings settings = new JsonSerializerSettings
             {
@@ -57,13 +53,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <summary>
         /// Gets the blob directory where timer statuses will be stored.
         /// </summary>
-        internal string TimerStatusPath
+        internal CloudBlobDirectory TimerStatusDirectory
         {
             get
             {
                 // We have to delay create the blob directory since we require the JobHost ID, and that will only
                 // be available AFTER the host as been started
-                if (string.IsNullOrEmpty(_timerStatusPath))
+                if (_timerStatusDirectory == null)
                 {
                     string hostId = _hostIdProvider.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
                     if (string.IsNullOrEmpty(hostId))
@@ -71,52 +67,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                         throw new InvalidOperationException("Unable to determine host ID.");
                     }
 
-                    _timerStatusPath = string.Format("timers/{0}", hostId);
-                }
-
-                return _timerStatusPath;
-            }
-        }
-
-        internal BlobContainerClient ContainerClient
-        {
-            get
-            {
-                if (_containerClient == null)
-                {
-                    if (_lockContainerProvider.InternalContainerClient != null)
+                    CloudBlobContainer container;
+                    if (_lockContainerProvider.InternalContainer != null)
                     {
-                        _containerClient = _lockContainerProvider.InternalContainerClient;
+                        container = _lockContainerProvider.InternalContainer;
                     }
                     else
                     {
-                        // TODO: Should we throw if we can't create the client?
-                        if (!_hostStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
-                        {
-                            throw new InvalidOperationException($"Could not create BlobServiceClient with connection {ConnectionStringNames.Storage}");
-                        }
-                        _containerClient = blobServiceClient.GetBlobContainerClient(HostContainerName);
+                        var connectionString = _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+                        CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
+                        CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+                        container = blobClient.GetContainerReference(HostContainerName);
                     }
-                }
 
-                return _containerClient;
+                    string timerStatusDirectoryPath = string.Format("timers/{0}", hostId);
+                    _timerStatusDirectory = container.GetDirectoryReference(timerStatusDirectoryPath);
+                }
+                return _timerStatusDirectory;
             }
         }
 
         /// <inheritdoc/>
         public override async Task<ScheduleStatus> GetStatusAsync(string timerName)
         {
-            BlobClient statusBlobClient = GetStatusBlobReference(timerName);
+            CloudBlockBlob statusBlob = GetStatusBlobReference(timerName);
 
             try
             {
-                string statusLine;
-                var downloadResponse = await statusBlobClient.DownloadAsync();
-                using (StreamReader reader = new StreamReader(downloadResponse.Value.Content))
-                {
-                    statusLine = reader.ReadToEnd();
-                }
-
+                string statusLine = await statusBlob.DownloadTextAsync();
                 ScheduleStatus status;
                 using (StringReader stringReader = new StringReader(statusLine))
                 {
@@ -124,9 +102,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 }
                 return status;
             }
-            catch (RequestFailedException exception)
+            catch (StorageException exception)
             {
-                if (exception.Status == 404)
+                if (exception.RequestInformation != null &&
+                    exception.RequestInformation.HttpStatusCode == 404)
                 {
                     // we haven't recorded a status yet
                     return null;
@@ -147,11 +126,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
 
             try
             {
-                BlobClient statusBlobClient = GetStatusBlobReference(timerName);
-                using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(statusLine)))
-                {
-                    await statusBlobClient.UploadAsync(stream, overwrite: true);
-                }
+                CloudBlockBlob statusBlob = GetStatusBlobReference(timerName);
+                await statusBlob.UploadTextAsync(statusLine);
             }
             catch (Exception ex)
             {
@@ -160,12 +136,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
             }
         }
 
-        private BlobClient GetStatusBlobReference(string timerName)
+        private CloudBlockBlob GetStatusBlobReference(string timerName)
         {
             // Path to the status blob is:
             // timers/{hostId}/{timerName}/status
-            string blobName = string.Format("{0}/{1}/status", TimerStatusPath, timerName);
-            return ContainerClient.GetBlobClient(blobName);
+            string blobName = string.Format("{0}/status", timerName);
+            return TimerStatusDirectory.GetBlockBlobReference(blobName);
         }
     }
 }

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitorV2.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitorV2.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Timers
+{
+    /// <summary>
+    /// <see cref="ScheduleMonitor"/> that stores schedule information in blob storage.
+    /// </summary>
+    public class StorageScheduleMonitorV2 : ScheduleMonitor
+    {
+        private const string HostContainerName = "azure-webjobs-hosts";
+
+        private readonly HostStorageProvider _hostStorageProvider;
+        private readonly JobHostInternalStorageOptions _storageOptions;
+        
+        private readonly JsonSerializer _serializer;
+        private readonly ILogger _logger;
+        private readonly IHostIdProvider _hostIdProvider;
+        private readonly IConfiguration _configuration;
+        private string _timerStatusPath;
+        private BlobContainerClient _containerClient;
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="hostIdProvider"></param>
+        /// <param name="configuration"></param>
+        /// <param name="loggerFactory"></param>
+        public StorageScheduleMonitorV2(IOptions<JobHostInternalStorageOptions> options, IHostIdProvider hostIdProvider,
+            IConfiguration configuration, ILoggerFactory loggerFactory, HostStorageProvider hostStorageProvider)
+        {
+            _storageOptions = options?.Value ?? throw new ArgumentNullException(nameof(options));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
+            _logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Timer"));
+            _hostStorageProvider = hostStorageProvider ?? throw new ArgumentNullException(nameof(hostStorageProvider));
+
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.IsoDateFormat
+            };
+            _serializer = JsonSerializer.Create(settings);
+        }
+
+        /// <summary>
+        /// Gets the blob directory where timer statuses will be stored.
+        /// </summary>
+        internal string TimerStatusPath
+        {
+            get
+            {
+                // We have to delay create the blob directory since we require the JobHost ID, and that will only
+                // be available AFTER the host as been started
+                if (string.IsNullOrEmpty(_timerStatusPath))
+                {
+                    string hostId = _hostIdProvider.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    if (string.IsNullOrEmpty(hostId))
+                    {
+                        throw new InvalidOperationException("Unable to determine host ID.");
+                    }
+
+                    _timerStatusPath = string.Format("timers/{0}", hostId);
+                }
+
+                return _timerStatusPath;
+            }
+        }
+
+        internal BlobContainerClient ContainerClient
+        {
+            get
+            {
+                if (_containerClient == null)
+                {
+                    if (_storageOptions.InternalSasBlobContainer != null)
+                    {
+                        _containerClient = new BlobContainerClient(new Uri(_storageOptions.InternalSasBlobContainer));   
+                    }
+                    else if (_storageOptions.InternalContainerName != null)
+                    {
+                        // TODO: Should we throw if we can't create the client?
+                        if (!_hostStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
+                        {
+                            throw new InvalidOperationException($"Could not create BlobServiceClient with connection {ConnectionStringNames.Storage}");
+                        }
+                        _containerClient = blobServiceClient.GetBlobContainerClient(HostContainerName);
+                    }
+                    else
+                    {
+                        // TODO: Should we throw if we can't create the client?
+                        if (!_hostStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
+                        {
+                            throw new InvalidOperationException($"Could not create BlobServiceClient with connection {ConnectionStringNames.Storage}");
+                        }
+                        _containerClient = blobServiceClient.GetBlobContainerClient(HostContainerName);
+                    }
+                }
+
+                return _containerClient;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override async Task<ScheduleStatus> GetStatusAsync(string timerName)
+        {
+            BlobClient statusBlobClient = GetStatusBlobReference(timerName);
+
+            try
+            {
+                string statusLine;
+                var downloadResponse = await statusBlobClient.DownloadAsync();
+                using (StreamReader reader = new StreamReader(downloadResponse.Value.Content))
+                {
+                    statusLine = reader.ReadToEnd();
+                }
+
+                ScheduleStatus status;
+                using (StringReader stringReader = new StringReader(statusLine))
+                {
+                    status = (ScheduleStatus)_serializer.Deserialize(stringReader, typeof(ScheduleStatus));
+                }
+                return status;
+            }
+            catch (RequestFailedException exception)
+            {
+                if (exception.Status == 404)
+                {
+                    // we haven't recorded a status yet
+                    return null;
+                }
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override async Task UpdateStatusAsync(string timerName, ScheduleStatus status)
+        {
+            string statusLine;
+            using (StringWriter stringWriter = new StringWriter())
+            {
+                _serializer.Serialize(stringWriter, status);
+                statusLine = stringWriter.ToString();
+            }
+
+            try
+            {
+                BlobClient statusBlobClient = GetStatusBlobReference(timerName);
+                using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(statusLine)))
+                {
+                    await statusBlobClient.UploadAsync(stream, overwrite: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                // best effort
+                _logger.LogError(ex, $"Function '{timerName}' failed to update the timer trigger status.");
+            }
+        }
+
+        private BlobClient GetStatusBlobReference(string timerName)
+        {
+            // Path to the status blob is:
+            // timers/{hostId}/{timerName}/status
+            string blobName = string.Format("{0}/{1}/status", TimerStatusPath, timerName);
+            return ContainerClient.GetBlobClient(blobName);
+        }
+    }
+}

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitorV2.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/StorageScheduleMonitorV2.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     {
         private const string HostContainerName = "azure-webjobs-hosts";
 
-        private readonly HostStorageProvider _hostStorageProvider;
+        private readonly AzureStorageProvider _azureStorageProvider;
         private readonly JobHostInternalStorageOptions _storageOptions;
         
         private readonly JsonSerializer _serializer;
@@ -42,13 +42,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <param name="configuration"></param>
         /// <param name="loggerFactory"></param>
         public StorageScheduleMonitorV2(IOptions<JobHostInternalStorageOptions> options, IHostIdProvider hostIdProvider,
-            IConfiguration configuration, ILoggerFactory loggerFactory, HostStorageProvider hostStorageProvider)
+            IConfiguration configuration, ILoggerFactory loggerFactory, AzureStorageProvider azureStorageProvider)
         {
             _storageOptions = options?.Value ?? throw new ArgumentNullException(nameof(options));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
             _logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Timer"));
-            _hostStorageProvider = hostStorageProvider ?? throw new ArgumentNullException(nameof(hostStorageProvider));
+            _azureStorageProvider = azureStorageProvider ?? throw new ArgumentNullException(nameof(azureStorageProvider));
 
             JsonSerializerSettings settings = new JsonSerializerSettings
             {
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                     else if (_storageOptions.InternalContainerName != null)
                     {
                         // TODO: Should we throw if we can't create the client?
-                        if (!_hostStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
+                        if (!_azureStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
                         {
                             throw new InvalidOperationException($"Could not create BlobServiceClient with connection {ConnectionStringNames.Storage}");
                         }
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                     else
                     {
                         // TODO: Should we throw if we can't create the client?
-                        if (!_hostStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
+                        if (!_azureStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient blobServiceClient, ConnectionStringNames.Storage))
                         {
                             throw new InvalidOperationException($"Could not create BlobServiceClient with connection {ConnectionStringNames.Storage}");
                         }

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -8,11 +8,12 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>$(ExtensionsVersion)</Version>
+    <Version>5.0.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETSTANDARD;NETSTANDARD2_0</DefineConstants>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -21,7 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0-alpha.20210317.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="5.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0" />
     <PackageReference Include="ncrontab.signed" Version="3.3.2" />
   </ItemGroup>

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0" />
     <PackageReference Include="ncrontab.signed" Version="3.3.2" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>$(ExtensionsVersion)</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -22,9 +22,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0-alpha.20210317.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.1.0" />
     <PackageReference Include="ncrontab.signed" Version="3.3.2" />
   </ItemGroup>
 

--- a/test/WebJobs.Extensions.Http.Tests/WebJobs.Extensions.Http.Tests.csproj
+++ b/test/WebJobs.Extensions.Http.Tests/WebJobs.Extensions.Http.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/WebJobs.Extensions.Tests.Common/WebJobs.Extensions.Tests.Common.csproj
+++ b/test/WebJobs.Extensions.Tests.Common/WebJobs.Extensions.Tests.Common.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/StorageScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/StorageScheduleMonitorTests.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.Storage.Blob;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Extensions.Configuration;
@@ -29,11 +30,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         }
 
         [Fact]
-        public void TimerStatusDirectory_ReturnsExpectedDirectory()
+        public void TimerStatusPath_ReturnsExpectedDirectory()
         {
-            CloudBlobDirectory directory = _scheduleMonitor.TimerStatusDirectory;
-            string expectedPath = string.Format("timers/{0}/", TestHostId);
-            Assert.Equal(expectedPath, directory.Prefix);
+            string path = _scheduleMonitor.TimerStatusPath;
+            string expectedPath = string.Format("timers/{0}", TestHostId);
+            Assert.Equal(expectedPath, path);
         }
 
         [Fact]
@@ -41,10 +42,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         {
             StorageScheduleMonitor localScheduleMonitor = CreateScheduleMonitor(null);
 
-            CloudBlobDirectory directory = null;
+            string path = null;
             var ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                directory = localScheduleMonitor.TimerStatusDirectory;
+                path = localScheduleMonitor.TimerStatusPath;
             });
 
             Assert.Equal("Unable to determine host ID.", ex.Message);
@@ -74,6 +75,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         }
 
         [Fact]
+        public async Task UpdateStatusAsync_MultipleUpdates()
+        {
+            // no status, so should return null
+            ScheduleStatus status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Null(status);
+
+            // update the status
+            ScheduleStatus expected = new ScheduleStatus
+            {
+                Last = DateTime.Now.AddMinutes(-5),
+                Next = DateTime.Now.AddMinutes(5),
+                LastUpdated = DateTime.Now.AddMinutes(-5),
+            };
+            await _scheduleMonitor.UpdateStatusAsync(TestTimerName, expected);
+
+            // expect the status to be returned
+            status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Equal(expected.Last, status.Last);
+            Assert.Equal(expected.Next, status.Next);
+            Assert.Equal(expected.LastUpdated, status.LastUpdated);
+
+            // update the status again
+            ScheduleStatus expected2 = new ScheduleStatus
+            {
+                Last = DateTime.Now.AddMinutes(-10),
+                Next = DateTime.Now.AddMinutes(10),
+                LastUpdated = DateTime.Now.AddMinutes(-10),
+            };
+            await _scheduleMonitor.UpdateStatusAsync(TestTimerName, expected2);
+
+            // expect the status to be returned
+            status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Equal(expected2.Last, status.Last);
+            Assert.Equal(expected2.Next, status.Next);
+            Assert.Equal(expected2.LastUpdated, status.LastUpdated);
+        }
+
+        [Fact]
         public async Task UpdateStatusAsync_MultipleFunctions()
         {
             // update status for 3 functions
@@ -87,39 +126,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
                 await _scheduleMonitor.UpdateStatusAsync(TestTimerName + i.ToString(), expected);
             }
 
-            var segments = await _scheduleMonitor.TimerStatusDirectory.ListBlobsSegmentedAsync(
-                useFlatBlobListing: true,
-                blobListingDetails: BlobListingDetails.None,
-                maxResults: null,
-                currentToken: null,
-                options: null,
-                operationContext: null);
+            var blobList = new List<BlobHierarchyItem>();
+            var segmentResult = _scheduleMonitor.ContainerClient.GetBlobsByHierarchyAsync(prefix: _scheduleMonitor.TimerStatusPath);
+            var asyncEnumerator = segmentResult.GetAsyncEnumerator();
 
-            var statuses = segments.Results.Cast<CloudBlockBlob>().ToArray();
+            while (await asyncEnumerator.MoveNextAsync())
+            {
+                blobList.Add(asyncEnumerator.Current);
+            }
+
+            var statuses = blobList.Select(b => b.Blob.Name).ToArray();
             Assert.Equal(3, statuses.Length);
-            Assert.Equal("timers/testhostid/TestProgram.TestTimer0/status", statuses[0].Name);
-            Assert.Equal("timers/testhostid/TestProgram.TestTimer1/status", statuses[1].Name);
-            Assert.Equal("timers/testhostid/TestProgram.TestTimer2/status", statuses[2].Name);
+            Assert.Equal("timers/testhostid/TestProgram.TestTimer0/status", statuses[0]);
+            Assert.Equal("timers/testhostid/TestProgram.TestTimer1/status", statuses[1]);
+            Assert.Equal("timers/testhostid/TestProgram.TestTimer2/status", statuses[2]);
         }
 
-        private void Cleanup()
+        private async Task Cleanup()
         {
-            CloudBlobDirectory directory = _scheduleMonitor.TimerStatusDirectory;
-            foreach (CloudBlockBlob blob in directory.ListBlobsSegmentedAsync(
-                useFlatBlobListing: true,
-                blobListingDetails: BlobListingDetails.None,
-                maxResults: null,
-                currentToken: null,
-                options: null,
-                operationContext: null).Result.Results)
+            var segmentResult = _scheduleMonitor.ContainerClient.GetBlobsByHierarchyAsync(prefix: _scheduleMonitor.TimerStatusPath);
+            var asyncEnumerator = segmentResult.GetAsyncEnumerator();
+
+            while (await asyncEnumerator.MoveNextAsync())
             {
-                blob.DeleteAsync().Wait();
+                _scheduleMonitor.ContainerClient.DeleteBlobIfExistsAsync(asyncEnumerator.Current.Blob.Name).Wait();
             }
         }
 
         public void Dispose()
         {
-            Cleanup();
+            Cleanup().GetAwaiter().GetResult();
         }
 
         private static StorageScheduleMonitor CreateScheduleMonitor(string hostId = null)
@@ -130,8 +166,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             var lockContainerManager = new DistributedLockManagerContainerProvider();
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new TestLoggerProvider());
+            HostStorageProvider hostStorageProvider = new HostStorageProvider();
 
-            return new StorageScheduleMonitor(lockContainerManager, new TestIdProvider(hostId), config, loggerFactory);
+            return new StorageScheduleMonitor(lockContainerManager, new TestIdProvider(hostId), config, loggerFactory, hostStorageProvider);
         }
 
         private class TestIdProvider : Host.Executors.IHostIdProvider

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/StorageScheduleMonitorV2Tests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/StorageScheduleMonitorV2Tests.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Timers;
+using Microsoft.Azure.WebJobs.StorageProvider.Blobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
+{
+    [Trait("Category", "E2E")]
+    public class StorageScheduleMonitorV2Tests : IDisposable
+    {
+        private const string TestTimerName = "TestProgram.TestTimer";
+        private const string TestHostId = "testhostid";
+        private readonly StorageScheduleMonitor _scheduleMonitor;
+
+        public StorageScheduleMonitorV2Tests()
+        {
+            _scheduleMonitor = CreateScheduleMonitor(TestHostId);
+
+            Cleanup();
+        }
+
+        [Fact]
+        public void TimerStatusPath_ReturnsExpectedDirectory()
+        {
+            string path = _scheduleMonitor.TimerStatusPath;
+            string expectedPath = string.Format("timers/{0}", TestHostId);
+            Assert.Equal(expectedPath, path);
+        }
+
+        [Fact]
+        public void TimerStatusDirectory_HostIdNull_Throws()
+        {
+            StorageScheduleMonitor localScheduleMonitor = CreateScheduleMonitor(null);
+
+            string path = null;
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                path = localScheduleMonitor.TimerStatusPath;
+            });
+
+            Assert.Equal("Unable to determine host ID.", ex.Message);
+        }
+
+        [Fact]
+        public async Task GetStatusAsync_ReturnsExpectedStatus()
+        {
+            // no status, so should return null
+            ScheduleStatus status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Null(status);
+
+            // update the status
+            ScheduleStatus expected = new ScheduleStatus
+            {
+                Last = DateTime.Now.AddMinutes(-5),
+                Next = DateTime.Now.AddMinutes(5),
+                LastUpdated = DateTime.Now.AddMinutes(-5),
+            };
+            await _scheduleMonitor.UpdateStatusAsync(TestTimerName, expected);
+
+            // expect the status to be returned
+            status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Equal(expected.Last, status.Last);
+            Assert.Equal(expected.Next, status.Next);
+            Assert.Equal(expected.LastUpdated, status.LastUpdated);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_MultipleUpdates()
+        {
+            // no status, so should return null
+            ScheduleStatus status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Null(status);
+
+            // update the status
+            ScheduleStatus expected = new ScheduleStatus
+            {
+                Last = DateTime.Now.AddMinutes(-5),
+                Next = DateTime.Now.AddMinutes(5),
+                LastUpdated = DateTime.Now.AddMinutes(-5),
+            };
+            await _scheduleMonitor.UpdateStatusAsync(TestTimerName, expected);
+
+            // expect the status to be returned
+            status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Equal(expected.Last, status.Last);
+            Assert.Equal(expected.Next, status.Next);
+            Assert.Equal(expected.LastUpdated, status.LastUpdated);
+
+            // update the status again
+            ScheduleStatus expected2 = new ScheduleStatus
+            {
+                Last = DateTime.Now.AddMinutes(-10),
+                Next = DateTime.Now.AddMinutes(10),
+                LastUpdated = DateTime.Now.AddMinutes(-10),
+            };
+            await _scheduleMonitor.UpdateStatusAsync(TestTimerName, expected2);
+
+            // expect the status to be returned
+            status = await _scheduleMonitor.GetStatusAsync(TestTimerName);
+            Assert.Equal(expected2.Last, status.Last);
+            Assert.Equal(expected2.Next, status.Next);
+            Assert.Equal(expected2.LastUpdated, status.LastUpdated);
+        }
+
+        [Fact]
+        public async Task UpdateStatusAsync_MultipleFunctions()
+        {
+            // update status for 3 functions
+            ScheduleStatus expected = new ScheduleStatus
+            {
+                Last = DateTime.Now.Subtract(TimeSpan.FromMinutes(5)),
+                Next = DateTime.Now.AddMinutes(5)
+            };
+            for (int i = 0; i < 3; i++)
+            {
+                await _scheduleMonitor.UpdateStatusAsync(TestTimerName + i.ToString(), expected);
+            }
+
+            var blobList = new List<BlobHierarchyItem>();
+            var segmentResult = _scheduleMonitor.ContainerClient.GetBlobsByHierarchyAsync(prefix: _scheduleMonitor.TimerStatusPath);
+            var asyncEnumerator = segmentResult.GetAsyncEnumerator();
+
+            while (await asyncEnumerator.MoveNextAsync())
+            {
+                blobList.Add(asyncEnumerator.Current);
+            }
+
+            var statuses = blobList.Select(b => b.Blob.Name).ToArray();
+            Assert.Equal(3, statuses.Length);
+            Assert.Equal("timers/testhostid/TestProgram.TestTimer0/status", statuses[0]);
+            Assert.Equal("timers/testhostid/TestProgram.TestTimer1/status", statuses[1]);
+            Assert.Equal("timers/testhostid/TestProgram.TestTimer2/status", statuses[2]);
+        }
+
+        private async Task Cleanup()
+        {
+            var segmentResult = _scheduleMonitor.ContainerClient.GetBlobsByHierarchyAsync(prefix: _scheduleMonitor.TimerStatusPath);
+            var asyncEnumerator = segmentResult.GetAsyncEnumerator();
+
+            while (await asyncEnumerator.MoveNextAsync())
+            {
+                _scheduleMonitor.ContainerClient.DeleteBlobIfExistsAsync(asyncEnumerator.Current.Blob.Name).Wait();
+            }
+        }
+
+        public void Dispose()
+        {
+            Cleanup().GetAwaiter().GetResult();
+        }
+
+        private static StorageScheduleMonitor CreateScheduleMonitor(string hostId = null)
+        {
+            var config = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+            var lockContainerManager = new DistributedLockManagerContainerProvider();
+            ILoggerFactory loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(new TestLoggerProvider());
+
+            var blobServiceClientProvider = GetAzureStorageService<BlobServiceClientProvider>(config);
+            HostStorageProvider hostStorageProvider = new HostStorageProvider(config, blobServiceClientProvider);
+
+            return new StorageScheduleMonitor(lockContainerManager, new TestIdProvider(hostId), config, loggerFactory, hostStorageProvider);
+        }
+
+        private static T GetAzureStorageService<T>(IConfiguration configuration)
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddHostStorageProvider();
+            serviceCollection.AddSingleton(configuration); // Override configuration
+            ServiceProvider provider = serviceCollection.BuildServiceProvider();
+            var service = provider.GetService<T>();
+            return service;
+        }
+
+        private class TestIdProvider : Host.Executors.IHostIdProvider
+        {
+            private readonly string _hostId;
+
+            public TestIdProvider(string hostId)
+            {
+                _hostId = hostId;
+            }
+
+            public Task<string> GetHostIdAsync(CancellationToken cancellationToken)
+            {
+                return Task.FromResult<string>(_hostId);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.Twilio.Tests/WebJobs.Extensions.Twilio.Tests.csproj
+++ b/test/WebJobs.Extensions.Twilio.Tests/WebJobs.Extensions.Twilio.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
- StorageScheduleMonitor now uses AzureStorageProvider in WebJobs.Host.Storage for storage dependency