### PR TITLE
Cosmos DB: Add retry policy support for Cosmos DB Trigger

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
@@ -14,6 +15,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
+    [SupportsRetry]
     internal class CosmosDBTriggerBinding<T> : ITriggerBinding
     {
         private static readonly IReadOnlyDictionary<string, Type> _emptyBindingContract = new Dictionary<string, Type>();

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.Tests;


### PR DESCRIPTION
This PR adds `[SupportsRetry]` decorator to the Trigger Binding to allow users to define retry policies. This would bring the Cosmos DB Trigger among the ones (Kafka, Timer, Event Hub) that will keep having Retry Policy support.

This support will be included in the `4.X` version of the extension.

Closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3437

Related to https://github.com/Azure/azure-webjobs-sdk-extensions/issues/783