### PR TITLE
Cosmos DB: Correctly handle DrainMode configuration 

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Config/CosmosDBExtensionConfigProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Bindings;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly ICosmosDBSerializerFactory _cosmosSerializerFactory;
         private readonly INameResolver _nameResolver;
         private readonly CosmosDBOptions _options;
+        private readonly IDrainModeManager _drainModeManager;
         private readonly ILoggerFactory _loggerFactory;
 
         public CosmosDBExtensionConfigProvider(
@@ -34,12 +36,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             ICosmosDBServiceFactory cosmosDBServiceFactory,
             ICosmosDBSerializerFactory cosmosSerializerFactory,
             INameResolver nameResolver,
+            IDrainModeManager drainModeManager,
             ILoggerFactory loggerFactory)
         {
             _cosmosDBServiceFactory = cosmosDBServiceFactory;
             _cosmosSerializerFactory = cosmosSerializerFactory;
             _nameResolver = nameResolver;
             _options = options.Value;
+            _drainModeManager = drainModeManager;
             _loggerFactory = loggerFactory;
         }
 
@@ -75,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
             // Trigger
             var rule2 = context.AddBindingRule<CosmosDBTriggerAttribute>();
-            rule2.BindToTrigger(new CosmosDBTriggerAttributeBindingProviderGenerator(_nameResolver, _options, this, _loggerFactory));
+            rule2.BindToTrigger(new CosmosDBTriggerAttributeBindingProviderGenerator(_nameResolver, _options, this, _drainModeManager, _loggerFactory));
         }
 
         internal void ValidateConnection(CosmosDBAttribute attribute, Type paramType)

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -22,13 +22,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly CosmosDBOptions _options;
         private readonly ILogger _logger;
         private readonly CosmosDBExtensionConfigProvider _configProvider;
+        private readonly IDrainModeManager _drainModeManager;
 
-        public CosmosDBTriggerAttributeBindingProvider(INameResolver nameResolver, CosmosDBOptions options,
-            CosmosDBExtensionConfigProvider configProvider, ILoggerFactory loggerFactory)
+        public CosmosDBTriggerAttributeBindingProvider(INameResolver nameResolver,
+            CosmosDBOptions options,
+            CosmosDBExtensionConfigProvider configProvider,
+            IDrainModeManager drainModeManager,
+            ILoggerFactory loggerFactory)
         {
             _nameResolver = nameResolver;
             _options = options;
             _configProvider = configProvider;
+            _drainModeManager = drainModeManager;
             _logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("CosmosDB"));
         }
 
@@ -118,6 +123,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 monitoredContainer,
                 leasesContainer, 
                 attribute,
+                _drainModeManager,
                 _logger);
         }
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -18,14 +19,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly INameResolver _nameResolver;
         private readonly CosmosDBOptions _options;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly IDrainModeManager _drainModeManager;
         private readonly CosmosDBExtensionConfigProvider _configProvider;
 
-        public CosmosDBTriggerAttributeBindingProviderGenerator(INameResolver nameResolver, CosmosDBOptions options,
-            CosmosDBExtensionConfigProvider configProvider, ILoggerFactory loggerFactory)
+        public CosmosDBTriggerAttributeBindingProviderGenerator(INameResolver nameResolver,
+            CosmosDBOptions options,
+            CosmosDBExtensionConfigProvider configProvider,
+            IDrainModeManager drainModeManager,
+            ILoggerFactory loggerFactory)
         {
             _nameResolver = nameResolver;
             _options = options;
             _configProvider = configProvider;
+            _drainModeManager = drainModeManager;
             _loggerFactory = loggerFactory;
         }
 
@@ -57,11 +63,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
             Type genericBindingType = baseType.MakeGenericType(documentType);
 
-            Type[] typeArgs = { typeof(INameResolver), typeof(CosmosDBOptions), typeof(CosmosDBExtensionConfigProvider), typeof(ILoggerFactory) };
+            Type[] typeArgs = { typeof(INameResolver), typeof(CosmosDBOptions), typeof(CosmosDBExtensionConfigProvider), typeof(IDrainModeManager), typeof(ILoggerFactory) };
 
             ConstructorInfo constructor = genericBindingType.GetConstructor(typeArgs);
 
-            object[] constructorParameterValues = { _nameResolver, _options, _configProvider, _loggerFactory };
+            object[] constructorParameterValues = { _nameResolver, _options, _configProvider, _drainModeManager, _loggerFactory };
 
             object cosmosDBTriggerAttributeBindingProvider = constructor.Invoke(constructorParameterValues);
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly Container _monitoredContainer;
         private readonly Container _leaseContainer;
         private readonly CosmosDBTriggerAttribute _cosmosDBAttribute;
+        private readonly IDrainModeManager _drainModeManager;
 
         public CosmosDBTriggerBinding(
             ParameterInfo parameter, 
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             Container monitoredContainer,
             Container leaseContainer,
             CosmosDBTriggerAttribute cosmosDBAttribute,
+            IDrainModeManager drainModeManager,
             ILogger logger)
         {
             _monitoredContainer = monitoredContainer;
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             _cosmosDBAttribute = cosmosDBAttribute;
             _parameter = parameter;
             _processorName = processorName;
+            _drainModeManager = drainModeManager;
             _logger = logger;
         }
 
@@ -85,6 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 this._monitoredContainer, 
                 this._leaseContainer, 
                 this._cosmosDBAttribute,
+                this._drainModeManager,
                 this._logger));
         }
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             }
 
             // Prevent the change feed lease from being checkpointed if cancellation was requested when not in Drain mode
-            _functionExecutionCancellationTokenSource.Token.ThrowIfCancellationRequested();
+            this._functionExecutionCancellationTokenSource.Token.ThrowIfCancellationRequested();
         }
 
         public IScaleMonitor GetMonitor()

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -34,6 +35,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly string _listenerLogDetails;
         private readonly IScaleMonitor<CosmosDBTriggerMetrics> _cosmosDBScaleMonitor;
         private readonly ITargetScaler _cosmosDBTargetScaler;
+        private readonly CancellationTokenSource _functionExecutionCancellationTokenSource;
+        private readonly IDrainModeManager _drainModeManager;
         private ChangeFeedProcessor _host;
         private ChangeFeedProcessorBuilder _hostBuilder;
         private int _listenerStatus;
@@ -45,10 +48,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             Container monitoredContainer,
             Container leaseContainer,
             CosmosDBTriggerAttribute cosmosDBAttribute,
+            IDrainModeManager drainModeManager,
             ILogger logger)
         {
             this._logger = logger;
             this._executor = executor;
+            this._drainModeManager = drainModeManager;
+            this._functionExecutionCancellationTokenSource = new CancellationTokenSource();
             this._processorName = processorName;
             this._hostName = Guid.NewGuid().ToString();
             this._functionId = functionId;
@@ -73,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         public void Dispose()
         {
-            //Nothing to dispose
+            _functionExecutionCancellationTokenSource.Cancel();
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -118,6 +124,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            if (!this._drainModeManager.IsDrainModeEnabled)
+            {
+                this._functionExecutionCancellationTokenSource.Cancel();
+            }
+
             try
             {
                 if (this._host != null)
@@ -211,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private async Task ProcessChangesAsync(ChangeFeedProcessorContext context, IReadOnlyCollection<T> docs, CancellationToken cancellationToken)
         {
             this._healthMonitor.OnChangesDelivered(context);
-            FunctionResult result = await this._executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = docs }, cancellationToken);
+            FunctionResult result = await this._executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = docs }, this._functionExecutionCancellationTokenSource.Token);
             if (result != null // TryExecuteAsync when using RetryPolicies can return null
                 && !result.Succeeded
                 && result.Exception != null)
@@ -220,8 +231,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 await this._healthMonitor.OnErrorAsync(context.LeaseToken, userException);
             }
 
-            // Prevent the change feed lease from being checkpointed if cancellation was requested
-            cancellationToken.ThrowIfCancellationRequested();
+            // Prevent the change feed lease from being checkpointed if cancellation was requested when not in Drain mode
+            _functionExecutionCancellationTokenSource.Token.ThrowIfCancellationRequested();
         }
 
         public IScaleMonitor GetMonitor()

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBConfigurationTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBConfigurationTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         {
             // Arrange
             var options = new CosmosDBOptions();
-            var config = new CosmosDBExtensionConfigProvider(new OptionsWrapper<CosmosDBOptions>(options), new DefaultCosmosDBServiceFactory(_baseConfig, Mock.Of<AzureComponentFactory>()), new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), NullLoggerFactory.Instance);
+            var config = new CosmosDBExtensionConfigProvider(new OptionsWrapper<CosmosDBOptions>(options), new DefaultCosmosDBServiceFactory(_baseConfig, Mock.Of<AzureComponentFactory>()), new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), Mock.Of<IDrainModeManager>(), NullLoggerFactory.Instance);
             var attribute = new CosmosDBAttribute { Id = "abcdef" };
 
             // Act
@@ -104,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             var options = new CosmosDBOptions();
             var factory = new DefaultCosmosDBServiceFactory(_baseConfig, Mock.Of<AzureComponentFactory>());
             var nameResolver = new TestNameResolver();
-            var configProvider = new CosmosDBExtensionConfigProvider(new OptionsWrapper<CosmosDBOptions>(options), factory, new DefaultCosmosDBSerializerFactory(), nameResolver, NullLoggerFactory.Instance);
+            var configProvider = new CosmosDBExtensionConfigProvider(new OptionsWrapper<CosmosDBOptions>(options), factory, new DefaultCosmosDBSerializerFactory(), nameResolver, Mock.Of<IDrainModeManager>(), NullLoggerFactory.Instance);
 
             var context = TestHelpers.CreateExtensionConfigContext(nameResolver);
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -61,6 +63,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 await TestHelpers.Await(() =>
                 {
                     var logMessages = _loggerProvider.GetAllLogMessages();
+                    int count1 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!"));
+                    int count2 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!"));
+                    int count3 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!"));
+                    int count4 = logMessages.Count(p => p.Exception != null && p.Exception.InnerException.Message.Contains("Test exception") && !p.Category.StartsWith("Host.Results"));
+                    Debug.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
+                    Trace.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
                     return logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!")) == 8

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -62,14 +61,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
                 await TestHelpers.Await(() =>
                 {
-                    var logMessages = _loggerProvider.GetAllLogMessages();
-                    int count1 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!"));
-                    int count2 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!"));
-                    int count3 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!"));
-                    int count4 = logMessages.Count(p => p.Exception != null && p.Exception.InnerException.Message.Contains("Test exception") && !p.Category.StartsWith("Host.Results"));
-                    Debug.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
-                    Trace.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
-                    Console.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
                     return logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!")) == 8
@@ -197,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void Trigger(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "test1")]IReadOnlyList<Item> documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "ciTrigger")]IReadOnlyList<Item> documents,
                 ILogger log)
             {
                 foreach (var document in documents)
@@ -207,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void TriggerWithString(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "test2")] string documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "ciTriggerWithString")] string documents,
                 ILogger log)
             {
                 foreach (var document in JArray.Parse(documents))
@@ -218,7 +209,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             [FixedDelayRetry(5, "00:00:01")]
             public static void TriggerWithRetry(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "test3")] IReadOnlyList<Item> documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "ciTriggerWithRetry")] IReadOnlyList<Item> documents,
                 ILogger log)
             {
                 foreach (var document in documents)
@@ -243,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                     DatabaseName,
                     CollectionName,
                     CreateLeaseContainerIfNotExists = true,
-                    LeaseContainerPrefix = "cancellation",
+                    LeaseContainerPrefix = "ciTriggerWithCancellation",
                     LeaseExpirationInterval = 20 * 1000,
                     LeaseRenewInterval = 5 * 1000,
                     FeedPollDelay = 500,

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                     int count4 = logMessages.Count(p => p.Exception != null && p.Exception.InnerException.Message.Contains("Test exception") && !p.Category.StartsWith("Host.Results"));
                     Debug.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
                     Trace.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
+                    Console.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
                     return logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!")) == 8
@@ -196,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void Trigger(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true)]IReadOnlyList<Item> documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "test1")]IReadOnlyList<Item> documents,
                 ILogger log)
             {
                 foreach (var document in documents)
@@ -206,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void TriggerWithString(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "withstring")] string documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "test2")] string documents,
                 ILogger log)
             {
                 foreach (var document in JArray.Parse(documents))
@@ -217,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
             [FixedDelayRetry(5, "00:00:01")]
             public static void TriggerWithRetry(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "retry")] IReadOnlyList<Item> documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "test3")] IReadOnlyList<Item> documents,
                 ILogger log)
             {
                 foreach (var document in documents)

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
     {
         private const string DatabaseName = "E2EDb";
         private const string CollectionName = "E2ECollection";
+        private const string LeaseCollectionName = "leases";
         private readonly TestLoggerProvider _loggerProvider = new TestLoggerProvider();
 
         [Fact]
@@ -73,6 +74,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                     .FormattedMessage;
                 JObject loggedOptions = JObject.Parse(optionsMessage.Substring(optionsMessage.IndexOf(Environment.NewLine)));
                 Assert.Null(loggedOptions["ConnectionMode"].Value<string>());
+
+                // Clean-up leases
+                Container leaseContainer = client.GetContainer(DatabaseName, LeaseCollectionName);
+                using FeedIterator<JObject> leaseIterator = leaseContainer.GetItemQueryIterator<JObject>();
+                while (leaseIterator.HasMoreResults)
+                {
+                    FeedResponse<JObject> leaseIteratorResponse = await leaseIterator.ReadNextAsync();
+                    foreach (JObject lease in leaseIteratorResponse)
+                    {
+                        await leaseContainer.DeleteItemStreamAsync(lease.Value<string>("id"), new PartitionKey(lease.Value<string>("id")));
+                    }
+                }
             }
         }
 
@@ -94,6 +107,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             // Start the host again and wait for the logs to show the cancelled item was reprocessed
             using (var host = await StartHostAsync(typeof(EndToEndCancellationTestClass)))
             {
+                var client = await InitializeDocumentClientAsync(host.Services.GetRequiredService<IConfiguration>(), DatabaseName, CollectionName);
+
                 await TestHelpers.Await(() =>
                 {
                     var logMessages = _loggerProvider.GetAllLogMessages();
@@ -102,6 +117,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Saw the first document again!")) == 1
                         && logMessages.Count(p => p.Exception is TaskCanceledException) > 0;
                 });
+
+                // Clean-up leases
+                Container leaseContainer = client.GetContainer(DatabaseName, LeaseCollectionName);
+                using FeedIterator<JObject> leaseIterator = leaseContainer.GetItemQueryIterator<JObject>();
+                while (leaseIterator.HasMoreResults)
+                {
+                    FeedResponse<JObject> leaseIteratorResponse = await leaseIterator.ReadNextAsync();
+                    foreach (JObject lease in leaseIteratorResponse)
+                    {
+                        await leaseContainer.DeleteItemStreamAsync(lease.Value<string>("id"), new PartitionKey(lease.Value<string>("id")));
+                    }
+                }
             }
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEnumerableBuilderTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -221,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             var options = new OptionsWrapper<CosmosDBOptions>(new CosmosDBOptions
             {
             });
-            var configProvider = new CosmosDBExtensionConfigProvider(options, mockServiceFactory.Object, new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), NullLoggerFactory.Instance);
+            var configProvider = new CosmosDBExtensionConfigProvider(options, mockServiceFactory.Object, new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), Mock.Of<IDrainModeManager>(), NullLoggerFactory.Instance);
 
             return new CosmosDBEnumerableBuilder<T>(configProvider);
         }

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
@@ -67,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
 
             var attribute = new CosmosDBTriggerAttribute(DatabaseName, ContainerName);
 
-            _listener = new CosmosDBTriggerListener<dynamic>(_mockExecutor.Object, _functionId, ProcessorName, _monitoredContainer.Object, _leasesContainer.Object, attribute, _loggerFactory.CreateLogger<CosmosDBTriggerListener<dynamic>>());
+            _listener = new CosmosDBTriggerListener<dynamic>(_mockExecutor.Object, _functionId, ProcessorName, _monitoredContainer.Object, _leasesContainer.Object, attribute, Mock.Of<IDrainModeManager>(), _loggerFactory.CreateLogger<CosmosDBTriggerListener<dynamic>>());
 
             _logDetails = $"prefix='{ProcessorName}', monitoredContainer='{ContainerName}', monitoredDatabase='{DatabaseName}', " +
                 $"leaseContainer='{ContainerName}', leaseDatabase='{DatabaseName}', functionId='{this._functionId}'";
@@ -80,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
            
             var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
 
-            var listener = new MockListener<dynamic>(mockExecutor.Object, _functionId, ProcessorName, _monitoredContainer.Object, _leasesContainer.Object, attribute, _loggerFactory.CreateLogger<CosmosDBTriggerListener<dynamic>>());
+            var listener = new MockListener<dynamic>(mockExecutor.Object, _functionId, ProcessorName, _monitoredContainer.Object, _leasesContainer.Object, attribute, Mock.Of<IDrainModeManager>(), _loggerFactory.CreateLogger<CosmosDBTriggerListener<dynamic>>());
 
             // Ensure that we can call StartAsync() multiple times to retry if there is an error.
             for (int i = 0; i < 3; i++)
@@ -117,8 +118,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
                 Container monitoredContainer,
                 Container leaseContainer,
                 CosmosDBTriggerAttribute cosmosDBAttribute,
+                IDrainModeManager drainModeManager,
                 ILogger logger)
-                : base(executor, functionId, processorName, monitoredContainer, leaseContainer, cosmosDBAttribute, logger)
+                : base(executor, functionId, processorName, monitoredContainer, leaseContainer, cosmosDBAttribute, drainModeManager, logger)
             {
             }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
     public class CosmosDBTriggerAttributeBindingProviderTests
     {
         private readonly ILoggerFactory _loggerFactory = new LoggerFactory();
+        private readonly IDrainModeManager _drainModeManager = Mock.Of<IDrainModeManager>();
         private static readonly IConfiguration _baseConfig = CosmosDBTestUtility.BuildConfiguration(new List<Tuple<string, string>>()
         {
             Tuple.Create(Constants.DefaultConnectionStringName, "AccountEndpoint=https://fromEnvironment;AccountKey=c29tZV9rZXk=;")
@@ -83,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
         [MemberData(nameof(InvalidCosmosDBTriggerParameters))]
         public async Task InvalidParameters_Fail(ParameterInfo parameter)
         {
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(_options, _baseConfig), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(_options, _baseConfig), _drainModeManager, _loggerFactory);
 
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None)));
 
@@ -103,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 })
                 .Build();
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -129,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 })
                 .Build();
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -151,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             nameResolver.Values["aDatabase"] = "myDatabase";
             nameResolver.Values["aCollection"] = "myCollection";
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, _baseConfig), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, _baseConfig), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -180,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 })
                 .Build();
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -204,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
             _options.ConnectionMode = ConnectionMode.Direct;
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -232,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
             _options.UserAgentSuffix = "randomtext";
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -250,7 +252,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
             var nameResolver = new TestNameResolver();
             nameResolver.Values["regions"] = "East US, North Europe,";
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, _baseConfig), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, _baseConfig), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -299,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 })
                 .Build();
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -355,7 +357,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .Setup(f => f.CreateService(It.IsAny<string>(), It.IsAny<CosmosClientOptions>()))
                 .Returns(serviceMock.Object);
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(factoryMock.Object, _options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(factoryMock.Object, _options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -413,7 +415,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 .Setup(f => f.CreateService(It.IsAny<string>(), It.IsAny<CosmosClientOptions>()))
                 .Returns(serviceMock.Object);
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(factoryMock.Object, _options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(factoryMock.Object, _options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -438,7 +440,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 })
                 .Build();
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(new TestNameResolver(), _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -464,7 +466,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
                 })
                 .Build();
 
-            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _loggerFactory);
+            CosmosDBTriggerAttributeBindingProvider<dynamic> provider = new CosmosDBTriggerAttributeBindingProvider<dynamic>(nameResolver, _options, CreateExtensionConfigProvider(_options, config), _drainModeManager, _loggerFactory);
 
             CosmosDBTriggerBinding<dynamic> binding = (CosmosDBTriggerBinding<dynamic>)await provider.TryCreateAsync(new TriggerBindingProviderContext(parameter, CancellationToken.None));
 
@@ -488,7 +490,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
 
         private static CosmosDBExtensionConfigProvider CreateExtensionConfigProvider(ICosmosDBServiceFactory serviceFactory, CosmosDBOptions options, IConfiguration config = null)
         {
-            return new CosmosDBExtensionConfigProvider(new OptionsWrapper<CosmosDBOptions>(options), serviceFactory, new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), NullLoggerFactory.Instance);
+            return new CosmosDBExtensionConfigProvider(new OptionsWrapper<CosmosDBOptions>(options), serviceFactory, new DefaultCosmosDBSerializerFactory(), new TestNameResolver(), Mock.Of<IDrainModeManager>(), NullLoggerFactory.Instance);
         }
 
         // These will use the default for ConnectionStringSetting, but override LeaseConnectionStringSetting


### PR DESCRIPTION
For cases where DrainMode is used, the `TryExecute` call should not be passing a cancelled cancellation.

When StopAsync is called, and if DrainMode is NOT enabled, then a local cancellation will be signaled which is the one passed to `TryExecute` and also verified when checkpointing.

If DrainMode IS enabled, then the cancellation is NOT signaling, which does not block checkpointing.