### PR TITLE
Adding [EditorBrowsable(EditorBrowsableState.Never)] for scale api me…

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="builder"></param>
         /// <param name="triggerMetadata">Trigger metadata.</param>
         /// <returns></returns>
-        ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IWebJobsBuilder AddCosmosDbScaleForTrigger(this IWebJobsBuilder builder, TriggerMetadata triggerMetadata)
         {

--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBWebJobsBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger;
@@ -72,6 +73,8 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="builder"></param>
         /// <param name="triggerMetadata">Trigger metadata.</param>
         /// <returns></returns>
+        ///
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static IWebJobsBuilder AddCosmosDbScaleForTrigger(this IWebJobsBuilder builder, TriggerMetadata triggerMetadata)
         {
             IServiceProvider serviceProvider = null;


### PR DESCRIPTION
…thod


The method is used in Scale Controller only - hiding behind `[EditorBrowsable(EditorBrowsableState.Never)]`

Similar change in azure-sdk-for-net:
https://github.com/Azure/azure-sdk-for-net/pull/38686/files