### PR TITLE
[Cosmos DB] Rename ConnectionStringSetting and collection

### DIFF
--- a/src/ExtensionsSample/Samples/CosmosDBTriggerSamples.cs
+++ b/src/ExtensionsSample/Samples/CosmosDBTriggerSamples.cs
@@ -23,7 +23,7 @@ namespace ExtensionsSample
         // Sample implementation of the CosmosDBTrigger that listens for changes in a collection.
         // The trigger uses an auxiliary collection for leases for multiple partitions.
         public static void Listen(
-            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseCollectionName = "Leases")] IReadOnlyList<Document> modifiedDocuments,
+            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseContainerName = "Leases")] IReadOnlyList<Document> modifiedDocuments,
             TraceWriter log)
         {
             foreach (Document modifiedDocument in modifiedDocuments)
@@ -33,7 +33,7 @@ namespace ExtensionsSample
         }
 
         public static void ListenJArray(
-            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseCollectionName = "Leases")] JArray modifiedDocuments,
+            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseContainerName = "Leases")] JArray modifiedDocuments,
             TraceWriter log)
         {
             foreach (var modifiedDocument in modifiedDocuments.Children())
@@ -46,7 +46,7 @@ namespace ExtensionsSample
         // The trigger uses an auxiliary collection for leases for multiple partitions.
         // This sample will also copy modifications to another target collection.        
         public static async Task ListenAndCopy(
-            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseCollectionName = "Leases")] IReadOnlyList<Document> modifiedDocuments,
+            [CosmosDBTrigger("ItemDb", "ItemCollection", LeaseContainerName = "Leases")] IReadOnlyList<Document> modifiedDocuments,
             [CosmosDB("ItemDb", "ItemCollectionCopy")] IAsyncCollector<Document> copyItems)
         {
             foreach (Document modifiedDocument in modifiedDocuments)

--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBAsyncCollector.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBAsyncCollector.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     else
                     {
                         // Throw a custom error so that it's easier to decipher.
-                        string message = $"The collection '{_docDBContext.ResolvedAttribute.CollectionName}' (in database '{_docDBContext.ResolvedAttribute.DatabaseName}') does not exist. To automatically create the collection, set '{nameof(CosmosDBAttribute.CreateIfNotExists)}' to 'true'.";
+                        string message = $"The collection '{_docDBContext.ResolvedAttribute.ContainerName}' (in database '{_docDBContext.ResolvedAttribute.DatabaseName}') does not exist. To automatically create the collection, set '{nameof(CosmosDBAttribute.CreateIfNotExists)}' to 'true'.";
                         throw new InvalidOperationException(message, ex);
                     }
                 }
@@ -62,10 +62,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             if (item is string)
             {
                 JObject asJObject = JObject.Parse(item.ToString());
-                return context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.CollectionName).UpsertItemAsync(asJObject);
+                return context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.ContainerName).UpsertItemAsync(asJObject);
             }
 
-            return context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.CollectionName).UpsertItemAsync(item);
+            return context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.ContainerName).UpsertItemAsync(item);
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBAsyncCollector.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBAsyncCollector.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     else
                     {
                         // Throw a custom error so that it's easier to decipher.
-                        string message = $"The collection '{_docDBContext.ResolvedAttribute.ContainerName}' (in database '{_docDBContext.ResolvedAttribute.DatabaseName}') does not exist. To automatically create the collection, set '{nameof(CosmosDBAttribute.CreateIfNotExists)}' to 'true'.";
+                        string message = $"The container '{_docDBContext.ResolvedAttribute.ContainerName}' (in database '{_docDBContext.ResolvedAttribute.DatabaseName}') does not exist. To automatically create the container, set '{nameof(CosmosDBAttribute.CreateIfNotExists)}' to 'true'.";
                         throw new InvalidOperationException(message, ex);
                     }
                 }

--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings
                 throw new ArgumentNullException(nameof(attribute));
             }
 
-            string resolvedConnectionString = _configProvider.ResolveConnectionString(attribute.ConnectionStringSetting);
+            string resolvedConnectionString = _configProvider.ResolveConnectionString(attribute.Connection);
             return _configProvider.GetService(
                 connectionString: resolvedConnectionString, 
                 preferredLocations: attribute.PreferredLocations);

--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBEnumerableBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBEnumerableBuilder.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
             List<T> finalResults = new List<T>();
 
-            Container container = context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.CollectionName);
+            Container container = context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.ContainerName);
 
             QueryDefinition queryDefinition = null;
             if (!string.IsNullOrEmpty(attribute.SqlQuery))

--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBItemValueBinder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBItemValueBinder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             {
                 try
                 {
-                    document = await _context.Service.GetContainer(_context.ResolvedAttribute.DatabaseName, _context.ResolvedAttribute.CollectionName)
+                    document = await _context.Service.GetContainer(_context.ResolvedAttribute.DatabaseName, _context.ResolvedAttribute.ContainerName)
                         .ReadItemAsync<T>(_context.ResolvedAttribute.Id, partitionKey);
 
                     _originalItem = JObject.FromObject(document);
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
             else
             {
-                JObject jObject = await _context.Service.GetContainer(_context.ResolvedAttribute.DatabaseName, _context.ResolvedAttribute.CollectionName)
+                JObject jObject = await _context.Service.GetContainer(_context.ResolvedAttribute.DatabaseName, _context.ResolvedAttribute.ContainerName)
                         .ReadItemAsync<JObject>(_context.ResolvedAttribute.Id, partitionKey);
                 _originalItem = jObject;
 
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     throw new InvalidOperationException(string.Format("The document must have an 'id' property."));
                 }
 
-                Container container = context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.CollectionName);
+                Container container = context.Service.GetContainer(context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.ContainerName);
                 await container.ReplaceItemAsync<T>(newItem, originalId);
             }
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -83,9 +83,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         internal void ValidateConnection(CosmosDBAttribute attribute, Type paramType)
         {
             if (string.IsNullOrEmpty(_options.ConnectionString) &&
-                string.IsNullOrEmpty(attribute.ConnectionStringSetting))
+                string.IsNullOrEmpty(attribute.Connection))
             {
-                string attributeProperty = $"{nameof(CosmosDBAttribute)}.{nameof(CosmosDBAttribute.ConnectionStringSetting)}";
+                string attributeProperty = $"{nameof(CosmosDBAttribute)}.{nameof(CosmosDBAttribute.Connection)}";
                 string optionsProperty = $"{nameof(CosmosDBOptions)}.{nameof(CosmosDBOptions.ConnectionString)}";
                 throw new InvalidOperationException(
                     $"The CosmosDB connection string must be set either via the '{Constants.DefaultConnectionStringName}' IConfiguration connection string, via the {attributeProperty} property or via {optionsProperty}.");
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         internal CosmosClient BindForClient(CosmosDBAttribute attribute)
         {
-            string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
+            string resolvedConnectionString = ResolveConnectionString(attribute.Connection);
             return GetService(
                 connectionString: resolvedConnectionString, 
                 preferredLocations: attribute.PreferredLocations);
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         internal CosmosDBContext CreateContext(CosmosDBAttribute attribute)
         {
-            string resolvedConnectionString = ResolveConnectionString(attribute.ConnectionStringSetting);
+            string resolvedConnectionString = ResolveConnectionString(attribute.Connection);
 
             CosmosClient service = GetService(
                 connectionString: resolvedConnectionString, 

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the connection string for the service containing the collection to monitor.
         /// </summary>
         [ConnectionString]
-        public string ConnectionStringSetting { get; set; }
+        public string Connection { get; set; }
 
         /// <summary>
         /// Gets or sets the Id of the document to retrieve from the collection.

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 
@@ -36,11 +35,11 @@ namespace Microsoft.Azure.WebJobs
         /// Constructs a new instance.
         /// </summary>
         /// <param name="databaseName">The Azure Cosmos database name.</param>
-        /// <param name="collectionName">The Azure Cosmos container name.</param>
-        public CosmosDBAttribute(string databaseName, string collectionName)
+        /// <param name="containerName">The Azure Cosmos container name.</param>
+        public CosmosDBAttribute(string databaseName, string containerName)
         {
             DatabaseName = databaseName;
-            CollectionName = collectionName;
+            ContainerName = containerName;
         }
 
         /// <summary>
@@ -51,14 +50,14 @@ namespace Microsoft.Azure.WebJobs
         public string DatabaseName { get; private set; }
 
         /// <summary>
-        /// Gets the name of the collection to which the parameter applies. 
+        /// Gets the name of the container to which the parameter applies. 
         /// May include binding parameters.
         /// </summary>
         [AutoResolve]
-        public string CollectionName { get; private set; }
+        public string ContainerName { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the database and collection will be automatically created if they do not exist.
+        /// Gets or sets a value indicating whether the database and container will be automatically created if they do not exist.
         /// </summary>
         /// <remarks>
         /// Only applies to output bindings.
@@ -66,13 +65,13 @@ namespace Microsoft.Azure.WebJobs
         public bool CreateIfNotExists { get; set; }
 
         /// <summary>
-        /// Gets or sets the connection string for the service containing the collection to monitor.
+        /// Gets or sets the connection string for the service containing the container to monitor.
         /// </summary>
         [ConnectionString]
         public string Connection { get; set; }
 
         /// <summary>
-        /// Gets or sets the Id of the document to retrieve from the collection.
+        /// Gets or sets the Id of the document to retrieve from the container.
         /// May include binding parameters.
         /// </summary>
         [AutoResolve]
@@ -87,13 +86,12 @@ namespace Microsoft.Azure.WebJobs
         public string PartitionKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the throughput to be used when creating the collection if <see cref="CreateIfNotExists"/> is true.
-        /// collection.
+        /// Gets or sets the throughput to be used when creating the container if <see cref="CreateIfNotExists"/> is true.
         /// </summary>
-        public int? CollectionThroughput { get; set; }
+        public int? ContainerThroughput { get; set; }
 
         /// <summary>
-        /// Gets or sets a sql query expression for an input binding to execute on the collection and produce results.
+        /// Gets or sets a sql query expression for an input binding to execute on the container and produce results.
         /// May include binding parameters.
         /// </summary>
         [AutoResolve(ResolutionPolicyType = typeof(CosmosDBSqlResolutionPolicy))]

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         internal static async Task CreateDatabaseAndCollectionIfNotExistAsync(CosmosDBContext context)
         {
-            await CreateDatabaseAndCollectionIfNotExistAsync(context.Service, context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.CollectionName,
-                context.ResolvedAttribute.PartitionKey, context.ResolvedAttribute.CollectionThroughput);
+            await CreateDatabaseAndCollectionIfNotExistAsync(context.Service, context.ResolvedAttribute.DatabaseName, context.ResolvedAttribute.ContainerName,
+                context.ResolvedAttribute.PartitionKey, context.ResolvedAttribute.ContainerThroughput);
         }
 
         internal static async Task CreateDatabaseAndCollectionIfNotExistAsync(CosmosClient service, string databaseName, string containerName, string partitionKey, int? throughput)

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the connection string for the service containing the collection to monitor.
         /// </summary>
         [ConnectionString]
-        public string ConnectionStringSetting { get; set; }
+        public string Connection { get; set; }
 
         /// <summary>
         /// Gets the name of the collection to monitor for changes.
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the connection string for the service containing the lease collection.
         /// </summary>
         [ConnectionString]
-        public string LeaseConnectionStringSetting { get; set; }
+        public string LeaseConnection { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the lease collection. Default value is "leases".

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -16,75 +16,75 @@ namespace Microsoft.Azure.WebJobs
     public sealed class CosmosDBTriggerAttribute : Attribute
     {
         /// <summary>
-        /// Triggers an event when changes occur on a monitored collection.
+        /// Triggers an event when changes occur on a monitored container.
         /// </summary>
-        /// <param name="databaseName">Name of the database of the collection to monitor for changes.</param>
-        /// <param name="collectionName">Name of the collection to monitor for changes.</param>
-        public CosmosDBTriggerAttribute(string databaseName, string collectionName)
+        /// <param name="databaseName">Name of the database of the container to monitor for changes.</param>
+        /// <param name="containerName">Name of the container to monitor for changes.</param>
+        public CosmosDBTriggerAttribute(string databaseName, string containerName)
         {
-            if (string.IsNullOrWhiteSpace(collectionName))
+            if (string.IsNullOrWhiteSpace(containerName))
             {
-                throw new ArgumentException("Missing information for the collection to monitor", "collectionName");
+                throw new ArgumentException("Missing information for the container to monitor", "containerName");
             }
 
             if (string.IsNullOrWhiteSpace(databaseName))
             {
-                throw new ArgumentException("Missing information for the collection to monitor", "databaseName");
+                throw new ArgumentException("Missing information for the container to monitor", "databaseName");
             }
 
-            CollectionName = collectionName;
+            ContainerName = containerName;
             DatabaseName = databaseName;
-            LeaseCollectionName = CosmosDBTriggerConstants.DefaultLeaseCollectionName;
+            LeaseContainerName = CosmosDBTriggerConstants.DefaultLeaseCollectionName;
             LeaseDatabaseName = this.DatabaseName;
         }
 
         /// <summary>
-        /// Gets or sets the connection string for the service containing the collection to monitor.
+        /// Gets or sets the connection string for the service containing the container to monitor.
         /// </summary>
         [ConnectionString]
         public string Connection { get; set; }
 
         /// <summary>
-        /// Gets the name of the collection to monitor for changes.
+        /// Gets the name of the container to monitor for changes.
         /// </summary>
-        public string CollectionName { get; private set; }
+        public string ContainerName { get; private set; }
 
         /// <summary>
-        /// Gets the name of the database containing the collection to monitor for changes.
+        /// Gets the name of the database containing the container to monitor for changes.
         /// </summary>
         public string DatabaseName { get; private set; }
 
         /// <summary>
-        /// Gets or sets the connection string for the service containing the lease collection.
+        /// Gets or sets the connection string for the service containing the lease container.
         /// </summary>
         [ConnectionString]
         public string LeaseConnection { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the lease collection. Default value is "leases".
+        /// Gets or sets the name of the lease container. Default value is "leases".
         /// </summary>
-        public string LeaseCollectionName { get; set; }
+        public string LeaseContainerName { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the database containing the lease collection.
+        /// Gets or sets the name of the database containing the lease container.
         /// </summary>
         public string LeaseDatabaseName { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the database and collection for leases will be automatically created if it does not exist.
+        /// Gets or sets a value indicating whether the database and container for leases will be automatically created if it does not exist.
         /// </summary>
-        public bool CreateLeaseCollectionIfNotExists { get; set; } = false;
+        public bool CreateLeaseContainerIfNotExists { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the throughput to be used when creating the collection if <see cref="CreateLeaseCollectionIfNotExists"/> is true.
-        /// collection.
+        /// Gets or sets the throughput to be used when creating the container if <see cref="CreateLeaseContainerIfNotExists"/> is true.
+        /// container.
         /// </summary>
-        public int? LeasesCollectionThroughput { get; set; }
+        public int? LeasesContainerThroughput { get; set; }
 
         /// <summary>
-        /// Gets or sets a prefix to be used within a Leases collection for this Trigger. Useful when sharing the same Lease collection among multiple Triggers.
+        /// Gets or sets a prefix to be used within a Leases container for this Trigger. Useful when sharing the same Lease container among multiple Triggers.
         /// </summary>
-        public string LeaseCollectionPrefix { get; set; }
+        public string LeaseContainerPrefix { get; set; }
         
         /// <summary>
         /// Gets or sets the delay in milliseconds in between polling a partition for new changes on the feed, after all current changes are drained.  Default is 5000 (5 seconds).

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         private string ResolveAttributeConnectionString(CosmosDBTriggerAttribute attribute)
         {
-            string connectionString = ResolveConnectionString(attribute.ConnectionStringSetting, nameof(CosmosDBTriggerAttribute.ConnectionStringSetting));
+            string connectionString = ResolveConnectionString(attribute.Connection, nameof(CosmosDBTriggerAttribute.Connection));
 
             if (string.IsNullOrEmpty(connectionString))
             {
@@ -163,13 +163,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private string ResolveAttributeLeasesConnectionString(CosmosDBTriggerAttribute attribute)
         {
             // If the lease connection string is not set, use the trigger's
-            string keyToResolve = attribute.LeaseConnectionStringSetting;
+            string keyToResolve = attribute.LeaseConnection;
             if (string.IsNullOrEmpty(keyToResolve))
             {
-                keyToResolve = attribute.ConnectionStringSetting;
+                keyToResolve = attribute.Connection;
             }
 
-            string connectionString = ResolveConnectionString(keyToResolve, nameof(CosmosDBTriggerAttribute.LeaseConnectionStringSetting));
+            string connectionString = ResolveConnectionString(keyToResolve, nameof(CosmosDBTriggerAttribute.LeaseConnection));
 
             if (string.IsNullOrEmpty(connectionString))
             {
@@ -182,8 +182,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private void ThrowMissingConnectionStringException(bool isLeaseConnectionString = false)
         {
             string attributeProperty = isLeaseConnectionString ?
-                $"{nameof(CosmosDBTriggerAttribute)}.{nameof(CosmosDBTriggerAttribute.LeaseConnectionStringSetting)}" :
-                $"{nameof(CosmosDBTriggerAttribute)}.{nameof(CosmosDBTriggerAttribute.ConnectionStringSetting)}";
+                $"{nameof(CosmosDBTriggerAttribute)}.{nameof(CosmosDBTriggerAttribute.LeaseConnection)}" :
+                $"{nameof(CosmosDBTriggerAttribute)}.{nameof(CosmosDBTriggerAttribute.Connection)}";
 
             string optionsProperty = $"{nameof(CosmosDBOptions)}.{nameof(CosmosDBOptions.ConnectionString)}";
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 string triggerConnectionString = ResolveAttributeConnectionString(attribute);
                 if (string.IsNullOrEmpty(triggerConnectionString))
                 {
-                    throw new InvalidOperationException("The connection string for the monitored collection is in an invalid format, please use AccountEndpoint=XXXXXX;AccountKey=XXXXXX;.");
+                    throw new InvalidOperationException("The connection string for the monitored container is in an invalid format, please use AccountEndpoint=XXXXXX;AccountKey=XXXXXX;.");
                 }
 
                 string leasesConnectionString = ResolveAttributeLeasesConnectionString(attribute);
                 if (string.IsNullOrEmpty(leasesConnectionString))
                 {
-                    throw new InvalidOperationException("The connection string for the leases collection is in an invalid format, please use AccountEndpoint=XXXXXX;AccountKey=XXXXXX;.");
+                    throw new InvalidOperationException("The connection string for the leases container is in an invalid format, please use AccountEndpoint=XXXXXX;AccountKey=XXXXXX;.");
                 }
 
                 if (string.IsNullOrEmpty(monitoredDatabaseName)
@@ -78,14 +78,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     || string.IsNullOrEmpty(leasesDatabaseName)
                     || string.IsNullOrEmpty(leasesCollectionName))
                 {
-                    throw new InvalidOperationException("Cannot establish database and collection values. If you are using environment and configuration values, please ensure these are correctly set.");
+                    throw new InvalidOperationException("Cannot establish database and container values. If you are using environment and configuration values, please ensure these are correctly set.");
                 }
 
                 if (triggerConnectionString.Equals(leasesConnectionString, StringComparison.InvariantCultureIgnoreCase)
                     && monitoredDatabaseName.Equals(leasesDatabaseName, StringComparison.InvariantCultureIgnoreCase)
                     && monitoredCollectionName.Equals(leasesCollectionName, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    throw new InvalidOperationException("The monitored collection cannot be the same as the collection storing the leases.");
+                    throw new InvalidOperationException("The monitored container cannot be the same as the container storing the leases.");
                 }
 
                 CosmosClient monitoredCosmosDBService = _configProvider.GetService(
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException(string.Format("Cannot create Collection Information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.ContainerName, attribute.DatabaseName, attribute.LeaseContainerName, attribute.LeaseDatabaseName, ex.Message), ex);
+                throw new InvalidOperationException(string.Format("Cannot create container information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.ContainerName, attribute.DatabaseName, attribute.LeaseContainerName, attribute.LeaseDatabaseName, ex.Message), ex);
             }
 
             return new CosmosDBTriggerBinding<T>(

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             Container monitoredContainer;
             Container leasesContainer;
             string monitoredDatabaseName = ResolveAttributeValue(attribute.DatabaseName);
-            string monitoredCollectionName = ResolveAttributeValue(attribute.CollectionName);
+            string monitoredCollectionName = ResolveAttributeValue(attribute.ContainerName);
             string leasesDatabaseName = ResolveAttributeValue(attribute.LeaseDatabaseName);
-            string leasesCollectionName = ResolveAttributeValue(attribute.LeaseCollectionName);
-            string processorName = ResolveAttributeValue(attribute.LeaseCollectionPrefix) ?? string.Empty;
+            string leasesCollectionName = ResolveAttributeValue(attribute.LeaseContainerName);
+            string processorName = ResolveAttributeValue(attribute.LeaseContainerPrefix) ?? string.Empty;
             string preferredLocations = ResolveAttributeValue(attribute.PreferredLocations);
 
             try
@@ -97,9 +97,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                     preferredLocations: preferredLocations, 
                     userAgent: CosmosDBTriggerUserAgentSuffix);
 
-                if (attribute.CreateLeaseCollectionIfNotExists)
+                if (attribute.CreateLeaseContainerIfNotExists)
                 {
-                    await CreateLeaseCollectionIfNotExistsAsync(leaseCosmosDBService, leasesDatabaseName, leasesCollectionName, attribute.LeasesCollectionThroughput);
+                    await CreateLeaseCollectionIfNotExistsAsync(leaseCosmosDBService, leasesDatabaseName, leasesCollectionName, attribute.LeasesContainerThroughput);
                 }
 
                 monitoredContainer = monitoredCosmosDBService.GetContainer(monitoredDatabaseName, monitoredCollectionName);
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException(string.Format("Cannot create Collection Information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.CollectionName, attribute.DatabaseName, attribute.LeaseCollectionName, attribute.LeaseDatabaseName, ex.Message), ex);
+                throw new InvalidOperationException(string.Format("Cannot create Collection Information for {0} in database {1} with lease {2} in database {3} : {4}", attribute.ContainerName, attribute.DatabaseName, attribute.LeaseContainerName, attribute.LeaseDatabaseName, ex.Message), ex);
             }
 
             return new CosmosDBTriggerBinding<T>(

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerConstants.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerConstants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         public const string TriggerName = "CosmosDBTrigger";
 
-        public const string TriggerDescription = "New changes on collection {0} at {1}";
+        public const string TriggerDescription = "New changes on container {0} at {1}";
 
         public const string InvokeString = "{0} changes detected.";
     }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 if (ex is CosmosException docEx && docEx.StatusCode == HttpStatusCode.NotFound)
                 {
                     // Throw a custom error so that it's easier to decipher.
-                    string message = $"Either the source collection '{this._cosmosDBAttribute.CollectionName}' (in database '{this._cosmosDBAttribute.DatabaseName}')  or the lease collection '{this._cosmosDBAttribute.LeaseCollectionName}' (in database '{this._cosmosDBAttribute.LeaseDatabaseName}') does not exist. Both collections must exist before the listener starts. To automatically create the lease collection, set '{nameof(CosmosDBTriggerAttribute.CreateLeaseCollectionIfNotExists)}' to 'true'.";
+                    string message = $"Either the source collection '{this._cosmosDBAttribute.ContainerName}' (in database '{this._cosmosDBAttribute.DatabaseName}')  or the lease collection '{this._cosmosDBAttribute.LeaseContainerName}' (in database '{this._cosmosDBAttribute.LeaseDatabaseName}') does not exist. Both collections must exist before the listener starts. To automatically create the lease collection, set '{nameof(CosmosDBTriggerAttribute.CreateLeaseContainerIfNotExists)}' to 'true'.";
                     this._host = null;
                     throw new InvalidOperationException(message, ex);
                 }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -37,14 +37,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         private static readonly Dictionary<string, string> KnownDocumentClientErrors = new Dictionary<string, string>()
         {
-            { "Resource Not Found", "Please check that the CosmosDB collection and leases collection exist and are listed correctly in Functions config files." },
+            { "Resource Not Found", "Please check that the CosmosDB container and leases container exist and are listed correctly in Functions config files." },
             { "The input authorization token can't serve the request", string.Empty },
             { "The MAC signature found in the HTTP request is not the same", string.Empty },
             { "Service is currently unavailable.", string.Empty },
             { "Entity with the specified id does not exist in the system.", string.Empty },
             { "Subscription owning the database account is disabled.", string.Empty },
             { "Request rate is large", string.Empty },
-            { "PartitionKey value must be supplied for this operation.", "We do not support lease collections with partitions at this time. Please create a new lease collection without partitions." },
+            { "PartitionKey value must be supplied for this operation.", "We do not support lease containers with partitions at this time. Please create a new lease collection without partitions." },
             { "The remote name could not be resolved:", string.Empty },
             { "Owner resource does not exist", string.Empty },
             { "The specified document collection is invalid", string.Empty }
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 if (ex is CosmosException docEx && docEx.StatusCode == HttpStatusCode.NotFound)
                 {
                     // Throw a custom error so that it's easier to decipher.
-                    string message = $"Either the source collection '{this._cosmosDBAttribute.ContainerName}' (in database '{this._cosmosDBAttribute.DatabaseName}')  or the lease collection '{this._cosmosDBAttribute.LeaseContainerName}' (in database '{this._cosmosDBAttribute.LeaseDatabaseName}') does not exist. Both collections must exist before the listener starts. To automatically create the lease collection, set '{nameof(CosmosDBTriggerAttribute.CreateLeaseContainerIfNotExists)}' to 'true'.";
+                    string message = $"Either the source container '{this._cosmosDBAttribute.ContainerName}' (in database '{this._cosmosDBAttribute.DatabaseName}')  or the lease container '{this._cosmosDBAttribute.LeaseContainerName}' (in database '{this._cosmosDBAttribute.LeaseDatabaseName}') does not exist. Both containers must exist before the listener starts. To automatically create the lease container, set '{nameof(CosmosDBTriggerAttribute.CreateLeaseContainerIfNotExists)}' to 'true'.";
                     this._host = null;
                     throw new InvalidOperationException(message, ex);
                 }
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 status.Vote = ScaleVote.ScaleIn;
                 _logger.LogInformation(string.Format($"WorkerCount ({workerCount}) > PartitionCount ({partitionCount})."));
                 _logger.LogInformation(string.Format($"Number of instances ({workerCount}) is too high relative to number " +
-                                                     $"of partitions for collection ({this._monitoredContainer.Id}, {partitionCount})."));
+                                                     $"of partitions for container ({this._monitoredContainer.Id}, {partitionCount})."));
                 return status;
             }
 
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             {
                 status.Vote = ScaleVote.ScaleOut;
                 _logger.LogInformation(string.Format($"RemainingWork ({latestRemainingWork}) > WorkerCount ({workerCount}) * 1,000."));
-                _logger.LogInformation(string.Format($"Remaining work for collection ({this._monitoredContainer.Id}, {latestRemainingWork}) " +
+                _logger.LogInformation(string.Format($"Remaining work for container ({this._monitoredContainer.Id}, {latestRemainingWork}) " +
                                                      $"is too high relative to the number of instances ({workerCount})."));
                 return status;
             }
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             if (documentsWaiting && partitionCount > 0 && partitionCount > workerCount)
             {
                 status.Vote = ScaleVote.ScaleOut;
-                _logger.LogInformation(string.Format($"CosmosDB collection '{this._monitoredContainer.Id}' has documents waiting to be processed."));
+                _logger.LogInformation(string.Format($"CosmosDB container '{this._monitoredContainer.Id}' has documents waiting to be processed."));
                 _logger.LogInformation(string.Format($"There are {workerCount} instances relative to {partitionCount} partitions."));
                 return status;
             }
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 return status;
             }
 
-            _logger.LogInformation($"CosmosDB collection '{this._monitoredContainer.Id}' is steady.");
+            _logger.LogInformation($"CosmosDB container '{this._monitoredContainer.Id}' is steady.");
 
             return status;
         }

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.0-beta009" />

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.0-beta009" />

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void Trigger(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseCollectionIfNotExists = true)]IReadOnlyList<Item> documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true)]IReadOnlyList<Item> documents,
                 ILogger log)
             {
                 foreach (var document in documents)
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void TriggerWithString(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseCollectionIfNotExists = true, LeaseCollectionPrefix = "withstring")] string documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "withstring")] string documents,
                 ILogger log)
             {
                 foreach (var document in JArray.Parse(documents))

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             [NoAutomaticTrigger]
             public static void TriggerObject(
                 [QueueTrigger("fakequeue1")] QueueData triggerData,
-                [CosmosDB(DatabaseName, CollectionName, Id = "{DocumentId}", PartitionKey = "{PartitionKey}", ConnectionStringSetting = "MyConnectionString")] dynamic item1,
+                [CosmosDB(DatabaseName, CollectionName, Id = "{DocumentId}", PartitionKey = "{PartitionKey}", Connection = "MyConnectionString")] dynamic item1,
                 TraceWriter trace)
             {
                 Assert.NotNull(item1);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBTestUtility.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBTestUtility.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             {
                 CreateIfNotExists = createIfNotExists,
                 PartitionKey = partitionKeyPath,
-                CollectionThroughput = throughput
+                ContainerThroughput = throughput
             };
 
             return new CosmosDBContext

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             Assert.NotEqual(default(DateTime), metrics.Timestamp);
 
             var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.Equal("Please check that the CosmosDB collection and leases collection exist and are listed correctly in Functions config files.", warning.FormattedMessage);
+            Assert.Equal("Please check that the CosmosDB container and leases container exist and are listed correctly in Functions config files.", warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await _listener.GetMetricsAsync());
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             Assert.Equal("WorkerCount (2) > PartitionCount (1).", log.FormattedMessage);
             log = logs[1];
             Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Information, log.Level);
-            Assert.Equal($"Number of instances (2) is too high relative to number of partitions for collection ({ContainerName}, 1).", log.FormattedMessage);
+            Assert.Equal($"Number of instances (2) is too high relative to number of partitions for container ({ContainerName}, 1).", log.FormattedMessage);
         }
 
         [Fact]
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             Assert.Equal("RemainingWork (2900) > WorkerCount (1) * 1,000.", log.FormattedMessage);
             log = logs[1];
             Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Information, log.Level);
-            Assert.Equal($"Remaining work for collection ({ContainerName}, 2900) is too high relative to the number of instances (1).", log.FormattedMessage);
+            Assert.Equal($"Remaining work for container ({ContainerName}, 2900) is too high relative to the number of instances (1).", log.FormattedMessage);
         }
 
         [Fact]
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             var logs = _loggerProvider.GetAllLogMessages().ToArray();
             var log = logs[0];
             Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Information, log.Level);
-            Assert.Equal($"CosmosDB collection '{ContainerName}' has documents waiting to be processed.", log.FormattedMessage);
+            Assert.Equal($"CosmosDB container '{ContainerName}' has documents waiting to be processed.", log.FormattedMessage);
             log = logs[1];
             Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Information, log.Level);
             Assert.Equal("There are 1 instances relative to 2 partitions.", log.FormattedMessage);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
         [Fact]
         public async Task StartAsync_Retries()
         {
-            var attribute = new CosmosDBTriggerAttribute("test", "test") { LeaseCollectionPrefix = Guid.NewGuid().ToString() };
+            var attribute = new CosmosDBTriggerAttribute("test", "test") { LeaseContainerPrefix = Guid.NewGuid().ToString() };
            
             var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -428,11 +428,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
         // These will use the default for ConnectionStringSetting, but override LeaseConnectionStringSetting
         private static class ValidCosmosDBTriggerBindigsWithLeaseHostOptions
         {
-            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnection = "LeaseConnectionString", LeaseCollectionPrefix = "someLeasePrefix")] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnection = "LeaseConnectionString", LeaseContainerPrefix = "someLeasePrefix")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnection = "LeaseConnectionString", LeaseCollectionPrefix = "%dynamicLeasePrefix%")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnection = "LeaseConnectionString", LeaseContainerPrefix = "%dynamicLeasePrefix%")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -482,11 +482,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "notAConnectionString", LeaseConnection = "notAConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "notAConnectionString", LeaseConnection = "notAConnectionString", LeaseDatabaseName = "aDatabase", LeaseContainerName = "aCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "CosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "CosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseContainerName = "aCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "LeaseCosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "LeaseCosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseContainerName = "aLeaseCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             {
             }
 
-            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", LeaseDatabaseName = "aDatabase", LeaseContainerName = "aLeaseCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -650,7 +650,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
         private static class ValidCosmosDBTriggerBindingsCreateLeaseContainer
         {
-            public static void Func1([CosmosDBTrigger("ItemDB", "ItemCollection", CreateLeaseCollectionIfNotExists = true)] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("ItemDB", "ItemCollection", CreateLeaseContainerIfNotExists = true)] IReadOnlyList<dynamic> docs)
             {
             }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -428,11 +428,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
         // These will use the default for ConnectionStringSetting, but override LeaseConnectionStringSetting
         private static class ValidCosmosDBTriggerBindigsWithLeaseHostOptions
         {
-            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnectionStringSetting = "LeaseConnectionString", LeaseCollectionPrefix = "someLeasePrefix")] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnection = "LeaseConnectionString", LeaseCollectionPrefix = "someLeasePrefix")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnectionStringSetting = "LeaseConnectionString", LeaseCollectionPrefix = "%dynamicLeasePrefix%")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", LeaseConnection = "LeaseConnectionString", LeaseCollectionPrefix = "%dynamicLeasePrefix%")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -451,15 +451,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
         // These will set ConnectionStringSetting, which LeaseConnectionStringSetting should also use by default
         private static class ValidCosmosDBTriggerBindigsWithChangeFeedOptions
         {
-            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", MaxItemsPerInvocation = 10, StartFromBeginning = true)] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", MaxItemsPerInvocation = 10, StartFromBeginning = true)] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", MaxItemsPerInvocation = 10, StartFromTime = "2020-11-25T22:36:29Z")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", MaxItemsPerInvocation = 10, StartFromTime = "2020-11-25T22:36:29Z")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", MaxItemsPerInvocation = 10, StartFromBeginning = false, StartFromTime = "2020-11-25T22:36:29Z")] IReadOnlyList<dynamic> docs)
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", MaxItemsPerInvocation = 10, StartFromBeginning = false, StartFromTime = "2020-11-25T22:36:29Z")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -478,31 +478,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
         private static class InvalidCosmosDBTriggerBindings
         {
-            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString")] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", Connection = "notAConnectionString")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "notAConnectionString", LeaseConnectionStringSetting = "notAConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "notAConnectionString", LeaseConnection = "notAConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "CosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func3([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "CosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func4([CosmosDBTrigger("aDatabase", "leases", ConnectionStringSetting = "CosmosDBConnectionString")] IReadOnlyList<dynamic> docs)
+            public static void Func4([CosmosDBTrigger("aDatabase", "leases", Connection = "CosmosDBConnectionString")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func5([CosmosDBTrigger("aDatabase", "leases", ConnectionStringSetting = "CosmosDBConnectionString", StartFromBeginning = true, StartFromTime = "2020-11-25T22:36:29Z")] IReadOnlyList<dynamic> docs)
+            public static void Func5([CosmosDBTrigger("aDatabase", "leases", Connection = "CosmosDBConnectionString", StartFromBeginning = true, StartFromTime = "2020-11-25T22:36:29Z")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func6([CosmosDBTrigger("aDatabase", "leases", ConnectionStringSetting = "CosmosDBConnectionString", StartFromTime = "blah")] IReadOnlyList<dynamic> docs)
+            public static void Func6([CosmosDBTrigger("aDatabase", "leases", Connection = "CosmosDBConnectionString", StartFromTime = "blah")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func7([CosmosDBTrigger("aDatabase", "leases", ConnectionStringSetting = "CosmosDBConnectionString", StartFromBeginning = true, StartFromTime = "blah")] IReadOnlyList<dynamic> docs)
+            public static void Func7([CosmosDBTrigger("aDatabase", "leases", Connection = "CosmosDBConnectionString", StartFromBeginning = true, StartFromTime = "blah")] IReadOnlyList<dynamic> docs)
             {
             }
 
@@ -525,15 +525,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
         private static class ValidCosmosDBTriggerBindingsWithAppSettings
         {
-            public static void Func1([CosmosDBTrigger("%aDatabase%", "%aCollection%", ConnectionStringSetting = "CosmosDBConnectionString")] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("%aDatabase%", "%aCollection%", Connection = "CosmosDBConnectionString")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func2([CosmosDBTrigger("%aDatabase%", "%aCollection%", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "CosmosDBConnectionString", LeaseDatabaseName = "%aDatabase%")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("%aDatabase%", "%aCollection%", Connection = "CosmosDBConnectionString", LeaseConnection = "CosmosDBConnectionString", LeaseDatabaseName = "%aDatabase%")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func3([CosmosDBTrigger("%aDatabase%", "%aCollection%", ConnectionStringSetting = "CosmosDBConnectionString")] JArray docs)
+            public static void Func3([CosmosDBTrigger("%aDatabase%", "%aCollection%", Connection = "CosmosDBConnectionString")] JArray docs)
             {
             }
 
@@ -552,11 +552,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
         private static class ValidCosmosDBTriggerBindigsDifferentConnections
         {
-            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "LeaseCosmosDBConnectionString")] IReadOnlyList<dynamic> docs)
+            public static void Func1([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "LeaseCosmosDBConnectionString")] IReadOnlyList<dynamic> docs)
             {
             }
 
-            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", ConnectionStringSetting = "CosmosDBConnectionString", LeaseConnectionStringSetting = "LeaseCosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<dynamic> docs)
+            public static void Func2([CosmosDBTrigger("aDatabase", "aCollection", Connection = "CosmosDBConnectionString", LeaseConnection = "LeaseCosmosDBConnectionString", LeaseDatabaseName = "aDatabase", LeaseCollectionName = "aLeaseCollection")] IReadOnlyList<dynamic> docs)
             {
             }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeTests.cs
@@ -29,16 +29,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
             CosmosDBTriggerAttribute attributeWithNoLeaseSpecified = new CosmosDBTriggerAttribute(databaseName, collectionName);
 
-            Assert.Equal(collectionName, attributeWithNoLeaseSpecified.CollectionName);
+            Assert.Equal(collectionName, attributeWithNoLeaseSpecified.ContainerName);
             Assert.Equal(databaseName, attributeWithNoLeaseSpecified.DatabaseName);
-            Assert.Equal(defaultLeaseCollectionName, attributeWithNoLeaseSpecified.LeaseCollectionName);
+            Assert.Equal(defaultLeaseCollectionName, attributeWithNoLeaseSpecified.LeaseContainerName);
             Assert.Equal(databaseName, attributeWithNoLeaseSpecified.LeaseDatabaseName);
 
-            CosmosDBTriggerAttribute attributeWithLeaseSpecified = new CosmosDBTriggerAttribute(databaseName, collectionName) { LeaseDatabaseName = leaseDatabaseName, LeaseCollectionName = leaseCollectionName };
+            CosmosDBTriggerAttribute attributeWithLeaseSpecified = new CosmosDBTriggerAttribute(databaseName, collectionName) { LeaseDatabaseName = leaseDatabaseName, LeaseContainerName = leaseCollectionName };
 
-            Assert.Equal(collectionName, attributeWithLeaseSpecified.CollectionName);
+            Assert.Equal(collectionName, attributeWithLeaseSpecified.ContainerName);
             Assert.Equal(databaseName, attributeWithLeaseSpecified.DatabaseName);
-            Assert.Equal(leaseCollectionName, attributeWithLeaseSpecified.LeaseCollectionName);
+            Assert.Equal(leaseCollectionName, attributeWithLeaseSpecified.LeaseContainerName);
             Assert.Equal(leaseDatabaseName, attributeWithLeaseSpecified.LeaseDatabaseName);
         }
     }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
         public void MissingArguments_Fail()
         {
             ArgumentException missingDatabaseAndCollection = Assert.Throws<ArgumentException>(() => new CosmosDBTriggerAttribute(null, null));
-            Assert.Equal("collectionName", missingDatabaseAndCollection.ParamName);
+            Assert.Equal("containerName", missingDatabaseAndCollection.ParamName);
 
             ArgumentException missingDatabase = Assert.Throws<ArgumentException>(() => new CosmosDBTriggerAttribute(null, "someCollection"));
             Assert.Equal("databaseName", missingDatabase.ParamName);


### PR DESCRIPTION
Other extensions are using the name `Connection` for attribute mapping that works for connection strings (example https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/EventHubAttribute.cs#L33) but would also work for AAD information.

Since we are already on a breaking change train (moving to V3 SDK), might as well rename it to be consistent (anyway, using `ConnectionStringSetting` would not sound great for AAD).

As part of the naming alignment, V3 SDK documentation talks about Containers, not Collections anymore, so the property names like `CollectionName` are renamed to `ContainerName`.