### PR TITLE
Cosmos DB - Remove auto-resolution of properties

### DIFF
--- a/src/ExtensionsSample/Program.cs
+++ b/src/ExtensionsSample/Program.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -54,6 +55,7 @@ namespace ExtensionsSample
                .ConfigureServices(s =>
                {
                    s.AddSingleton<ITypeLocator>(typeLocator);
+                   s.AddAzureClientsCore();
                })
                .UseConsoleLifetime();
 

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -67,7 +67,6 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets the connection string for the service containing the container to monitor.
         /// </summary>
-        [ConnectionString]
         public string Connection { get; set; }
 
         /// <summary>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets the connection string for the service containing the container to monitor.
         /// </summary>
-        [ConnectionString]
         public string Connection { get; set; }
 
         /// <summary>

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBMockEndToEndTests.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
             factoryMock
-                .Setup(f => f.CreateService(AttributeConnStr, It.IsAny<CosmosClientOptions>()))
+                .Setup(f => f.CreateService("MyConnectionString", It.IsAny<CosmosClientOptions>()))
                 .Returns(serviceMock.Object);
 
             var jobject = JObject.FromObject(new QueueData { DocumentId = "docid1", PartitionKey = "partkey1" });
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             await RunTestAsync(nameof(CosmosDBEndToEndFunctions.TriggerObject), factoryMock.Object, jobject.ToString());
 
             // Assert
-            factoryMock.Verify(f => f.CreateService(AttributeConnStr, It.IsAny<CosmosClientOptions>()), Times.Once());
+            factoryMock.Verify(f => f.CreateService("MyConnectionString", It.IsAny<CosmosClientOptions>()), Times.Once());
             Assert.Equal("TriggerObject", _loggerProvider.GetAllUserLogMessages().Single().FormattedMessage);
         }
 


### PR DESCRIPTION
The `[ConnectionString]` decorator attempts to resolve automatically and interferes with the internal resolution in place that has AAD support.