### PR TITLE
Cosmos DB: Increase extension version

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>4.0.3$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>3.0.9$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>3.0.10$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.0.12$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.1$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DocumentDB.ChangeFeedProcessor" Version="2.3.2" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.12.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.13.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Increasing extension version for new release that includes:

* https://github.com/Azure/azure-webjobs-sdk-extensions/pull/712
* https://github.com/Azure/azure-webjobs-sdk-extensions/pull/710
* https://github.com/Azure/azure-webjobs-sdk-extensions/pull/691

Also increasing SDK dependency to cover improvements done in availability mechanics (failover detection).