### PR TITLE
A few small repairs.

### DIFF
--- a/build/pipelines/templates/ci.yml
+++ b/build/pipelines/templates/ci.yml
@@ -59,7 +59,7 @@ jobs:
         $config = "Release"
         Write-Host "Git tag found. Setting Configuration to '$config'"
         $env:Configuration = $config
-        echo "##vso[task.setvariable variable=Configuration]$config" # let downstream tasks read this variable
+        Write-Host "##vso[task.setvariable variable=Configuration]$config" # let downstream tasks read this variable
       }
 
       $projectsArray = "$(targetProjects)" -split ";"

--- a/build/pipelines/templates/variables.yml
+++ b/build/pipelines/templates/variables.yml
@@ -3,14 +3,14 @@ variables:
 - group: 'WebJobs SDK Extensions Testing'
 - group: 'Funkins Signing'
 - name: buildNumber
-  value: $[ counter('constant', 11000) ]
+  value: $[ format('{0:yyyyMMddHHmmssfff}', pipeline.startTime) ]
 - name: buildOutputDirectory
   value: '$(System.DefaultWorkingDirectory)\buildoutput'
 - name: IncludeBuildNumberInVersion
   value: ${{ 0 }}
 - name: isPr
-  value: $[ eq('$(Build.Reason)', 'PullRequest') ]
+  value: $[ eq(variables['Build.Reason'], 'PullRequest') ]
 - name: hasTag
-  value: $[ startsWith('$(Build.SourceBranch)', 'refs/tag/') ]
+  value: $[ startsWith(variables['Build.SourceBranch'], 'refs/tags') ]
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: ${{ true }}

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -11,8 +11,8 @@ function RunTest([string]$project, [bool]$skipBuild = $false, [string]$filter = 
 
     if ($null -ne $env:Configuration)
     {
-        Write-Host "Adding: --configuration $config"
-        $cmdargs += "--configuration", "$config"
+        Write-Host "Adding: --configuration $env:Configuration"
+        $cmdargs += "--configuration", "$env:Configuration"
     }
 
     if ($filter) {


### PR DESCRIPTION
* Changed build number to pipeline start time to avoid collisions between the main extensions pipeline and CosmosDB pipeline at signing. Shouldn't matter once we move to ESRP ADO tasks.
* Fixed a typo in the `hasTag` check.