### PR TITLE
Cosmos DB - Add Support for AAD authentication

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Bindings/CosmosDBClientBuilder.cs
@@ -22,9 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings
                 throw new ArgumentNullException(nameof(attribute));
             }
 
-            string resolvedConnectionString = _configProvider.ResolveConnectionString(attribute.Connection);
             return _configProvider.GetService(
-                connectionString: resolvedConnectionString, 
+                connection: attribute.Connection ?? Constants.DefaultConnectionStringName, 
                 preferredLocations: attribute.PreferredLocations);
         }
     }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
     [Extension("CosmosDB")]
     internal class CosmosDBExtensionConfigProvider : IExtensionConfigProvider
     {
-        private readonly IConfiguration _configuration;
         private readonly ICosmosDBServiceFactory _cosmosDBServiceFactory;
         private readonly ICosmosDBSerializerFactory _cosmosSerializerFactory;
         private readonly INameResolver _nameResolver;
@@ -34,11 +33,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             IOptions<CosmosDBOptions> options, 
             ICosmosDBServiceFactory cosmosDBServiceFactory, 
             ICosmosDBSerializerFactory cosmosSerializerFactory,
-            IConfiguration configuration, 
             INameResolver nameResolver, 
             ILoggerFactory loggerFactory)
         {
-            _configuration = configuration;
             _cosmosDBServiceFactory = cosmosDBServiceFactory;
             _cosmosSerializerFactory = cosmosSerializerFactory;
             _nameResolver = nameResolver;
@@ -77,16 +74,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
             // Trigger
             var rule2 = context.AddBindingRule<CosmosDBTriggerAttribute>();
-            rule2.BindToTrigger(new CosmosDBTriggerAttributeBindingProviderGenerator(_configuration, _nameResolver, _options, this, _loggerFactory));
+            rule2.BindToTrigger(new CosmosDBTriggerAttributeBindingProviderGenerator(_nameResolver, _options, this, _loggerFactory));
         }
 
         internal void ValidateConnection(CosmosDBAttribute attribute, Type paramType)
         {
-            if (string.IsNullOrEmpty(attribute.Connection))
+            if (attribute.Connection == string.Empty)
             {
                 string attributeProperty = $"{nameof(CosmosDBAttribute)}.{nameof(CosmosDBAttribute.Connection)}";
                 throw new InvalidOperationException(
-                    $"The CosmosDB connection must be set either via the '{Constants.DefaultConnectionStringName}' IConfiguration connection or via the {attributeProperty} property.");
+                    $"The {attributeProperty} property cannot be an empty value.");
             }
         }
 

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -82,22 +82,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         internal void ValidateConnection(CosmosDBAttribute attribute, Type paramType)
         {
-            if (string.IsNullOrEmpty(_options.ConnectionString) &&
-                string.IsNullOrEmpty(attribute.Connection))
+            if (string.IsNullOrEmpty(attribute.Connection))
             {
                 string attributeProperty = $"{nameof(CosmosDBAttribute)}.{nameof(CosmosDBAttribute.Connection)}";
-                string optionsProperty = $"{nameof(CosmosDBOptions)}.{nameof(CosmosDBOptions.ConnectionString)}";
                 throw new InvalidOperationException(
-                    $"The CosmosDB connection string must be set either via the '{Constants.DefaultConnectionStringName}' IConfiguration connection string, via the {attributeProperty} property or via {optionsProperty}.");
+                    $"The CosmosDB connection must be set either via the '{Constants.DefaultConnectionStringName}' IConfiguration connection or via the {attributeProperty} property.");
             }
-        }
-
-        internal CosmosClient BindForClient(CosmosDBAttribute attribute)
-        {
-            string resolvedConnectionString = ResolveConnectionString(attribute.Connection);
-            return GetService(
-                connectionString: resolvedConnectionString, 
-                preferredLocations: attribute.PreferredLocations);
         }
 
         internal Task<IValueBinder> BindForItemAsync(CosmosDBAttribute attribute, Type type)
@@ -115,31 +105,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return Task.FromResult(binder);
         }
 
-        internal string ResolveConnectionString(string attributeConnectionString)
+        internal CosmosClient GetService(string connection, string preferredLocations = "", string userAgent = "")
         {
-            // First, try the Attribute's string.
-            if (!string.IsNullOrEmpty(attributeConnectionString))
-            {
-                return attributeConnectionString;
-            }
-
-            // Then use the options.
-            return _options.ConnectionString;
-        }
-
-        internal CosmosClient GetService(string connectionString, string preferredLocations = "", string userAgent = "")
-        {
-            string cacheKey = BuildCacheKey(connectionString, preferredLocations);
+            string cacheKey = BuildCacheKey(connection, preferredLocations);
             CosmosClientOptions cosmosClientOptions = CosmosDBUtility.BuildClientOptions(_options.ConnectionMode, _cosmosSerializerFactory.CreateSerializer(), preferredLocations, userAgent);
-            return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connectionString, cosmosClientOptions));
+            return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connection, cosmosClientOptions));
         }
 
         internal CosmosDBContext CreateContext(CosmosDBAttribute attribute)
         {
-            string resolvedConnectionString = ResolveConnectionString(attribute.Connection);
-
             CosmosClient service = GetService(
-                connectionString: resolvedConnectionString, 
+                connection: attribute.Connection ?? Constants.DefaultConnectionStringName, 
                 preferredLocations: attribute.PreferredLocations);
 
             return new CosmosDBContext

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBOptions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBOptions.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
     public class CosmosDBOptions : IOptionsFormatter
     {
         /// <summary>
-        /// Gets or sets the CosmosDB connection string.
-        /// </summary>
-        public string ConnectionString { get; set; }
-
-        /// <summary>
         /// Gets or sets the ConnectionMode used in the CosmosClient instances.
         /// </summary>
         /// <remarks>Default is Gateway mode.</remarks>

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Extensions.Hosting
             builder.AddExtension<CosmosDBExtensionConfigProvider>()               
                 .ConfigureOptions<CosmosDBOptions>((config, path, options) =>
                 {
-                    options.ConnectionString = config.GetConnectionStringOrSetting(Constants.DefaultConnectionStringName);
-
                     IConfigurationSection section = config.GetSection(path);
                     section.Bind(options);
                 });                

--- a/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
@@ -1,15 +1,107 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using Azure.Core;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
     internal class DefaultCosmosDBServiceFactory : ICosmosDBServiceFactory
     {
-        public CosmosClient CreateService(string connectionString, CosmosClientOptions cosmosClientOptions)
+        private readonly IConfiguration _configuration;
+        private readonly AzureComponentFactory _componentFactory;
+
+        public DefaultCosmosDBServiceFactory(
+            IConfiguration configuration,
+            AzureComponentFactory componentFactory)
         {
-            return new CosmosClient(connectionString, cosmosClientOptions);
+            this._configuration = configuration;
+            this._componentFactory = componentFactory;
+        }
+
+        public CosmosClient CreateService(string connectionName, CosmosClientOptions cosmosClientOptions)
+        {
+            CosmosConnectionInformation cosmosConnectionInformation = this.ResolveConnectionInformation(connectionName);
+            if (cosmosConnectionInformation.UsesConnectionString)
+            {
+                // Connection string based auth
+                return new CosmosClient(cosmosConnectionInformation.ConnectionString, cosmosClientOptions);
+            }
+
+            // AAD auth
+            return new CosmosClient(cosmosConnectionInformation.AccountEndpoint, cosmosConnectionInformation.Credential, cosmosClientOptions);
+        }
+
+        private CosmosConnectionInformation ResolveConnectionInformation(string connection)
+        {
+            var connectionSetting = connection ?? Constants.DefaultConnectionStringName;
+            IConfigurationSection connectionSection = GetWebJobsConnectionStringSectionCosmos(this._configuration, connectionSetting);
+            if (!connectionSection.Exists())
+            {
+                // Not found
+                throw new InvalidOperationException($"Cosmos DB connection configuration '{connectionSetting}' does not exist. " +
+                                                    $"Make sure that it is a defined App Setting.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(connectionSection.Value))
+            {
+                return new CosmosConnectionInformation(connectionSection.Value);
+            }
+            else
+            {
+                string accountEndpoint = connectionSection["accountEndpoint"];
+                if (string.IsNullOrWhiteSpace(accountEndpoint))
+                {
+                    // Not found
+                    throw new InvalidOperationException($"Connection should have an 'accountEndpoint' property or be a " +
+                        $"string representing a connection string.");
+                }
+
+                TokenCredential credential = _componentFactory.CreateTokenCredential(connectionSection);
+                return new CosmosConnectionInformation(accountEndpoint, credential);
+            }
+        }
+
+        public static IConfigurationSection GetWebJobsConnectionStringSectionCosmos(IConfiguration configuration, string connectionStringName)
+        {
+            // first try a direct unprefixed lookup
+            IConfigurationSection section = WebJobsConfigurationExtensions.GetConnectionStringOrSetting(configuration, connectionStringName);
+
+            if (!section.Exists())
+            {
+                // next try prefixing
+                string prefixedConnectionStringName = WebJobsConfigurationExtensions.GetPrefixedConnectionStringName(connectionStringName);
+                section = WebJobsConfigurationExtensions.GetConnectionStringOrSetting(configuration, prefixedConnectionStringName);
+            }
+
+            return section;
+        }
+
+        private class CosmosConnectionInformation
+        {
+            public CosmosConnectionInformation(string connectionString)
+            {
+                this.ConnectionString = connectionString;
+                this.UsesConnectionString = true;
+            }
+
+            public CosmosConnectionInformation(string accountEndpoint, TokenCredential tokenCredential)
+            {
+                this.AccountEndpoint = accountEndpoint;
+                this.Credential = tokenCredential;
+                this.UsesConnectionString = false;
+            }
+
+            public bool UsesConnectionString { get; }
+
+            public string ConnectionString { get; }
+
+            public string AccountEndpoint { get; }
+
+            public TokenCredential Credential { get; }
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/DefaultCosmosDBServiceFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private CosmosConnectionInformation ResolveConnectionInformation(string connection)
         {
             var connectionSetting = connection ?? Constants.DefaultConnectionStringName;
-            IConfigurationSection connectionSection = GetWebJobsConnectionStringSectionCosmos(this._configuration, connectionSetting);
+            IConfigurationSection connectionSection = WebJobsConfigurationExtensions.GetWebJobsConnectionStringSection(this._configuration, connectionSetting);
             if (!connectionSection.Exists())
             {
                 // Not found
@@ -63,21 +63,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 TokenCredential credential = _componentFactory.CreateTokenCredential(connectionSection);
                 return new CosmosConnectionInformation(accountEndpoint, credential);
             }
-        }
-
-        public static IConfigurationSection GetWebJobsConnectionStringSectionCosmos(IConfiguration configuration, string connectionStringName)
-        {
-            // first try a direct unprefixed lookup
-            IConfigurationSection section = WebJobsConfigurationExtensions.GetConnectionStringOrSetting(configuration, connectionStringName);
-
-            if (!section.Exists())
-            {
-                // next try prefixing
-                string prefixedConnectionStringName = WebJobsConfigurationExtensions.GetPrefixedConnectionStringName(connectionStringName);
-                section = WebJobsConfigurationExtensions.GetConnectionStringOrSetting(configuration, prefixedConnectionStringName);
-            }
-
-            return section;
         }
 
         private class CosmosConnectionInformation

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -8,7 +8,6 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
@@ -19,16 +18,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private const string SharedThroughputRequirementException = "Shared throughput collection should have a partition key";
         private const string LeaseCollectionRequiredPartitionKey = "/id";
         private const string LeaseCollectionRequiredPartitionKeyFromGremlin = "/partitionKey";
-        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
         private readonly CosmosDBOptions _options;
         private readonly ILogger _logger;
         private readonly CosmosDBExtensionConfigProvider _configProvider;
 
-        public CosmosDBTriggerAttributeBindingProvider(IConfiguration configuration, INameResolver nameResolver, CosmosDBOptions options,
+        public CosmosDBTriggerAttributeBindingProvider(INameResolver nameResolver, CosmosDBOptions options,
             CosmosDBExtensionConfigProvider configProvider, ILoggerFactory loggerFactory)
         {
-            _configuration = configuration;
             _nameResolver = nameResolver;
             _options = options;
             _configProvider = configProvider;

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
@@ -16,16 +16,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
     /// </summary>
     internal class CosmosDBTriggerAttributeBindingProviderGenerator : ITriggerBindingProvider
     {
-        private readonly IConfiguration _configuration;
         private readonly INameResolver _nameResolver;
         private readonly CosmosDBOptions _options;
         private readonly ILoggerFactory _loggerFactory;
         private readonly CosmosDBExtensionConfigProvider _configProvider;
 
-        public CosmosDBTriggerAttributeBindingProviderGenerator(IConfiguration configuration, INameResolver nameResolver, CosmosDBOptions options,
+        public CosmosDBTriggerAttributeBindingProviderGenerator(INameResolver nameResolver, CosmosDBOptions options,
             CosmosDBExtensionConfigProvider configProvider, ILoggerFactory loggerFactory)
         {
-            _configuration = configuration;
             _nameResolver = nameResolver;
             _options = options;
             _configProvider = configProvider;
@@ -59,11 +57,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
             Type genericBindingType = baseType.MakeGenericType(documentType);
 
-            Type[] typeArgs = { typeof(IConfiguration), typeof(INameResolver), typeof(CosmosDBOptions), typeof(CosmosDBExtensionConfigProvider), typeof(ILoggerFactory) };
+            Type[] typeArgs = { typeof(INameResolver), typeof(CosmosDBOptions), typeof(CosmosDBExtensionConfigProvider), typeof(ILoggerFactory) };
 
             ConstructorInfo constructor = genericBindingType.GetConstructor(typeArgs);
 
-            object[] constructorParameterValues = { _configuration, _nameResolver, _options, _configProvider, _loggerFactory };
+            object[] constructorParameterValues = { _nameResolver, _options, _configProvider, _loggerFactory };
 
             object cosmosDBTriggerAttributeBindingProvider = constructor.Invoke(constructorParameterValues);
 

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>$(CosmosDBVersion)-preview</Version>
+    <Version>$(CosmosDBVersion)-preview1</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>$(CosmosDBVersion)</Version>
+    <Version>$(CosmosDBVersion)-preview</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="StyleCop.Analyzers" Version="1.1.0-beta009" />

--- a/src/WebJobs.Extensions.CosmosDB/WebJobsConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobsConfigurationExtensions.cs
@@ -37,13 +37,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         /// <returns></returns>
         public static IConfigurationSection GetConnectionStringOrSetting(this IConfiguration configuration, string connectionName)
         {
-            var connectionStringSection = configuration?.GetSection("ConnectionStrings").GetSection(connectionName);
-
-            if (connectionStringSection.Exists())
+            if (configuration.GetSection("ConnectionStrings").Exists())
             {
-                return connectionStringSection;
+                return configuration.GetSection("ConnectionStrings").GetSection(connectionName);
             }
-            return configuration?.GetSection(connectionName);
+
+            return configuration.GetSection(connectionName);
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/WebJobsConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobsConfigurationExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
+{
+    internal static class WebJobsConfigurationExtensions
+    {
+        private const string WebJobsConfigurationSectionName = "AzureWebJobs";
+
+        public static IConfigurationSection GetWebJobsConnectionStringSection(this IConfiguration configuration, string connectionStringName)
+        {
+            // first try prefixing
+            string prefixedConnectionStringName = GetPrefixedConnectionStringName(connectionStringName);
+            IConfigurationSection section = GetConnectionStringOrSetting(configuration, prefixedConnectionStringName);
+
+            if (!section.Exists())
+            {
+                // next try a direct unprefixed lookup
+                section = GetConnectionStringOrSetting(configuration, connectionStringName);
+            }
+
+            return section;
+        }
+
+        public static string GetPrefixedConnectionStringName(string connectionStringName)
+        {
+            return WebJobsConfigurationSectionName + connectionStringName;
+        }
+
+        /// <summary>
+        /// Looks for a connection string by first checking the ConfigurationStrings section, and then the root.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="connectionName">The connection string key.</param>
+        /// <returns></returns>
+        public static IConfigurationSection GetConnectionStringOrSetting(this IConfiguration configuration, string connectionName)
+        {
+            var connectionStringSection = configuration?.GetSection("ConnectionStrings").GetSection(connectionName);
+
+            if (connectionStringSection.Exists())
+            {
+                return connectionStringSection;
+            }
+            return configuration?.GetSection(connectionName);
+        }
+    }
+}

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -10,10 +10,13 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.Tests;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -75,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
         private async Task<CosmosClient> InitializeDocumentClientAsync(IConfiguration configuration)
         {
-            var client = new CosmosClient(configuration.GetConnectionStringOrSetting(Constants.DefaultConnectionStringName));
+            var client = new CosmosClient(configuration.GetConnectionStringOrSetting(Constants.DefaultConnectionStringName).Value);
 
             Database database = await client.CreateDatabaseIfNotExistsAsync(DatabaseName);
 
@@ -109,6 +112,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<ITypeLocator>(locator);
+                    services.TryAddSingleton(Mock.Of<AzureComponentFactory>());
                 })
                 .ConfigureLogging(logging =>
                 {

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<ITypeLocator>(locator);
-                    services.TryAddSingleton(Mock.Of<AzureComponentFactory>());
+                    services.AddAzureClientsCore();
                 })
                 .ConfigureLogging(logging =>
                 {

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
     {
         private const string DatabaseName = "ItemDb";
         private const string CollectionName = "ItemCollection";
-        private static readonly IConfiguration _emptyConfig = new ConfigurationBuilder().Build();
+        private static readonly IConfiguration _baseConfig = CosmosDBTestUtility.BuildConfiguration(new List<Tuple<string, string>>()
+        {
+            Tuple.Create(Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;")
+        });
 
         [Fact]
         public async Task ConvertAsync_Succeeds_NoContinuation()
@@ -217,9 +220,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var options = new OptionsWrapper<CosmosDBOptions>(new CosmosDBOptions
             {
-                ConnectionString = "AccountEndpoint=https://someuri;AccountKey=c29tZV9rZXk=;"
             });
-            var configProvider = new CosmosDBExtensionConfigProvider(options, mockServiceFactory.Object, new DefaultCosmosDBSerializerFactory(), _emptyConfig, new TestNameResolver(), NullLoggerFactory.Instance);
+            var configProvider = new CosmosDBExtensionConfigProvider(options, mockServiceFactory.Object, new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), NullLoggerFactory.Instance);
 
             return new CosmosDBEnumerableBuilder<T>(configProvider);
         }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBHostBuilderExtensionsTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -77,16 +78,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 .ConfigureAppConfiguration(c =>
                 {
                     c.Sources.Clear();
-
-                    var source = new MemoryConfigurationSource
+                    c.AddInMemoryCollection(new Dictionary<string, string>
                     {
-                        InitialData = new Dictionary<string, string>
-                        {
-                            { "TestConnection",  "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" }
-                        }
-                    };
-
-                    c.Add(source);
+                        { "TestConnection", "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" }
+                    });
                 })
                  .ConfigureWebJobs(builder =>
                  {

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBHostBuilderExtensionsTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                     c.Sources.Clear();
                     c.AddInMemoryCollection(new Dictionary<string, string>
                     {
-                        { "TestConnection", "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" }
+                        { Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" }
                     });
                 })
                  .ConfigureWebJobs(builder =>
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             Assert.IsType<CosmosDBExtensionConfigProvider>(extensionConfig);
 
             CosmosDBExtensionConfigProvider cosmosDBExtensionConfigProvider = (CosmosDBExtensionConfigProvider)extensionConfig;
-            CosmosClient dummyClient = cosmosDBExtensionConfigProvider.GetService("TestConnection");
+            CosmosClient dummyClient = cosmosDBExtensionConfigProvider.GetService(Constants.DefaultConnectionStringName);
             Assert.True(customFactory.CreateWasCalled);
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBWebJobsStartupTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBWebJobsStartupTests.cs
@@ -6,8 +6,11 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
@@ -22,6 +25,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 .ConfigureWebJobs(builder =>
                 {
                     builder.UseExternalStartup(new TestStartupTypeLocator());
+                })
+                .ConfigureServices(s =>
+                {
+                    s.TryAddSingleton(Mock.Of<AzureComponentFactory>());
                 })
                 .Build();
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/DefaultCosmosDBServiceFactoryTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/DefaultCosmosDBServiceFactoryTests.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
+{
+    public class DefaultCosmosDBServiceFactoryTests
+    {
+        [Fact]
+        public void UsesDefaultConnection()
+        {
+            // Arrange
+            var config = CosmosDBTestUtility.BuildConfiguration(new List<Tuple<string, string>>()
+            {
+                Tuple.Create(Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;"),
+            });
+
+            var factory = new DefaultCosmosDBServiceFactory(config, Mock.Of<AzureComponentFactory>());
+            var options = new CosmosClientOptions()
+            {
+                ApplicationName = Guid.NewGuid().ToString()
+            };
+
+            // Act
+            var client = factory.CreateService(null, options);
+
+            // Assert
+            Assert.NotNull(client);
+            Assert.True(client.Endpoint.ToString().Contains("default"));
+            Assert.Equal(options.ApplicationName, client.ClientOptions.ApplicationName);
+        }
+
+        [Fact]
+        public void UsesConfig()
+        {
+            // Arrange
+            var config = CosmosDBTestUtility.BuildConfiguration(new List<Tuple<string, string>>()
+            {
+                Tuple.Create(Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;"),
+                Tuple.Create("Attribute", "AccountEndpoint=https://attributeUri;AccountKey=c29tZV9rZXk=;")
+            });
+
+            var factory = new DefaultCosmosDBServiceFactory(config, Mock.Of<AzureComponentFactory>());
+
+            // Act
+            var client = factory.CreateService("Attribute", new CosmosClientOptions());
+
+            // Assert
+            Assert.NotNull(client);
+            Assert.True(client.Endpoint.ToString().Contains("attribute"));
+        }
+
+        [Fact]
+        public void FailsIfNotExists()
+        {
+            // Arrange
+            var config = CosmosDBTestUtility.BuildConfiguration(new List<Tuple<string, string>>()
+            {
+                Tuple.Create(Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;")
+            });
+
+            var factory = new DefaultCosmosDBServiceFactory(config, Mock.Of<AzureComponentFactory>());
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => factory.CreateService("Attribute", new CosmosClientOptions()));
+        }
+
+        [Fact]
+        public void CreatesCredentials_NoEndpoint()
+        {
+            // Arrange
+            var myConfiguration = new Dictionary<string, string>
+            {
+                {"Credentials:tenantId", "ConfigurationTenant"},
+                {"Credentials:clientId", "ConfigurationClientId"},
+                {"Credentials:clientSecret", "ConfigurationSecret"}
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            var factory = new DefaultCosmosDBServiceFactory(configuration, Mock.Of<AzureComponentFactory>());
+
+            // Act
+            Assert.Throws<InvalidOperationException>(() => factory.CreateService("Credentials", new CosmosClientOptions()));
+        }
+
+        [Fact]
+        public void CreatesCredentials()
+        {
+            // Arrange
+            var myConfiguration = new Dictionary<string, string>
+            {
+                {"Credentials:accountEndpoint", "http://someEndpoint"},
+                {"Credentials:tenantId", "ConfigurationTenant"},
+                {"Credentials:clientId", "ConfigurationClientId"},
+                {"Credentials:clientSecret", "ConfigurationSecret"}
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            var componentFactoryMock = new Mock<AzureComponentFactory>();
+            componentFactoryMock.Setup(f => f.CreateTokenCredential(It.Is<IConfigurationSection>(section => section.Key == "Credentials")))
+                .Returns(Mock.Of<TokenCredential>());
+
+            var factory = new DefaultCosmosDBServiceFactory(configuration, componentFactoryMock.Object);
+
+            // Act
+            var client = factory.CreateService("Credentials", new CosmosClientOptions());
+
+            // Assert
+            Assert.NotNull(client);
+            Assert.True(client.Endpoint.ToString().Contains("someendpoint"));
+        }
+    }
+}

--- a/test/WebJobs.Extensions.CosmosDB.Tests/DefaultCosmosDBServiceFactoryTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/DefaultCosmosDBServiceFactoryTests.cs
@@ -3,12 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Core;
 using Microsoft.Azure.Cosmos;
-using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Moq;
@@ -83,9 +79,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             // Arrange
             var myConfiguration = new Dictionary<string, string>
             {
-                {"Credentials:tenantId", "ConfigurationTenant"},
-                {"Credentials:clientId", "ConfigurationClientId"},
-                {"Credentials:clientSecret", "ConfigurationSecret"}
+                { "Credentials:tenantId", "ConfigurationTenant" },
+                { "Credentials:clientId", "ConfigurationClientId" },
+                { "Credentials:clientSecret", "ConfigurationSecret" }
             };
 
             var configuration = new ConfigurationBuilder()
@@ -104,10 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             // Arrange
             var myConfiguration = new Dictionary<string, string>
             {
-                {"Credentials:accountEndpoint", "http://someEndpoint"},
-                {"Credentials:tenantId", "ConfigurationTenant"},
-                {"Credentials:clientId", "ConfigurationClientId"},
-                {"Credentials:clientSecret", "ConfigurationSecret"}
+                { "Credentials:accountEndpoint", "http://someEndpoint" },
+                { "Credentials:tenantId", "ConfigurationTenant" },
+                { "Credentials:clientId", "ConfigurationClientId" },
+                { "Credentials:clientSecret", "ConfigurationSecret" }
             };
 
             var configuration = new ConfigurationBuilder()


### PR DESCRIPTION
This PR expands the support for authentication to include AAD.

Users can define on the Cosmos DB Trigger or binding a Connection value that points to a configuration that either:

* Is a string and represents a valid Cosmos DB Connection String
```json
{
        "MyConnection": "<cosmos db connection string>"
}
```
* Is a JSON node with valid AAD information:

```json
{
	"MyConnection" : {
             "accountEndpoint": "https://myCosmosDBaccount.documents.azure.com:443/",
	     "clientId": "AAD client Id",
	     "tenantId": "AAD Tenant Id",
	     "clientSecret": "AAD secret"
       }
}
```