### PR TITLE
Prototyping for the new scale controller architecture

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBScaleMonitor.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBScaleMonitor.cs
@@ -1,0 +1,272 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
+{
+    public class CosmosDBScaleMonitor : IScaleMonitor<CosmosDBTriggerMetrics>
+    {
+        private readonly ILogger _logger;
+        private readonly Container _monitoredContainer;
+        private readonly Container _leaseContainer;
+        private readonly string _processorName;
+
+        // Todo should be in the shared class.
+        private static readonly Dictionary<string, string> KnownDocumentClientErrors = new Dictionary<string, string>()
+        {
+            { "Resource Not Found", "Please check that the CosmosDB container and leases container exist and are listed correctly in Functions config files." },
+            { "The input authorization token can't serve the request", string.Empty },
+            { "The MAC signature found in the HTTP request is not the same", string.Empty },
+            { "Service is currently unavailable.", string.Empty },
+            { "Entity with the specified id does not exist in the system.", string.Empty },
+            { "Subscription owning the database account is disabled.", string.Empty },
+            { "Request rate is large", string.Empty },
+            { "PartitionKey value must be supplied for this operation.", "We do not support lease containers with partitions at this time. Please create a new lease collection without partitions." },
+            { "The remote name could not be resolved:", string.Empty },
+            { "Owner resource does not exist", string.Empty },
+            { "The specified document collection is invalid", string.Empty }
+        };
+
+        public CosmosDBScaleMonitor(ILogger logger, Container monitoredContainer, Container leaseContainer, string processorName, ScaleMonitorDescriptor scaleMonitorDescriptor)
+        {
+            _logger = logger;
+            _monitoredContainer = monitoredContainer;
+            _leaseContainer = leaseContainer;
+            _processorName = processorName;
+            Descriptor = scaleMonitorDescriptor;
+        }
+
+        public ScaleMonitorDescriptor Descriptor { get; set; }
+
+        public async Task<CosmosDBTriggerMetrics> GetMetricsAsync()
+        {
+            int partitionCount = 0;
+            long remainingWork = 0;
+
+            try
+            {
+                List<ChangeFeedProcessorState> partitionWorkList = new List<ChangeFeedProcessorState>();
+                ChangeFeedEstimator estimator = this._monitoredContainer.GetChangeFeedEstimator(this._processorName, this._leaseContainer);
+                using (FeedIterator<ChangeFeedProcessorState> iterator = estimator.GetCurrentStateIterator())
+                {
+                    while (iterator.HasMoreResults)
+                    {
+                        FeedResponse<ChangeFeedProcessorState> response = await iterator.ReadNextAsync();
+                        partitionWorkList.AddRange(response);
+                    }
+                }
+
+                partitionCount = partitionWorkList.Count;
+                remainingWork = partitionWorkList.Sum(item => item.EstimatedLag);
+            }
+            catch (Exception e) when (e is CosmosException || e is InvalidOperationException)
+            {
+                if (!TryHandleCosmosException(e))
+                {
+                    _logger.LogWarning(Events.OnScaling, "Unable to handle {0}: {1}", e.GetType().ToString(), e.Message);
+                    if (e is InvalidOperationException)
+                    {
+                        throw;
+                    }
+                }
+            }
+            catch (System.Net.Http.HttpRequestException e)
+            {
+                string errormsg;
+
+                var webException = e.InnerException as WebException;
+                if (webException != null &&
+                    webException.Status == WebExceptionStatus.ProtocolError)
+                {
+                    string statusCode = ((HttpWebResponse)webException.Response).StatusCode.ToString();
+                    string statusDesc = ((HttpWebResponse)webException.Response).StatusDescription;
+                    errormsg = string.Format("CosmosDBTrigger status {0}: {1}.", statusCode, statusDesc);
+                }
+                else if (webException != null &&
+                    webException.Status == WebExceptionStatus.NameResolutionFailure)
+                {
+                    errormsg = string.Format("CosmosDBTrigger Exception message: {0}.", webException.Message);
+                }
+                else
+                {
+                    errormsg = e.ToString();
+                }
+
+                _logger.LogWarning(Events.OnScaling, errormsg);
+            }
+
+            return new CosmosDBTriggerMetrics
+            {
+                Timestamp = DateTime.UtcNow,
+                PartitionCount = partitionCount,
+                RemainingWork = remainingWork
+            };
+        }
+
+        private ScaleStatus GetScaleStatus(ScaleStatusContext<CosmosDBTriggerMetrics> context)
+        {
+            return GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<CosmosDBTriggerMetrics>().ToArray());
+        }
+
+        public ScaleStatus GetScaleStatus(ScaleStatusContext context)
+        {
+            return GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<CosmosDBTriggerMetrics>().ToArray());
+        }
+
+        async Task<ScaleMetrics> IScaleMonitor.GetMetricsAsync()
+        {
+            return await GetMetricsAsync();
+        }
+
+        private ScaleStatus GetScaleStatusCore(int workerCount, CosmosDBTriggerMetrics[] metrics)
+        {
+            ScaleStatus status = new ScaleStatus
+            {
+                Vote = ScaleVote.None
+            };
+
+            const int NumberOfSamplesToConsider = 5;
+
+            // Unable to determine the correct vote with no metrics.
+            if (metrics == null)
+            {
+                return status;
+            }
+
+            // We shouldn't assign more workers than there are partitions (Cosmos DB, Event Hub, Service Bus Queue/Topic)
+            // This check is first, because it is independent of load or number of samples.
+            int partitionCount = metrics.Length > 0 ? metrics.Last().PartitionCount : 0;
+            if (partitionCount > 0 && partitionCount < workerCount)
+            {
+                status.Vote = ScaleVote.ScaleIn;
+                _logger.LogInformation(Events.OnScaling, string.Format($"WorkerCount ({workerCount}) > PartitionCount ({partitionCount})."));
+                _logger.LogInformation(Events.OnScaling, string.Format($"Number of instances ({workerCount}) is too high relative to number " +
+                                                     $"of partitions for container ({this._monitoredContainer.Id}, {partitionCount})."));
+                return status;
+            }
+
+            // At least 5 samples are required to make a scale decision for the rest of the checks.
+            if (metrics.Length < NumberOfSamplesToConsider)
+            {
+                return status;
+            }
+
+            // Maintain a minimum ratio of 1 worker per 1,000 items of remaining work.
+            long latestRemainingWork = metrics.Last().RemainingWork;
+            if (latestRemainingWork > workerCount * 1000)
+            {
+                status.Vote = ScaleVote.ScaleOut;
+                _logger.LogInformation(Events.OnScaling, string.Format($"RemainingWork ({latestRemainingWork}) > WorkerCount ({workerCount}) * 1,000."));
+                _logger.LogInformation(Events.OnScaling, string.Format($"Remaining work for container ({this._monitoredContainer.Id}, {latestRemainingWork}) " +
+                                                     $"is too high relative to the number of instances ({workerCount})."));
+                return status;
+            }
+
+            bool documentsWaiting = metrics.All(m => m.RemainingWork > 0);
+            if (documentsWaiting && partitionCount > 0 && partitionCount > workerCount)
+            {
+                status.Vote = ScaleVote.ScaleOut;
+                _logger.LogInformation(Events.OnScaling, string.Format($"CosmosDB container '{this._monitoredContainer.Id}' has documents waiting to be processed."));
+                _logger.LogInformation(Events.OnScaling, string.Format($"There are {workerCount} instances relative to {partitionCount} partitions."));
+                return status;
+            }
+
+            // Check to see if the trigger source has been empty for a while. Only if all trigger sources are empty do we scale down.
+            bool isIdle = metrics.All(m => m.RemainingWork == 0);
+            if (isIdle)
+            {
+                status.Vote = ScaleVote.ScaleIn;
+                _logger.LogInformation(Events.OnScaling, string.Format($"'{this._monitoredContainer.Id}' is idle."));
+                return status;
+            }
+
+            // Samples are in chronological order. Check for a continuous increase in work remaining.
+            // If detected, this results in an automatic scale out for the site container.
+            bool remainingWorkIncreasing =
+                IsTrueForLast(
+                    metrics,
+                    NumberOfSamplesToConsider,
+                    (prev, next) => prev.RemainingWork < next.RemainingWork) && metrics[0].RemainingWork > 0;
+            if (remainingWorkIncreasing)
+            {
+                status.Vote = ScaleVote.ScaleOut;
+                _logger.LogInformation(Events.OnScaling, $"Remaining work is increasing for '{this._monitoredContainer.Id}'.");
+                return status;
+            }
+
+            bool remainingWorkDecreasing =
+                IsTrueForLast(
+                    metrics,
+                    NumberOfSamplesToConsider,
+                    (prev, next) => prev.RemainingWork > next.RemainingWork);
+            if (remainingWorkDecreasing)
+            {
+                status.Vote = ScaleVote.ScaleIn;
+                _logger.LogInformation(Events.OnScaling, $"Remaining work is decreasing for '{this._monitoredContainer.Id}'.");
+                return status;
+            }
+
+            _logger.LogInformation(Events.OnScaling, $"CosmosDB container '{this._monitoredContainer.Id}' is steady.");
+
+            return status;
+        }
+
+        // TODO The following section should be shared code
+        private bool TryHandleCosmosException(Exception exception)
+        {
+            string errormsg = null;
+            string exceptionMessage = exception.Message;
+
+            if (!string.IsNullOrEmpty(exceptionMessage))
+            {
+                foreach (KeyValuePair<string, string> exceptionString in KnownDocumentClientErrors)
+                {
+                    if (exceptionMessage.IndexOf(exceptionString.Key, StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        errormsg = !string.IsNullOrEmpty(exceptionString.Value) ? exceptionString.Value : exceptionMessage;
+                    }
+                }
+            }
+
+            if (!string.IsNullOrEmpty(errormsg))
+            {
+                _logger.LogWarning(errormsg);
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsTrueForLast(IList<CosmosDBTriggerMetrics> metrics, int count, Func<CosmosDBTriggerMetrics, CosmosDBTriggerMetrics, bool> predicate)
+        {
+            Debug.Assert(count > 1, "count must be greater than 1.");
+            Debug.Assert(count <= metrics.Count, "count must be less than or equal to the list size.");
+
+            // Walks through the list from left to right starting at len(samples) - count.
+            for (int i = metrics.Count - count; i < metrics.Count - 1; i++)
+            {
+                if (!predicate(metrics[i], metrics[i + 1]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        ScaleStatus IScaleMonitor<CosmosDBTriggerMetrics>.GetScaleStatus(ScaleStatusContext<CosmosDBTriggerMetrics> context)
+        {
+            return GetScaleStatusCore(context.WorkerCount, context.Metrics?.Cast<CosmosDBTriggerMetrics>().ToArray());
+        }
+    }
+}

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerMetrics.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerMetrics.cs
@@ -5,7 +5,7 @@ using Microsoft.Azure.WebJobs.Host.Scale;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
-    internal class CosmosDBTriggerMetrics : ScaleMetrics
+    public class CosmosDBTriggerMetrics : ScaleMetrics
     {
         public int PartitionCount { get; set; }
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/IScaleMonitorFactory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/IScaleMonitorFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.WebJobs.Host.Scale;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
+{
+    public interface IScaleMonitorFactory
+    {
+        IScaleMonitor Create(ScaleMonitorContext context);
+    }
+}

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/ManagedIdentityInformation.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/ManagedIdentityInformation.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
+{
+    public enum ManagedIdentityType
+    {
+        None = 0,
+        SystemAssigned = 1,
+        UserAssigned = 2
+    }
+
+    public class ManagedIdentityInformation
+    {
+        public ManagedIdentityInformation(ManagedIdentityType type,
+                                string tenantId,
+                                string clientId,
+                                string principalId,
+                                string identityUrl,
+                                string authenticationEndpoint,
+                                byte[] certBytes,
+                                string resourceId = null)
+        {
+            this.Type = type;
+            this.TenantId = tenantId;
+            this.ClientId = clientId;
+            this.PrincipalId = principalId;
+            this.IdentityUrl = identityUrl;
+            this.AuthenticationEndpoint = authenticationEndpoint;
+            this.CertificateBytes = certBytes;
+            this.ResourceId = resourceId;
+        }
+
+        public ManagedIdentityType Type { get; }
+
+        public string TenantId { get; }
+
+        public string ClientId { get; }
+
+        public string PrincipalId { get; }
+
+        public string IdentityUrl { get; }
+
+        public string AuthenticationEndpoint { get; }
+
+        public byte[] CertificateBytes { get; }
+
+        public string ResourceId { get; }
+    }
+}

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorContext.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorContext.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
+{
+    public class ScaleMonitorContext
+    {
+        // plan to obsolute
+        private IDictionary<string, string> _config = new Dictionary<string, string>();
+
+        public ILogger Logger { get; set; }
+
+        public string TriggerData { get; set; }
+
+        public string ExtensionOptions { get; set; } // payload of admin/host/config API
+        
+        public IDictionary<string, string> AppSettings { get; set; }
+
+        public string FunctionName { get; set; }
+
+        public List<ManagedIdentityInformation> ManagedIdentities { get; set; }
+
+        public IConfiguration Configration { get; set; } // Convert from AppSettings
+
+        public INameResolver NameResolver
+        {
+            get
+            {
+                return new DefaultNameResolver(Configration); // consider caching or immutable
+            } 
+        }
+
+        public string this[string key]
+        {
+            get { return _config[key]; }
+        }
+
+        public T GetTriggerAttribute<T>()
+        {
+            // Write a logic hydrate T from TriggerData
+            return default(T);
+        }
+
+        public T GetExtensionOption<T>()
+        {
+            // Write a logic hydrate K from ExtensionOption
+            return default(T);
+        }
+
+        public void Add(string key, string value)
+        {
+            _config.Add(key, value);
+        } 
+    }
+}

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorContext.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorContext.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Configuration;

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorFacctory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorFacctory.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Azure.Cosmos;

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorFacctory.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/ScaleMonitorFacctory.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
+{
+    public class ScaleMonitorFacctory : IScaleMonitorFactory
+    {
+        private static CosmosClientOptions defaultCosmosClientOptions = new CosmosClientOptions()
+        {
+            // Gateway mode reduces number of connections at the expense of performance/latency
+            ConnectionMode = ConnectionMode.Gateway,
+
+            // Adding ApplicationName to stamp all requests with this value in the User Agent that can help identify traffic
+            ApplicationName = "Antares-ScaleController"
+        };
+
+        public IScaleMonitor Create(ScaleMonitorContext context)
+        {
+            // TODO if we can provide the feature that hydrate the Attribute and configration, extension owners can share the validation logic
+            CosmosClient monitorClient = null;
+            CosmosClient leaseClient = null;
+            if (!TryCreateCosmosClient(context["connectionStringSetting"], defaultCosmosClientOptions, out monitorClient, context.Logger) ||
+                !TryCreateCosmosClient(context["leaseConnectionStringSetting"], defaultCosmosClientOptions, out leaseClient, context.Logger))
+            {
+                throw new ArgumentException($"Function Name: {context.FunctionName}.Unable to create CosmosClient for the trigger and / or lease collection.");
+            }
+            Container monitorContainer = monitorClient.GetContainer(context["databaseName"], context["collectionName"]);
+            Container leaseContainer = leaseClient.GetContainer(context["leaseDatabaseName"], context["leaseCollectionName"]);
+            var descriptor = new ScaleMonitorDescriptor($"ScaleController-{context.FunctionName}-CosmosDBTrigger-{monitorContainer.Database.Id}-{monitorContainer.Id}".ToLower());
+            return new CosmosDBScaleMonitor(context.Logger, monitorContainer, leaseContainer, context["processName"], descriptor);
+        }
+
+        // TODO: Adding Managed Identity Support.
+        private static bool TryCreateCosmosClient(string connectionString, CosmosClientOptions options, out CosmosClient cosmosClient, ILogger logger)
+        {
+            try
+            {
+                cosmosClient = new CosmosClient(connectionString, options);
+                return true;
+            }
+            catch (UriFormatException e)
+            {
+                logger.LogWarning($"The lease and/or trigger collection have a malformed account endpoint URI. Exception: {e.Message}");
+            }
+            catch (FormatException e)
+            {
+                logger.LogWarning($"The lease and/or trigger collection have a malformed account key. Exception: {e.Message}");
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning("Unable to create CosmosClient with ConnectionString in CosmosClientProvider.TryCreateCosmosClient. Exception: {0}", ex.ToString());
+            }
+            cosmosClient = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This PR is for experiment the new scale controller interface that aim for using the same Scale Controller logic for Runtime Driven Monitoring and Scale Controller. This draft pr is exists for sharing the idea of the dynamic loading interface for new scale controller design.

# Purpose 
* Introduce the Factory for enabling instantiate the IScaleMonitor object on Scale Controller
* It also helps when we implement TriggerMonitor

# How to 
* Obsolete the method that use IListener and IScaleMonitor at the same time
* Provide the generic ScaleMonitorContext object that contains all the information that need to be instantiated IScaleMonitor implementations.

# TODO 
* Provide the hydration of CosmosDBAttribute and CosmosDBOptions in the ScaleMonitorContext

That would be help to extension owner shar the logic of validation and some operation for each configuration

* Refactor the current IListener -> It will affect the tests, so that I leave it
* Refactor the Unit test
