### PR TITLE
[Cosmos DB] Release 4.5.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.4.2$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.5.0$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.4" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0" />


### PR DESCRIPTION
This PR prepares the 4.5.0 release which includes 

1. Bumping the SDK to `3.38.1` 
2. Applying a temporary fix to Scale Controller Metrics APIs. When the Scale Controller runs and the customer Function instances are dormant, there is a chance that the monitored container splits. In this case, the Metrics API is throwing a CosmosException with StatusCode 410. The solution is to return a Metric value that would prompt the Scale Controller to at least start 1 instance, which will take care of handling the split.

Bumping to SDK to `3.38.1` includes related fixes to the Extension:

- [4220](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4220) Change Feed Processor: Fixes disposal of unused CancellationTokenSource (#4220)
- [4276](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4276) Change Feed Processor: Fixes LeaseLostException on Notifications API for Renewer (#4276)
- [4251](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4251) Emulator : Adds support for flag in connection string to ignore SSL check (#4251)

Along other general improvements: https://raw.githubusercontent.com/Azure/azure-cosmos-dotnet-v3/master/changelog.md

Closes https://github.com/Azure/azure-webjobs-sdk-extensions/issues/762