### PR TITLE
Cosmos DB: Fix Hierarchical PK support

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.3.1$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.4.0$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.33.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0" />

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         [Fact]
         public async Task CosmosDBEndToEnd()
         {
-            Console.WriteLine("start");
-            _loggerProvider.ClearAllLogMessages();
             using (var host = await StartHostAsync(typeof(EndToEndTestClass)))
             {
                 var client = await InitializeDocumentClientAsync(host.Services.GetRequiredService<IConfiguration>(), DatabaseName, CollectionName);
@@ -65,11 +63,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 await TestHelpers.Await(() =>
                 {
                     var logMessages = _loggerProvider.GetAllLogMessages();
-                    int count1 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!"));
-                    int count2 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!"));
-                    int count3 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!"));
-                    int count4 = logMessages.Count(p => p.Exception != null && p.Exception.InnerException.Message.Contains("Test exception") && !p.Category.StartsWith("Host.Results"));
-                    Console.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
                     return logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!")) == 8
@@ -94,17 +87,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                         await leaseContainer.DeleteItemStreamAsync(lease.Value<string>("id"), new PartitionKey(lease.Value<string>("id")));
                     }
                 }
-
-                await host.StopAsync();
             }
-            Console.WriteLine("end");
         }
 
         [Fact]
         public async Task CosmosDBEndToEndCancellation()
         {
-            Console.WriteLine("Cancellationstart");
-            _loggerProvider.ClearAllLogMessages();
             using (var host = await StartHostAsync(typeof(EndToEndCancellationTestClass)))
             {
                 var client = await InitializeDocumentClientAsync(host.Services.GetRequiredService<IConfiguration>(), DatabaseName, CollectionName);
@@ -142,11 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                         await leaseContainer.DeleteItemStreamAsync(lease.Value<string>("id"), new PartitionKey(lease.Value<string>("id")));
                     }
                 }
-
-                await host.StopAsync();
             }
-
-            Console.WriteLine("Cancellationend");
         }
 
         public static async Task<CosmosClient> InitializeDocumentClientAsync(IConfiguration configuration, string databaseName, string collectionName)

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         [Fact]
         public async Task CosmosDBEndToEnd()
         {
+            Console.WriteLine("start");
             _loggerProvider.ClearAllLogMessages();
             using (var host = await StartHostAsync(typeof(EndToEndTestClass)))
             {
@@ -96,11 +97,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
                 await host.StopAsync();
             }
+            Console.WriteLine("end");
         }
 
-        //[Fact]
+        [Fact]
         public async Task CosmosDBEndToEndCancellation()
         {
+            Console.WriteLine("Cancellationstart");
             _loggerProvider.ClearAllLogMessages();
             using (var host = await StartHostAsync(typeof(EndToEndCancellationTestClass)))
             {
@@ -142,6 +145,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
                 await host.StopAsync();
             }
+
+            Console.WriteLine("Cancellationend");
         }
 
         public static async Task<CosmosClient> InitializeDocumentClientAsync(IConfiguration configuration, string databaseName, string collectionName)

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -214,6 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 [CosmosDB(DatabaseName, CollectionName, CreateIfNotExists = true)] IAsyncCollector<object> collector,
                 ILogger log)
             {
+                Console.WriteLine("outputs");
                 for (int i = 0; i < 3; i++)
                 {
                     await collector.AddAsync(new { input = input, id = Guid.NewGuid().ToString() });
@@ -237,6 +238,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             {
                 foreach (var document in documents)
                 {
+                    Console.WriteLine("first" + document.Id);
                     log.LogInformation("Trigger called!");
                 }
             }
@@ -258,6 +260,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             {
                 foreach (var document in documents)
                 {
+                    Console.WriteLine("retry" + document.Id);
                     log.LogInformation($"Trigger with retry called!");
                 }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -63,6 +63,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                 await TestHelpers.Await(() =>
                 {
                     var logMessages = _loggerProvider.GetAllLogMessages();
+                    int count1 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!"));
+                    int count2 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!"));
+                    int count3 = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!"));
+                    int count4 = logMessages.Count(p => p.Exception != null && p.Exception.InnerException.Message.Contains("Test exception") && !p.Category.StartsWith("Host.Results"));
+                    Console.WriteLine($"count1 {count1}, count2, {count2}, count3 {count3}, count4 {count4}");
                     return logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with string called!")) == 4
                         && logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Trigger with retry called!")) == 8
@@ -87,6 +92,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                         await leaseContainer.DeleteItemStreamAsync(lease.Value<string>("id"), new PartitionKey(lease.Value<string>("id")));
                     }
                 }
+
+                await host.StopAsync();
             }
         }
 
@@ -130,6 +137,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
                         await leaseContainer.DeleteItemStreamAsync(lease.Value<string>("id"), new PartitionKey(lease.Value<string>("id")));
                     }
                 }
+
+                await host.StopAsync();
             }
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
         }
 
-        [Fact]
+        //[Fact]
         public async Task CosmosDBEndToEndCancellation()
         {
             _loggerProvider.ClearAllLogMessages();

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         [Fact]
         public async Task CosmosDBEndToEnd()
         {
+            _loggerProvider.ClearAllLogMessages();
             using (var host = await StartHostAsync(typeof(EndToEndTestClass)))
             {
                 var client = await InitializeDocumentClientAsync(host.Services.GetRequiredService<IConfiguration>(), DatabaseName, CollectionName);
@@ -100,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
         [Fact]
         public async Task CosmosDBEndToEndCancellation()
         {
+            _loggerProvider.ClearAllLogMessages();
             using (var host = await StartHostAsync(typeof(EndToEndCancellationTestClass)))
             {
                 var client = await InitializeDocumentClientAsync(host.Services.GetRequiredService<IConfiguration>(), DatabaseName, CollectionName);


### PR DESCRIPTION
New SDK version fixes multiple Hierarchical partition key support scenarios:

* https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3934
* https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3879

## Extra changes

Fixing End To End tests to be resilient to failures and cleanup after execution correctly. Currently when a test fails, it leaves the container lease state behind. Because these tests use the Change Feed, they are accidentally generating data that is consumed by the other test in a subsequent run.