### PR TITLE
Cosmos DB - Correctly fallback to AppSettings

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobsConfigurationExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobsConfigurationExtensions.cs
@@ -39,7 +39,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         {
             if (configuration.GetSection("ConnectionStrings").Exists())
             {
-                return configuration.GetSection("ConnectionStrings").GetSection(connectionName);
+                IConfigurationSection onConnectionStrings = configuration.GetSection("ConnectionStrings").GetSection(connectionName);
+                if (onConnectionStrings.Exists())
+                {
+                    return onConnectionStrings;
+                }
             }
 
             return configuration.GetSection(connectionName);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/DefaultCosmosDBServiceFactoryTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/DefaultCosmosDBServiceFactoryTests.cs
@@ -39,6 +39,63 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         }
 
         [Fact]
+        public void UsesDefaultConnection_EvenIfConnectionStringSectionExists()
+        {
+            // Arrange
+            var myConfiguration = new Dictionary<string, string>
+            {
+                { Constants.DefaultConnectionStringName, "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" },
+                { "ConnectionStrings:SomeConnectionString", "NotAValidConnectionString" },
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            var factory = new DefaultCosmosDBServiceFactory(configuration, Mock.Of<AzureComponentFactory>());
+            var options = new CosmosClientOptions()
+            {
+                ApplicationName = Guid.NewGuid().ToString()
+            };
+
+            // Act
+            var client = factory.CreateService(null, options);
+
+            // Assert
+            Assert.NotNull(client);
+            Assert.True(client.Endpoint.ToString().Contains("default"));
+            Assert.Equal(options.ApplicationName, client.ClientOptions.ApplicationName);
+        }
+
+        [Fact]
+        public void UsesDefaultConnection_FromConnectionStrings()
+        {
+            // Arrange
+            var myConfiguration = new Dictionary<string, string>
+            {
+                { $"ConnectionStrings:{Constants.DefaultConnectionStringName}", "AccountEndpoint=https://defaultUri;AccountKey=c29tZV9rZXk=;" },
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            var factory = new DefaultCosmosDBServiceFactory(configuration, Mock.Of<AzureComponentFactory>());
+            var options = new CosmosClientOptions()
+            {
+                ApplicationName = Guid.NewGuid().ToString()
+            };
+
+            // Act
+            var client = factory.CreateService(null, options);
+
+            // Assert
+            Assert.NotNull(client);
+            Assert.True(client.Endpoint.ToString().Contains("default"));
+            Assert.Equal(options.ApplicationName, client.ClientOptions.ApplicationName);
+        }
+
+        [Fact]
         public void UsesConfig()
         {
             // Arrange


### PR DESCRIPTION
If the Application has a configuration with `ConnectionStrings` section but the Cosmos Connection is not there but on the `AppSettings`, the extension was failing to identify it.

Closes https://github.com/Azure/azure-webjobs-sdk-extensions/issues/748