### PR TITLE
CosmosDB support for ParameterBindingData reference type

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -174,10 +174,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         // Has the same properties as CosmosDBAttribute
         private class CosmosParameterBindingDataContent
         {
-            public CosmosParameterBindingDataContent()
-            {
-            }
-
             public CosmosParameterBindingDataContent(CosmosDBAttribute attribute)
             {
                 DatabaseName = attribute.DatabaseName;

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -188,19 +188,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 PartitionKey = attribute.PartitionKey;
                 ContainerThroughput = attribute.ContainerThroughput;
                 SqlQuery = attribute.SqlQuery;
-                SqlQueryParameters = attribute.SqlQueryParameters is null ?  default : attribute.SqlQueryParameters.ToDictionary(x => x.Item1, x => x.Item2);
+                SqlQueryParameters = attribute.SqlQueryParameters is null ? default : attribute.SqlQueryParameters.ToDictionary(x => x.Item1, x => x.Item2);
                 PreferredLocations = attribute.PreferredLocations;
             }
 
             public string DatabaseName { get; set; }
+
             public string ContainerName { get; set; }
+
             public bool CreateIfNotExists { get; set; }
+
             public string Connection { get; set; }
+
             public string Id { get; set; }
+
             public string PartitionKey { get; set; }
+
             public int ContainerThroughput { get; set; }
+
             public string SqlQuery { get; set; }
+
             public IDictionary<string, object> SqlQueryParameters { get; set; }
+
             public string PreferredLocations { get; set; }
         }
     }

--- a/src/WebJobs.Extensions.CosmosDB/Constants.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Constants.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
     public static class Constants
     {
         public const string DefaultConnectionStringName = "CosmosDB";
+        public const string WebJobsCosmosExtensionName = "CosmosDB";
     }
 
     internal static class Events

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Triggers;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
@@ -50,6 +50,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
 
             if (typeof(string).IsAssignableFrom(documentType))
+            {
+                documentType = typeof(JObject);
+            }
+
+            if (typeof(ParameterBindingData).IsAssignableFrom(documentType))
             {
                 documentType = typeof(JObject);
             }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -50,11 +49,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
 
             if (typeof(string).IsAssignableFrom(documentType))
-            {
-                documentType = typeof(JObject);
-            }
-
-            if (typeof(ParameterBindingData).IsAssignableFrom(documentType))
             {
                 documentType = typeof(JObject);
             }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBConfigurationTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBConfigurationTests.cs
@@ -65,6 +65,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             Assert.True(context.Service.Endpoint.ToString().Contains("default"));
         }
 
+        [Fact]
+        public void CreateParameterBindingData_CreatesValidParameterBindingDataObject()
+        {
+            var config = InitializeExtensionConfigProvider();
+
+            var sqlQueryParameters = new List<(string, object)>();
+            sqlQueryParameters.Add(("id", "1"));
+            var attribute = new CosmosDBAttribute("testDb", "testContainer") { Connection = "testConnection", Id = "id", SqlQueryParameters =  sqlQueryParameters};
+            var data = @"{""DatabaseName"":""testDb"",""ContainerName"":""testContainer"",""CreateIfNotExists"":false,""Connection"":""testConnection"",""Id"":""id"",""PartitionKey"":null,""ContainerThroughput"":0,""SqlQuery"":null,""SqlQueryParameters"":{""id"":""1""},""PreferredLocations"":null}";
+            var expectedBinaryData = new BinaryData(data).ToString();
+
+            // Act
+            var pbdObj = config.CreateParameterBindingData(attribute);
+
+            // Assert
+            Assert.Equal("CosmosDB", pbdObj.Source);
+            Assert.Equal("1.0", pbdObj.Version);
+            Assert.Equal(expectedBinaryData, pbdObj.Content.ToString());
+            Assert.Equal("application/json", pbdObj.ContentType);
+        }
+
         [Theory]
         [InlineData(typeof(IEnumerable<string>), true)]
         [InlineData(typeof(IEnumerable<Item>), true)]


### PR DESCRIPTION
The Azure Functions team is working on enabling SDK-type bindings for out-of-proc language workers. To enable this, we are introducing a reference type that contains all the information the worker would require to hydrate the SDK-type on the worker side, instead of passing the payload through the host. You can read internal design document [here](https://eng.ms/docs/cloud-ai-platform/devdiv/serverless-paas-balam/serverless-paas-benbyrd/app-service-web-apps/app-service-team-documents/functionteamdocs/design/oopworkers/sdktypebindings).

This PR adds rules and converters for `ParameterBindingData` which is the reference type mentioned above ^ 

- You can read this [PR description](https://github.com/Azure/azure-functions-dotnet-worker/pull/1406) to learn more about how this is used in the Functions Dotnet-Isolated worker.
- You can learn more about how this is used on the Functions host in this [PR description](https://github.com/Azure/azure-functions-host/pull/8815)

Related issue: https://github.com/Azure/azure-functions-dotnet-worker/issues/1034

