### PR TITLE
Fix to my previous TimerListener changes

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -267,17 +267,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
         /// <param name="runOnStartup">True if the invocation is because the timer is configured to run on startup.</param>
         internal async Task InvokeJobFunction(DateTime invocationTime, bool isPastDue = false, bool runOnStartup = false, DateTime? originalSchedule = null)
         {
-            await _invocationLock.WaitAsync();
-
-            // if Cancel, Stop, or Dispose have been called, skip the invocation
-            // since we're stopping the listener
-            if (_cancellationTokenSource.IsCancellationRequested)
-            {
-                return;
-            }
-
             try
             {
+                await _invocationLock.WaitAsync();
+
+                // if Cancel, Stop, or Dispose have been called, skip the invocation
+                // since we're stopping the listener
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 CancellationToken token = _cancellationTokenSource.Token;
                 ScheduleStatus timerInfoStatus = null;
                 if (ScheduleMonitor != null)


### PR DESCRIPTION
Fixing my previous change for https://github.com/Azure/azure-webjobs-sdk-extensions/pull/792. The lock operation needs to be done under the try/finally to ensure it's released.