### PR TITLE
Add support for custom names for values in data binding

### DIFF
--- a/src/WebJobs.Extensions.Http/PropertyHelper.cs
+++ b/src/WebJobs.Extensions.Http/PropertyHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Http
 {
@@ -49,10 +50,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
             }
 
             Property = property;
-            Name = property.Name;
+            Name = GetDataMemberAttributeValue(property) ?? property.Name;
             ValueGetter = MakeFastPropertyGetter(property);
         }
-
+        
         // Delegate type for a by-ref property getter
         private delegate TValue ByRefFunc<TDeclaringType, TValue>(ref TDeclaringType arg);
 
@@ -509,6 +510,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
                 property.GetMethod != null &&
                 property.GetMethod.IsPublic &&
                 !property.GetMethod.IsStatic;
+        }
+        
+        private static string GetDataMemberAttributeValue(MemberInfo property)
+        {
+            return property.GetCustomAttribute<DataMemberAttribute>()?.Name;
         }
     }
 }

--- a/src/WebJobs.Extensions.Http/PropertyHelper.cs
+++ b/src/WebJobs.Extensions.Http/PropertyHelper.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
             Name = GetDataMemberAttributeValue(property) ?? property.Name;
             ValueGetter = MakeFastPropertyGetter(property);
         }
-        
+
         // Delegate type for a by-ref property getter
         private delegate TValue ByRefFunc<TDeclaringType, TValue>(ref TDeclaringType arg);
 
@@ -507,11 +507,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         private static bool IsInterestingProperty(PropertyInfo property)
         {
             return property.GetIndexParameters().Length == 0 &&
-                property.GetMethod != null &&
-                property.GetMethod.IsPublic &&
-                !property.GetMethod.IsStatic;
+                   property.GetMethod != null &&
+                   property.GetMethod.IsPublic &&
+                   !property.GetMethod.IsStatic;
         }
-        
+
         private static string GetDataMemberAttributeValue(MemberInfo property)
         {
             return property.GetCustomAttribute<DataMemberAttribute>()?.Name;

--- a/test/WebJobs.Extensions.Http.Tests/HttpTriggerBindingTests.cs
+++ b/test/WebJobs.Extensions.Http.Tests/HttpTriggerBindingTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
         [Fact]
         public async Task BindAsync_Poco_FromQueryParameters_WithDifferentNaming()
         {
-            ParameterInfo parameterInfo = GetType().GetMethod("TestPocoFunction").GetParameters()[0];
+            ParameterInfo parameterInfo = GetType().GetMethod("TestPocoFunctionWithCustomName").GetParameters()[0];
             HttpTriggerAttributeBindingProvider.HttpTriggerBinding binding = new HttpTriggerAttributeBindingProvider.HttpTriggerBinding(new HttpTriggerAttribute(), parameterInfo, true);
 
             HttpRequest request = HttpTestHelpers.CreateHttpRequest("GET", "http://functions/myfunc?code=abc123&custom_value=Mathew%20Charles&Location=Seattle");
@@ -269,9 +269,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
             ITriggerData triggerData = await binding.BindAsync(request, context);
 
-            Assert.Equal(5, triggerData.BindingData.Count);
-            Assert.Equal("Mathew Charles", triggerData.BindingData["Name"]);
-            Assert.Equal("Seattle", triggerData.BindingData["Location"]);
+            Assert.Equal(6, triggerData.BindingData.Count);
+            Assert.Null(triggerData.BindingData[nameof(TestPocoWithDataMember.CustomValue)]);
+            Assert.Equal("Mathew Charles", triggerData.BindingData["custom_value"]);
+            Assert.Equal("Seattle", triggerData.BindingData[nameof(TestPocoWithDataMember.Location)]);
 
             TestPocoWithDataMember testPoco = (TestPocoWithDataMember)(await triggerData.ValueProvider.GetValueAsync());
             Assert.Equal("Mathew Charles", testPoco.CustomValue);
@@ -587,6 +588,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Http
         }
 
         public void TestPocoFunction(TestPoco poco)
+        {
+        }
+
+        public void TestPocoFunctionWithCustomName(TestPocoWithDataMember poco)
         {
         }
 


### PR DESCRIPTION
Currently it is not possible to use different names for binding than the property names. To be more flexible, i added a check if DataMemberAttribute is set and use this name instead of the property name

```cs
public class TestPocoWithDataMember
{
    [DataMember(Name = "custom_value")]
    public string CustomValue { get; set; }

    public string Location { get; set; }
}
```

This would allow the developer to bind the data against query parameter like custom_value.