### PR TITLE
Cosmos DB - AddAzureClientsCore should be called during registration

### DIFF
--- a/src/ExtensionsSample/Program.cs
+++ b/src/ExtensionsSample/Program.cs
@@ -4,7 +4,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -55,7 +54,6 @@ namespace ExtensionsSample
                .ConfigureServices(s =>
                {
                    s.AddSingleton<ITypeLocator>(typeLocator);
-                   s.AddAzureClientsCore();
                })
                .UseConsoleLifetime();
 

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -34,8 +35,8 @@ namespace Microsoft.Extensions.Hosting
                 });
 
             builder.Services.AddAzureClientsCore();
-            builder.Services.AddSingleton<ICosmosDBServiceFactory, DefaultCosmosDBServiceFactory>();
-            builder.Services.AddSingleton<ICosmosDBSerializerFactory, DefaultCosmosDBSerializerFactory>();
+            builder.Services.TryAddSingleton<ICosmosDBServiceFactory, DefaultCosmosDBServiceFactory>();
+            builder.Services.TryAddSingleton<ICosmosDBSerializerFactory, DefaultCosmosDBSerializerFactory>();
             
             return builder;
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -30,11 +31,12 @@ namespace Microsoft.Extensions.Hosting
                 {
                     IConfigurationSection section = config.GetSection(path);
                     section.Bind(options);
-                });                
+                });
 
+            builder.Services.AddAzureClientsCore();
             builder.Services.AddSingleton<ICosmosDBServiceFactory, DefaultCosmosDBServiceFactory>();
             builder.Services.AddSingleton<ICosmosDBSerializerFactory, DefaultCosmosDBSerializerFactory>();
-
+            
             return builder;
         }
 

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBAttribute.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets the throughput to be used when creating the container if <see cref="CreateIfNotExists"/> is true.
         /// </summary>
-        public int? ContainerThroughput { get; set; }
+        public int ContainerThroughput { get; set; }
 
         /// <summary>
         /// Gets or sets a sql query expression for an input binding to execute on the container and produce results.

--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
@@ -41,12 +41,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 context.ResolvedAttribute.PartitionKey, context.ResolvedAttribute.ContainerThroughput);
         }
 
-        internal static async Task CreateDatabaseAndCollectionIfNotExistAsync(CosmosClient service, string databaseName, string containerName, string partitionKey, int? throughput)
+        internal static async Task CreateDatabaseAndCollectionIfNotExistAsync(CosmosClient service, string databaseName, string containerName, string partitionKey, int throughput)
         {
             await service.CreateDatabaseIfNotExistsAsync(databaseName);
 
             int? desiredThroughput = null;
-            if (throughput.HasValue && throughput.Value > 0)
+            if (throughput > 0)
             {
                 desiredThroughput = throughput;
             }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Gets or sets the connection string for the service containing the lease container.
         /// </summary>
-        [ConnectionString]
         public string LeaseConnection { get; set; }
 
         /// <summary>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttribute.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs
         /// Gets or sets the throughput to be used when creating the container if <see cref="CreateLeaseContainerIfNotExists"/> is true.
         /// container.
         /// </summary>
-        public int? LeasesContainerThroughput { get; set; }
+        public int LeasesContainerThroughput { get; set; }
 
         /// <summary>
         /// Gets or sets a prefix to be used within a Leases container for this Trigger. Useful when sharing the same Lease container among multiple Triggers.

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return TimeSpan.FromMilliseconds(attributeValue.Value);
         }
 
-        private static async Task CreateLeaseCollectionIfNotExistsAsync(CosmosClient cosmosClient, string databaseName, string collectionName, int? throughput)
+        private static async Task CreateLeaseCollectionIfNotExistsAsync(CosmosClient cosmosClient, string databaseName, string collectionName, int throughput)
         {
             try
             {

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <Version>$(CosmosDBVersion)-preview1</Version>
+    <Version>$(CosmosDBVersion)-preview2</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -3,20 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.Tests;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -112,7 +108,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton<ITypeLocator>(locator);
-                    services.AddAzureClientsCore();
                 })
                 .ConfigureLogging(logging =>
                 {

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBHostBuilderExtensionsTests.cs
@@ -83,15 +83,48 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                         { Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" }
                     });
                 })
-                 .ConfigureWebJobs(builder =>
-                 {
-                     builder.AddCosmosDB();
-                 })
+                .ConfigureWebJobs(builder =>
+                {
+                    builder.AddCosmosDB();
+                })
                 .ConfigureServices(s =>
                 {
                     s.AddSingleton<ICosmosDBSerializerFactory>(customFactory);
                     s.TryAddSingleton(Mock.Of<AzureComponentFactory>());
                 })
+                .Build();
+
+            var extensionConfig = host.Services.GetServices<IExtensionConfigProvider>().Single();
+            Assert.NotNull(extensionConfig);
+            Assert.IsType<CosmosDBExtensionConfigProvider>(extensionConfig);
+
+            CosmosDBExtensionConfigProvider cosmosDBExtensionConfigProvider = (CosmosDBExtensionConfigProvider)extensionConfig;
+            CosmosClient dummyClient = cosmosDBExtensionConfigProvider.GetService(Constants.DefaultConnectionStringName);
+            Assert.True(customFactory.CreateWasCalled);
+        }
+
+        [Fact]
+        public void ConfigurationBindsToOptions_WithSerializer_Before()
+        {
+            CustomFactory customFactory = new CustomFactory();
+            IHost host = new HostBuilder()
+                .ConfigureAppConfiguration(c =>
+                {
+                    c.Sources.Clear();
+                    c.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                { Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" }
+                    });
+                })
+                .ConfigureServices(s =>
+                {
+                    s.AddSingleton<ICosmosDBSerializerFactory>(customFactory);
+                    s.TryAddSingleton(Mock.Of<AzureComponentFactory>());
+                })
+                .ConfigureWebJobs(builder =>
+                {
+                    builder.AddCosmosDB();
+                })                
                 .Build();
 
             var extensionConfig = host.Services.GetServices<IExtensionConfigProvider>().Single();


### PR DESCRIPTION
Current preview build expects users to register and call `AddAzureClientsCore` during webjob initialization, this can be moved to be part of the Cosmos DB Extension registration.

We also detected that binding types `int?` do not work on runtime.

And if a user was trying to customize the `ICosmosDBSerializerFactory`, current code was only working if the customization happened after the `AddCosmosDB` call because we were registering the default implementation with `AddSingleton` instead of `TryAddSingleton`, the tests did not catch it because the order on which they were written. The PR contains the fix plus new test coverage.

Closes #741
Closes #743