### PR TITLE
Cosmos DB: Add log case for lease lost due to scaling

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerHealthMonitor.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerHealthMonitor.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 case CosmosException cosmosException when cosmosException.StatusCode == HttpStatusCode.RequestTimeout || cosmosException.StatusCode == HttpStatusCode.ServiceUnavailable:
                     this.logger.LogWarning(Events.OnError, cosmosException, "Lease {LeaseToken} experiencing transient connectivity issues.", leaseToken);
                     break;
+                case CosmosException cosmosException when cosmosException.StatusCode == HttpStatusCode.PreconditionFailed:
+                    this.logger.LogInformation(Events.OnError, cosmosException, "Lease {LeaseToken} was lost. This is expected during scaling and briefly during initialization as the leases are rebalanced across instances.", leaseToken);
+                    break;
                 default:
                     this.logger.LogError(Events.OnError, exception, "Lease {LeaseToken} experienced an error during processing.", leaseToken);
                     break;

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             string diagnosticsString = Guid.NewGuid().ToString();
             Mock<CosmosDiagnostics> diagnostics = new Mock<CosmosDiagnostics>();
             diagnostics.Setup(m => m.ToString()).Returns(diagnosticsString);
-            MockedException cosmosException = new MockedException(httpStatusCode.PreconditionFailed, diagnostics.Object);
+            MockedException cosmosException = new MockedException(HttpStatusCode.PreconditionFailed, diagnostics.Object);
 
             await cosmosDBTriggerHealthMonitor.OnErrorAsync(leaseToken, cosmosException);
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             await cosmosDBTriggerHealthMonitor.OnErrorAsync(leaseToken, cosmosException);
 
-            Assert.Equal(1, mockedLogger.Events.Count);
+            Assert.Equal(2, mockedLogger.Events.Count);
 
             LogEvent loggedEvent = mockedLogger.Events[0];
             Assert.Equal(LogLevel.Information, loggedEvent.LogLevel);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         }
 
         [Fact]
-        public async Task LogsLeaseLostConnectivity()
+        public async Task LogsLeaseLost412()
         {
             MockedLogger mockedLogger = new MockedLogger();
             CosmosDBTriggerHealthMonitor cosmosDBTriggerHealthMonitor = new CosmosDBTriggerHealthMonitor(mockedLogger);


### PR DESCRIPTION
When a lease is lost due to Scaling/Rebalancing, currently the extension is producing the logs but using an `Error` level.

The HTTP 412 from the Change Feed Processor should not be an `Error` because it's part of the expected flow when new instances are added.

This PR adds the case for HTTP 412 and reduces the log level to Information.