### PR TITLE
Updated HTTP and SendGrid extension versions.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,9 +4,9 @@
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>4.0.3$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
     <CosmosDBVersion>3.0.10$(VersionSuffix)</CosmosDBVersion>
-    <HttpVersion>3.1.0$(VersionSuffix)</HttpVersion>
+    <HttpVersion>3.1.1$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
-    <SendGridVersion>3.0.1$(VersionSuffix)</SendGridVersion>
+    <SendGridVersion>3.0.2$(VersionSuffix)</SendGridVersion>
     <TwilioVersion>3.0.1$(VersionSuffix)</TwilioVersion>
     <DebugType>embedded</DebugType>    
     <LatestCommit Condition="$(LatestCommit) == ''">$(CommitHash)</LatestCommit>


### PR DESCRIPTION
Pairs with https://github.com/Azure/azure-webjobs-sdk-extensions/commit/3f93611297a929e6fefc0235f03c00dc2ccfcffa. Preparation for creating new release.