### PR TITLE
Added direct references to System.Text.Encodings.Web 4.5.1.

### DIFF
--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.25" />
     <PackageReference Include="SendGrid" Version="9.10.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Extensions.Tests.Common/WebJobs.Extensions.Tests.Common.csproj
+++ b/test/WebJobs.Extensions.Tests.Common/WebJobs.Extensions.Tests.Common.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
Addresses CVE-2021-26701. Part of https://github.com/Azure/azure-functions-vs-build-sdk/issues/502

See https://github.com/dotnet/announcements/issues/178 for more information.