### PR TITLE
Cosmos DB: Enable TTL on lease container creation

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
+++ b/src/WebJobs.Extensions.CosmosDB/CosmosDBUtility.cs
@@ -59,7 +59,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
             catch (CosmosException cosmosException) when (cosmosException.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
-                ContainerProperties containerProperties = new ContainerProperties(containerName, partitionKey);
+                ContainerProperties containerProperties = new ContainerProperties()
+                {
+                    Id = containerName
+                };
+
+                if (!string.IsNullOrEmpty(partitionKey))
+                {
+                    containerProperties.PartitionKeyPath = partitionKey;
+                }
+
                 if (setTTL)
                 {
                     // Enabling TTL on the container without any defined time. TTL is set on the individual items.

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -140,13 +140,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         {
             try
             {
-                await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(cosmosClient, databaseName, collectionName, LeaseCollectionRequiredPartitionKey, throughput);
+                await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(cosmosClient, databaseName, collectionName, LeaseCollectionRequiredPartitionKey, throughput, setTTL: true);
             }
             catch (CosmosException cosmosException) 
                 when (cosmosException.StatusCode == System.Net.HttpStatusCode.BadRequest
                     && cosmosException.Message.Contains("invalid for Gremlin API"))
             {
-                await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(cosmosClient, databaseName, collectionName, LeaseCollectionRequiredPartitionKeyFromGremlin, throughput);
+                await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(cosmosClient, databaseName, collectionName, LeaseCollectionRequiredPartitionKeyFromGremlin, throughput, setTTL: true);
             }
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBTestUtility.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBTestUtility.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         public const string DatabaseName = "ItemDB";
         public const string ContainerName = "ItemCollection";
 
-        public static Mock<Container> SetupCollectionMock(Mock<CosmosClient> mockService, Mock<Database> mockDatabase, string partitionKeyPath = null, int throughput = 0)
+        public static Mock<Container> SetupCollectionMock(Mock<CosmosClient> mockService, Mock<Database> mockDatabase, string partitionKeyPath, int throughput = 0, bool setTTL = false)
         {
             var mockContainer = new Mock<Container>(MockBehavior.Strict);
 
@@ -46,8 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             if (throughput == 0)
             {
                 mockDatabase
-                    .Setup(m => m.CreateContainerAsync(It.Is<string>(i => i == ContainerName),
-                        It.Is<string>(p => p == partitionKeyPath),
+                    .Setup(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.Id == ContainerName && cp.PartitionKeyPath == partitionKeyPath && (!setTTL || cp.DefaultTimeToLive == -1)),
                         It.Is<int?>(t => t == null),
                         It.IsAny<RequestOptions>(),
                         It.IsAny<CancellationToken>()))
@@ -56,8 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             else
             {
                 mockDatabase
-                    .Setup(m => m.CreateContainerAsync(It.Is<string>(i => i == ContainerName),
-                        It.Is<string>(p => p == partitionKeyPath),
+                    .Setup(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.Id == ContainerName && cp.PartitionKeyPath == partitionKeyPath && (!setTTL || cp.DefaultTimeToLive == -1)),
                         It.Is<int?>(t => t == throughput),
                         It.IsAny<RequestOptions>(),
                         It.IsAny<CancellationToken>()))

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBUtilityTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBUtilityTests.cs
@@ -21,7 +21,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             // Arrange
             var mockService = new Mock<CosmosClient>(MockBehavior.Strict);
             var context = CosmosDBTestUtility.CreateContext(mockService.Object, throughput: 0);
-            CosmosDBTestUtility.SetupCollectionMock(mockService, CosmosDBTestUtility.SetupDatabaseMock(mockService));
+            CosmosDBTestUtility.SetupCollectionMock(mockService, CosmosDBTestUtility.SetupDatabaseMock(mockService), "/id");
+
+            // Act
+            await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(context);
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task CreateIfNotExists_SetsThroughput()
+        {
+            // Arrange
+            int throughput = 1000;
+            var mockService = new Mock<CosmosClient>(MockBehavior.Strict);
+            var context = CosmosDBTestUtility.CreateContext(mockService.Object, throughput: throughput);
+            CosmosDBTestUtility.SetupCollectionMock(mockService, CosmosDBTestUtility.SetupDatabaseMock(mockService), "/id", throughput: throughput);
 
             // Act
             await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(context);
@@ -47,12 +63,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         }
 
         [Fact]
+        public async Task CreateIfNotExists_SetsTTL_IfSpecified()
+        {
+            // Arrange
+            string partitionKeyPath = "partitionKey";
+            var mockService = new Mock<CosmosClient>(MockBehavior.Strict);
+            
+            CosmosDBTestUtility.SetupCollectionMock(mockService, CosmosDBTestUtility.SetupDatabaseMock(mockService), partitionKeyPath, setTTL: true);
+
+            // Act
+            await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(mockService.Object, CosmosDBTestUtility.DatabaseName, CosmosDBTestUtility.ContainerName, partitionKeyPath, throughput: 0, setTTL: true);
+
+            // Assert
+            mockService.VerifyAll();
+        }
+
+        [Fact]
         public async Task CreateIfNotExist_Succeeds()
         {
             // Arrange
             var mockService = new Mock<CosmosClient>(MockBehavior.Strict);
             CosmosDBContext context = CosmosDBTestUtility.CreateContext(mockService.Object);
-            CosmosDBTestUtility.SetupCollectionMock(mockService, CosmosDBTestUtility.SetupDatabaseMock(mockService));
+            CosmosDBTestUtility.SetupCollectionMock(mockService, CosmosDBTestUtility.SetupDatabaseMock(mockService), null);
 
             // Act
             await CosmosDBUtility.CreateDatabaseAndCollectionIfNotExistAsync(context);

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .ThrowsAsync(new CosmosException("not found", System.Net.HttpStatusCode.NotFound, 0, Guid.NewGuid().ToString(), 0));
 
             mockDatabase
-                .Setup(m => m.CreateContainerAsync(It.IsAny<string>(), It.Is<string>(pk => pk == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.PartitionKeyPath == "/id" && cp.DefaultTimeToLive == -1), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Mock.Of<ContainerResponse>());
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             CosmosDBTriggerAttribute cosmosDBTriggerAttribute = parameter.GetCustomAttribute<CosmosDBTriggerAttribute>(inherit: false);
 
             mockDatabase
-                .Verify(m => m.CreateContainerAsync(It.IsAny<string>(), It.Is<string>(pk => pk == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                .Verify(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.PartitionKeyPath == "/id" && cp.DefaultTimeToLive == -1), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Theory]
@@ -401,11 +401,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .ThrowsAsync(new CosmosException("not found", System.Net.HttpStatusCode.NotFound, 0, Guid.NewGuid().ToString(), 0));
 
             mockDatabase
-                .Setup(m => m.CreateContainerAsync(It.IsAny<string>(), It.Is<string>(pk => pk == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.PartitionKeyPath == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new CosmosException("invalid for Gremlin API", System.Net.HttpStatusCode.BadRequest, 0, Guid.NewGuid().ToString(), 0));
 
             mockDatabase
-                .Setup(m => m.CreateContainerAsync(It.IsAny<string>(), It.Is<string>(pk => pk == "/partitionKey"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.PartitionKeyPath == "/partitionKey"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Mock.Of<ContainerResponse>());
 
             var factoryMock = new Mock<ICosmosDBServiceFactory>(MockBehavior.Strict);
@@ -420,10 +420,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             CosmosDBTriggerAttribute cosmosDBTriggerAttribute = parameter.GetCustomAttribute<CosmosDBTriggerAttribute>(inherit: false);
 
             mockDatabase
-                .Verify(m => m.CreateContainerAsync(It.IsAny<string>(), It.Is<string>(pk => pk == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                .Verify(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.PartitionKeyPath == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
 
             mockDatabase
-                .Verify(m => m.CreateContainerAsync(It.IsAny<string>(), It.Is<string>(pk => pk == "/partitionKey"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                .Verify(m => m.CreateContainerAsync(It.Is<ContainerProperties>(cp => cp.PartitionKeyPath == "/id"), It.IsAny<int?>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Theory]


### PR DESCRIPTION
Setting DefaultTimeToLive to `-1` enables TTL on the lease container without explicitly evicting any document except those that have a "ttl" property.

Lease documents do not have a "ttl" property.

Initialization lock however, does. 

Closes https://github.com/Azure/azure-webjobs-sdk-extensions/issues/858