### PR TITLE
Use JArray.Parse instead of JArray.FromObject for string values

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosdbTriggerValueBinder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosdbTriggerValueBinder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         {
             if (_isString)
             {
-                return Task.FromResult<object>(JArray.FromObject(_value).ToString(Newtonsoft.Json.Formatting.None));
+                return Task.FromResult<object>(JArray.Parse(_value as string).ToString(Newtonsoft.Json.Formatting.None));
             }
 
             if (_isJArray)


### PR DESCRIPTION
JArray.FromObject fails if passed a string value. As a result, manual triggering (Test/Run in portal, "Execute Function Now" in VSC, etc.) fails with:

```
System.ArgumentException : Object serialized to String. JArray instance expected.
at Newtonsoft.Json.Linq.JArray.FromObject(Object o,JsonSerializer)
at Newtonsoft.Json.Linq.JArray.FromObject(Object o)
at Microsoft.Azure.WebJobs.Extensions.CosmosDB.CosmosDBTriggerValueBinder.GetValueAsync() at ...\WebJobs.Extensions.CosmosDB\Trigger\CosmosdbTriggerValueBinder.cs : 49
at async Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ParameterHelper.PrepareParametersAsync()
...
```
The proposed change replaces JArray.FromObject with JArray.Parse for string values.

Note: This is for the out-of-process scenario (any language but dotnet). For dotnet, manual triggering also fails, but with an exception originating from the WebJobs SDK.