### PR TITLE
Add Continuation to debug traces

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.6.1$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.7.0$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerHealthMonitor.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerHealthMonitor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         public void OnChangesDelivered(ChangeFeedProcessorContext context)
         {
-            this.logger.LogDebug(Events.OnDelivery, "Events delivered to lease {LeaseToken} with diagnostics {Diagnostics}", context.LeaseToken, context.Diagnostics);
+            this.logger.LogDebug(Events.OnDelivery, "Events delivered to lease {LeaseToken}, Continuation {Continuation} with diagnostics {Diagnostics}", context.LeaseToken, context.Headers.ContinuationToken, context.Diagnostics);
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -19,7 +19,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerHealthMonitorTests.cs
@@ -57,10 +57,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             string diagnosticsString = Guid.NewGuid().ToString();
             Mock<CosmosDiagnostics> diagnostics = new Mock<CosmosDiagnostics>();
             diagnostics.Setup(m => m.ToString()).Returns(diagnosticsString);
+            Headers headers = new Headers();
+            string continuationValue = Guid.NewGuid().ToString();
+            headers["x-ms-continuation"] = continuationValue;
             Mock<ChangeFeedProcessorContext> context = new Mock<ChangeFeedProcessorContext>();
             context.Setup(m => m.LeaseToken).Returns(leaseToken);
             context.Setup(m => m.Diagnostics).Returns(diagnostics.Object);
-
+            context.Setup(m => m.Headers).Returns(headers);
             cosmosDBTriggerHealthMonitor.OnChangesDelivered(context.Object);
 
             Assert.Single(mockedLogger.Events);
@@ -68,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             LogEvent loggedEvent = mockedLogger.Events[0];
             Assert.Equal(LogLevel.Debug, loggedEvent.LogLevel);
             Assert.Null(loggedEvent.Exception);
-            Assert.True(loggedEvent.Message.Contains(leaseToken) && loggedEvent.Message.Contains(diagnosticsString));
+            Assert.True(loggedEvent.Message.Contains(leaseToken) && loggedEvent.Message.Contains(diagnosticsString) && loggedEvent.Message.Contains(continuationValue));
         }
 
         [Theory]


### PR DESCRIPTION
This PR adds the Continuation, useful for Debugging cases when it's relevant to know the current progress of a lease.

It is also increasing the SDK dependency to the latest version.
See more https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md