### PR TITLE
Create DefaultCosmosDBServiceFactory with AzureComponentFactory

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.3.0$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.3.0-alpha</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.3.0-alpha</CosmosDBVersion>
+    <CosmosDBVersion>4.3.0$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDbScalerProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDbScalerProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             CosmosDbMetadata cosmosDbMetadata = JsonConvert.DeserializeObject<CosmosDbMetadata>(triggerMetadata.Metadata.ToString());
             cosmosDbMetadata.ResolveProperties(serviceProvider.GetService<INameResolver>());
             IOptions<CosmosClientOptions> options = serviceProvider.GetService<IOptions<CosmosClientOptions>>();
-            ICosmosDBServiceFactory serviceFactory = new DefaultCosmosDBServiceFactory(config, azureComponentFactory);
+            ICosmosDBServiceFactory serviceFactory = new DefaultCosmosDBServiceFactory(config,  azureComponentFactory);
             CosmosClient cosmosClient = serviceFactory.CreateService(cosmosDbMetadata.Connection, options.Value);
             var monitoredContainer = cosmosClient.GetContainer(cosmosDbMetadata.DatabaseName, cosmosDbMetadata.ContainerName);
             var leaseContainer = cosmosClient.GetContainer(string.IsNullOrEmpty(cosmosDbMetadata.LeaseDatabaseName) ? cosmosDbMetadata.DatabaseName : cosmosDbMetadata.LeaseDatabaseName, string.IsNullOrEmpty(cosmosDbMetadata.LeaseContainerName) ? CosmosDBTriggerConstants.DefaultLeaseCollectionName : cosmosDbMetadata.LeaseContainerName);

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDbScalerProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDbScalerProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             CosmosDbMetadata cosmosDbMetadata = JsonConvert.DeserializeObject<CosmosDbMetadata>(triggerMetadata.Metadata.ToString());
             cosmosDbMetadata.ResolveProperties(serviceProvider.GetService<INameResolver>());
             IOptions<CosmosClientOptions> options = serviceProvider.GetService<IOptions<CosmosClientOptions>>();
-            ICosmosDBServiceFactory serviceFactory = new DefaultCosmosDBServiceFactory(config,  azureComponentFactory);
+            ICosmosDBServiceFactory serviceFactory = new DefaultCosmosDBServiceFactory(config, azureComponentFactory);
             CosmosClient cosmosClient = serviceFactory.CreateService(cosmosDbMetadata.Connection, options.Value);
             var monitoredContainer = cosmosClient.GetContainer(cosmosDbMetadata.DatabaseName, cosmosDbMetadata.ContainerName);
             var leaseContainer = cosmosClient.GetContainer(string.IsNullOrEmpty(cosmosDbMetadata.LeaseDatabaseName) ? cosmosDbMetadata.DatabaseName : cosmosDbMetadata.LeaseDatabaseName, string.IsNullOrEmpty(cosmosDbMetadata.LeaseContainerName) ? CosmosDBTriggerConstants.DefaultLeaseCollectionName : cosmosDbMetadata.LeaseContainerName);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -151,7 +151,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 [QueueTrigger("NotUsed")] QueueItem item,
                 [CosmosDB(DatabaseName, CollectionName, Id = "{DocumentId}")] JObject document,
                 [CosmosDB(DatabaseName, CollectionName, SqlQuery = "SELECT * FROM c where c.input = {Input}")] IEnumerable<Item> documents,
-                //[CosmosDB(DatabaseName, CollectionName, SqlQuery = "SELECT * FROM c where c.id = {DocumentId}")] IEnumerable<Item> documents1,
                 ILogger log)
             {
                 Assert.NotNull(document);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
             catch (CosmosException cosmosException) when (cosmosException.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
-                await database.CreateContainerAsync(CollectionName, "/id");
+                await database.CreateContainerAsync(collectionName, "/id");
             }
 
             return client;
@@ -151,6 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 [QueueTrigger("NotUsed")] QueueItem item,
                 [CosmosDB(DatabaseName, CollectionName, Id = "{DocumentId}")] JObject document,
                 [CosmosDB(DatabaseName, CollectionName, SqlQuery = "SELECT * FROM c where c.input = {Input}")] IEnumerable<Item> documents,
+                //[CosmosDB(DatabaseName, CollectionName, SqlQuery = "SELECT * FROM c where c.id = {DocumentId}")] IEnumerable<Item> documents1,
                 ILogger log)
             {
                 Assert.NotNull(document);


### PR DESCRIPTION
The PR instantiates the `DefaultCosmosDBServiceFactory`, which uses the AzureComponentFactory passed in from the scale controller. Previously, the ICosmosDBServiceFactory was using the DI implementation, which was using the wrong AzureComponentFactory. This generated tokens that did not correctly authorize on the cosmos side.


## Private Stamp Testing Logs 
[[Kusto Link]](https://wawstest.kusto.windows.net/wawskustotest?query=H4sIAAAAAAAEAH2QzWrDMBCE736KJacYEtmSrNgx5FBKDoG6GOwXUNVtq6IfI28bCn342jn01p6WgflmmSkK6C5gYghoyMYAmuBZE5L1uBWlkPuy2ZdHEGUr6raSTHElGl7nWVHAgIGAA36u929Q8rY6sqaWlVzBwWiH9zFQis5hOq%2f0nH3D9Q0Twk32yXqdvgbSfnrUHuF0gs3LRzCT06QDbeDX3yc0dsZxeXuzwxPSFTHA9p8anEmhDqo55MAYKG9DvgROKb4vK8B46c7DeNf1O%2bhwnvUr7uBhKemy7AebZdFsLwEAAA%3d%3d&web=0)

// MI connection at datetime(2023-08-09 20:27:43.5152817)
// Sent 1 event at datetime(2023-08-09 20:31:49.8734317)
ScaleControllerEvents
| where EventPrimaryStampName == "funcplatant" 
| where PreciseTimeStamp between (datetime(2023-08-09 20:27:41.3256586) .. 5min)
| project TIMESTAMP, Message, Level

