### PR TITLE
Check for cancellation after triggering function

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -219,6 +219,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 ChangeFeedProcessorUserException userException = new ChangeFeedProcessorUserException(result.Exception, context);
                 await this._healthMonitor.OnErrorAsync(context.LeaseToken, userException);
             }
+            // Prevent the change feed lease from being checkpointed if cancellation was requested
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         public IScaleMonitor GetMonitor()

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -219,6 +219,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 ChangeFeedProcessorUserException userException = new ChangeFeedProcessorUserException(result.Exception, context);
                 await this._healthMonitor.OnErrorAsync(context.LeaseToken, userException);
             }
+
             // Prevent the change feed lease from being checkpointed if cancellation was requested
             cancellationToken.ThrowIfCancellationRequested();
         }


### PR DESCRIPTION
Fixes #851 by throwing an exception if cancellation is requested, preventing automatic checkpointing from occurring.