### PR TITLE
Update default ScheduleStatus values to include timezone indicator

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 ScheduleStatus = new ScheduleStatus
                 {
                     Last = default(DateTime).ToLocalTime(),
-                    Next = _schedule.GetNextOccurrence(now),
+                    Next = _schedule.GetNextOccurrence(now)
                 };
             }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -110,14 +110,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
 
             if (ScheduleStatus == null)
             {
-                var defaultDateTime = new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Local);
-
                 // no schedule status has been stored yet, so initialize
                 ScheduleStatus = new ScheduleStatus
                 {
-                    Last = defaultDateTime,
+                    Last = default(DateTime).ToLocalTime(),
                     Next = _schedule.GetNextOccurrence(now),
-                    LastUpdated = defaultDateTime
                 };
             }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 ScheduleStatus = new ScheduleStatus
                 {
                     Last = default(DateTime).ToLocalTime(),
-                    Next = _schedule.GetNextOccurrence(now)
+                    Next = _schedule.GetNextOccurrence(now),
+                    LastUpdated = default(DateTime).ToLocalTime()
                 };
             }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -110,15 +110,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
 
             if (ScheduleStatus == null)
             {
+                var defaultDateTime = new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Local);
+
                 // no schedule status has been stored yet, so initialize
                 ScheduleStatus = new ScheduleStatus
                 {
-                    Last = default(DateTime),
-                    Next = _schedule.GetNextOccurrence(now)
+                    Last = defaultDateTime,
+                    Next = _schedule.GetNextOccurrence(now),
+                    LastUpdated = defaultDateTime
                 };
             }
 
-            // log the next several occurrences to console for visibility            
+            // log the next several occurrences to console for visibility
             string nextOccurrences = TimerInfo.FormatNextOccurrences(_schedule, 5);
             Logger.NextOccurrences(_logger, _functionLogName, _schedule, nextOccurrences);
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 DateTime nextOccurrence = schedule.GetNextOccurrence(now);
                 lastStatus = new ScheduleStatus
                 {
-                    Last = default(DateTime),
+                    Last = default(DateTime).ToLocalTime(),
                     Next = nextOccurrence,
                     LastUpdated = now
                 };

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     /// </summary>
     public abstract class ScheduleMonitor
     {
+        private static DateTime defaultDateTime = default(DateTime).ToLocalTime();
+
         /// <summary>
         /// Gets the last recorded schedule status for the specified timer.
         /// If the timer has not ran yet, null will be returned.
@@ -55,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 DateTime nextOccurrence = schedule.GetNextOccurrence(now);
                 lastStatus = new ScheduleStatus
                 {
-                    Last = default(DateTime).ToLocalTime(),
+                    Last = defaultDateTime,
                     Next = nextOccurrence,
                     LastUpdated = now
                 };
@@ -69,14 +71,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 // Track the time that was used to create 'expectedNextOccurrence'.
                 DateTime lastUpdated;
 
-                if (lastStatus.Last != default(DateTime))
+                if (lastStatus.Last != defaultDateTime)
                 {
                     // If we have a 'Last' value, we know that we used this to calculate 'Next'
-                    // in a previous invocation. 
+                    // in a previous invocation.
                     expectedNextOccurrence = schedule.GetNextOccurrence(lastStatus.Last);
                     lastUpdated = lastStatus.Last;
                 }
-                else if (lastStatus.LastUpdated != default(DateTime))
+                else if (lastStatus.LastUpdated != defaultDateTime)
                 {
                     // If the trigger has never fired, we won't have 'Last', but we will have
                     // 'LastUpdated', which tells us the last time that we used to calculate 'Next'.
@@ -85,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 }
                 else
                 {
-                    // If we do not have 'LastUpdated' or 'Last', we don't have enough information to 
+                    // If we do not have 'LastUpdated' or 'Last', we don't have enough information to
                     // properly calculate 'Next', so we'll calculate it from the current time.
                     expectedNextOccurrence = schedule.GetNextOccurrence(now);
                     lastUpdated = now;
@@ -104,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                         lastUpdated = now;
                     }
 
-                    lastStatus.Last = default(DateTime);
+                    lastStatus.Last = defaultDateTime;
                     lastStatus.Next = expectedNextOccurrence;
                     lastStatus.LastUpdated = lastUpdated;
                     await UpdateStatusAsync(timerName, lastStatus);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -298,9 +298,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             CancellationToken cancellationToken = CancellationToken.None;
             await _listener.StartAsync(cancellationToken);
 
-            Assert.Same(_listener.ScheduleStatus.Last.Kind, DateTimeKind.Local);
-            Assert.Same(_listener.ScheduleStatus.Next.Kind, DateTimeKind.Local);
-            Assert.Same(_listener.ScheduleStatus.LastUpdated.Kind, DateTimeKind.Local);
+            Assert.Equal(_listener.ScheduleStatus.Last.Kind, DateTimeKind.Local);
+            Assert.Equal(_listener.ScheduleStatus.Next.Kind, DateTimeKind.Local);
+            Assert.Equal(_listener.ScheduleStatus.LastUpdated.Kind, DateTimeKind.Local);
 
             _listener.Dispose();
         }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -293,6 +293,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         }
 
         [Fact]
+        public async Task StartAsync_ScheduleStatus_DateKindIsLocal()
+        {
+            CancellationToken cancellationToken = CancellationToken.None;
+            await _listener.StartAsync(cancellationToken);
+
+            Assert.Same(_listener.ScheduleStatus.Last.Kind, DateTimeKind.Local);
+            Assert.Same(_listener.ScheduleStatus.Next.Kind, DateTimeKind.Local);
+            Assert.Same(_listener.ScheduleStatus.LastUpdated.Kind, DateTimeKind.Local);
+
+            _listener.Dispose();
+        }
+
+        [Fact]
         public async Task StartAsync_ExtendedScheduleInterval_TimerContinuesUntilTotalIntervalComplete()
         {
             // create a timer with an extended interval that exceeds the max

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -295,6 +295,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         [Fact]
         public async Task StartAsync_ScheduleStatus_DateKindIsLocal()
         {
+            _listener.ScheduleMonitor = null;
+
             CancellationToken cancellationToken = CancellationToken.None;
             await _listener.StartAsync(cancellationToken);
 

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _dailySchedule, null);
             Assert.Equal(TimeSpan.Zero, pastDueAmount);
             Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+            Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
             Assert.Equal(new DateTime(2017, 1, 2), monitor.CurrentStatus.Next);
             Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
         }
@@ -56,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
 
             MockScheduleMonitor monitor = new MockScheduleMonitor();
 
-            // Check the schedule (simulating a host start without any schedule change). We should not 
+            // Check the schedule (simulating a host start without any schedule change). We should not
             // update the status.
             TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _hourlySchedule, status);
             Assert.Equal(TimeSpan.Zero, pastDueAmount);
@@ -91,11 +92,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             }
             else
             {
-                // Legacy behavior -- 'LastUpdated' fixed this. The schedule didn't change and we're past due, 
+                // Legacy behavior -- 'LastUpdated' fixed this. The schedule didn't change and we're past due,
                 //      but we miss it because there is no 'Last' value, which we require to calculate the 'Next'
                 //      value. It also shouldn't register as a schedule change.
                 Assert.Equal(TimeSpan.Zero, pastDueAmount);
                 Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+                Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
                 Assert.Equal(DateTime.Parse("1/1/2017 11:00"), monitor.CurrentStatus.Next);
                 Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
             }
@@ -126,6 +128,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
 
             DateTime expectedNext = new DateTime(2017, 1, 2);
             Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+            Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
             Assert.Equal(expectedNext, monitor.CurrentStatus.Next);
 
             if (lastUpdatedSet || lastSet)
@@ -157,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
 
             MockScheduleMonitor monitor = new MockScheduleMonitor();
 
-            // Change to half-hour schedule (status is hourly). 
+            // Change to half-hour schedule (status is hourly).
             // The 'Next' time calculated by this could be in the past -- so it will be seen as past due
             TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _halfHourlySchedule, status);
 
@@ -166,6 +169,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
                 // Because the new time is in the past, we re-calculate it to be the next invocation from 'now'.
                 Assert.Equal(TimeSpan.Zero, pastDueAmount);
                 Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+                Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
                 Assert.Equal(new DateTime(2017, 1, 1, 10, 0, 0), monitor.CurrentStatus.Next);
                 Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
             }


### PR DESCRIPTION
Related https://github.com/Azure/azure-functions-host/issues/7391

We're getting a couple CRIs where customers are not able to parse the schedule data because a the timestamp indicator is missing. 

Currently, when we get the schedule information it looks like this:

```json
{
	"Schedule": {
		"AdjustForDST": true
	},
	"ScheduleStatus": {
		"Last": "0001-01-01T00:00:00",
		"Next": "2023-02-14T16:50:00-08:00",
		"LastUpdated": "0001-01-01T00:00:00"
	},
	"IsPastDue": false
}
```

With java and custom functions, this leads to the following exception:

```log
Microsoft.Azure.WebJobs.Host.FunctionInvocationException : Exception while executing function: Functions.az3125-func ---> Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException : Result: Failure
Exception: IllegalArgumentException: No time zone indicator
Stack: com.google.gson.JsonSyntaxException: Failed parsing '0001-01-01T00:00:00' as Date; at path $.ScheduleStatus.
	at com.google.gson.internal.bind.DateTypeAdapter.deserializeToDate(DateTypeAdapter.java:90)
	at com.google.gson.internal.bind.DateTypeAdapter.read(DateTypeAdapter.java:75)
	at com.google.gson.internal.bind.DateTypeAdapter.read(DateTypeAdapter.java:46)
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41)
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:187)
	at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:145)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:130)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:221)
```

We can use the Utc or Local kind to give values that include timezone information. Open to better suggestions on how to approach this.