### PR TITLE
Cosmos DB: Add support for Gremlin accounts

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Gremlin accounts support Change Feed using the SQL API, but until V3 SDK, they could not use the Change Feed Processor.

V3 added support for Gremlin recently (https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2491).

This PR adds the required logic to the CreateIfNotExist for lease collections.