### PR TITLE
Cosmos DB: Add UserAgentSuffix

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         internal CosmosClient GetService(string connection, string preferredLocations = "", string userAgent = "")
         {
             string cacheKey = BuildCacheKey(connection, preferredLocations);
+            userAgent = string.IsNullOrEmpty(_options.UserAgentSuffix) ? userAgent : userAgent + _options.UserAgentSuffix;
             CosmosClientOptions cosmosClientOptions = CosmosDBUtility.BuildClientOptions(_options.ConnectionMode, _cosmosSerializerFactory.CreateSerializer(), preferredLocations, userAgent);
             return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connection, cosmosClientOptions));
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -105,7 +105,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         internal CosmosClient GetService(string connection, string preferredLocations = "", string userAgent = "")
         {
             string cacheKey = BuildCacheKey(connection, preferredLocations);
-            userAgent = string.IsNullOrEmpty(_options.UserAgentSuffix) ? userAgent : userAgent + _options.UserAgentSuffix;
+            if (!string.IsNullOrEmpty(_options.UserAgentSuffix))
+            {
+                userAgent += _options.UserAgentSuffix;
+            }
+            
             CosmosClientOptions cosmosClientOptions = CosmosDBUtility.BuildClientOptions(_options.ConnectionMode, _cosmosSerializerFactory.CreateSerializer(), preferredLocations, userAgent);
             return ClientCache.GetOrAdd(cacheKey, (c) => _cosmosDBServiceFactory.CreateService(connection, cosmosClientOptions));
         }

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBOptions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBOptions.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         /// <remarks>Default is Gateway mode.</remarks>
         public ConnectionMode? ConnectionMode { get; set; }
 
+        /// <summary>
+        /// Gets or sets a string to be included in the User Agent for all operations by Cosmos DB bindings and triggers.
+        /// </summary>
+        public string UserAgentSuffix { get; set; }
+
         public string Format()
         {
             StringWriter sw = new StringWriter();
@@ -25,6 +30,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
                 writer.WritePropertyName(nameof(this.ConnectionMode));
                 writer.WriteValue(this.ConnectionMode);
+
+                if (!string.IsNullOrEmpty(UserAgentSuffix))
+                {
+                    writer.WritePropertyName(nameof(this.UserAgentSuffix));
+                    writer.WriteValue(this.UserAgentSuffix);
+                }
 
                 writer.WriteEndObject();
             }


### PR DESCRIPTION
For scenarios when users want to stamp all requests made by the Function App to Cosmos DB through the Bindings/Trigger with a particular string.

It is useful if the user wants to separate the activity in the Azure Metrics for a particular Function App, by filtering the User Agent containing the defined string.

This configuration is exposed through `host.json`:

```json
{
  "cosmosDB": {
    "userAgentSuffix": "MyDesiredUserAgentStamp"
  }
}
```

Closes #729