### PR TITLE
Fix scaling for empty lease.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.6.0$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.6.1$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
@@ -88,10 +88,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 // However, it could also signal an issue with the monitoring container configuration.
                 // As a result, we make a limited number of attempts to create the lease container.
                 _assignWorkerOnNotFoundCount++;
-                _logger.LogWarning(Events.OnScaling, $"Possible non-exiting lease container detected. Trying to create the lease container attemt '{_assignWorkerOnNotFoundCount}'",
+                _logger.LogWarning(Events.OnScaling, $"Possible non-exiting lease container detected. Trying to create the lease container, attempt '{_assignWorkerOnNotFoundCount}'",
                     cosmosException.GetType().ToString(), cosmosException.Message);
                 partitionCount = 1;
-                remainingWork = 1;                
+                remainingWork = 1;
             }
             catch (Exception e) when (e is CosmosException || e is InvalidOperationException)
             {

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBMetricsProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBMetricsProviderTests.cs
@@ -78,8 +78,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
 
             var metrics = await _cosmosDbMetricsProvider.GetMetricsAsync();
 
-            Assert.Equal(0, metrics.PartitionCount);
-            Assert.Equal(0, metrics.RemainingWork);
+            Assert.Equal(1, metrics.PartitionCount);
+            Assert.Equal(1, metrics.RemainingWork);
             Assert.NotEqual(default(DateTime), metrics.Timestamp);
 
             _estimatorIterator
@@ -140,12 +140,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
 
             var metrics = (CosmosDBTriggerMetrics)await _cosmosDbMetricsProvider.GetMetricsAsync();
 
-            Assert.Equal(0, metrics.PartitionCount);
-            Assert.Equal(0, metrics.RemainingWork);
+            Assert.Equal(1, metrics.PartitionCount);
+            Assert.Equal(1, metrics.RemainingWork);
             Assert.NotEqual(default(DateTime), metrics.Timestamp);
 
             var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.Equal("Please check that the CosmosDB container and leases container exist and are listed correctly in Functions config files.", warning.FormattedMessage);
+            Assert.StartsWith("Possible non-exiting lease container detected. Trying to create the lease container, attempt", warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await _cosmosDbMetricsProvider.GetMetricsAsync());


### PR DESCRIPTION
CosmosDb trigger need at least one execution to initiate correct lease/checkpoint,


actually it works, we just missing a document in the beginning:
1. FunctionApp is deployed, no assigned workers.
2. SC handles "Non Found" - SC detect empty leases and add a new worker -> worker creates leases container and "ContinuationToken": null doc.
3. SC votes for 0 workers as Delta = 0.
4. Add a doc1 -> SC always votes for 1 worker as Delta = 1. We always have 1 assigned worker.
5. Add doc2 -> triggers executes on doc2 as we have an active worker - proper lease doc is created. The trigger executes fine from this point of time.
doc1 has never triggered.