### PR TITLE
Catch and log all exception in CosmosDBMetricsProvider, 4.8.1 version upgrade

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.9.0$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.8.1$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/build/common.props
+++ b/build/common.props
@@ -3,7 +3,7 @@
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
     <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
-    <CosmosDBVersion>4.8.0$(VersionSuffix)</CosmosDBVersion>
+    <CosmosDBVersion>4.9.0$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             }
             catch (Exception e)
             {
-                _logger.LogWarning(Events.OnScaling, "Exception occurred while obtaining metrics for CosmosDB {0}: {1}.", e.GetType().ToString(), e.Message);
+                _logger.LogWarning(Events.OnScaling, "Exception occurred while obtaining metrics for CosmosDB {0}: {1}.", e.GetType().ToString(), e.ToString());
             }
 
             return new CosmosDBTriggerMetrics

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
@@ -96,6 +96,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
 
                 _logger.LogWarning(Events.OnScaling, errormsg);
             }
+            catch (Exception e)
+            {
+                _logger.LogWarning(Events.OnScaling, "Exception occurred while obtaining metrics for CosmosDB {0}: {1}.", e.GetType().ToString(), e.Message);
+            }
 
             return new CosmosDBTriggerMetrics
             {


### PR DESCRIPTION
We should be catching and logging all exceptions thrown during the CosmosDBMetricsProvider 