### PR TITLE
[TimerTrigger] fixing daylight savings bug

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
-    <ExtensionsVersion>5.0.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
+    <ExtensionsVersion>5.1.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
     <CosmosDBVersion>4.8.1$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.Logger.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.Logger.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 LoggerMessage.Define<string, TimeSpan>(LogLevel.Debug, new EventId(6, nameof(TimerStarted)),
                     "Timer for '{functionName}' started with interval '{interval}'.");
 
+            private static readonly Action<ILogger, DateTime, string, Exception> _ambiguousTimeAdjustment =
+                LoggerMessage.Define<DateTime, string>(LogLevel.Debug, new EventId(7, nameof(AmbiguousTimeAdjustment)),
+                    "The time '{ambiguousTime}' is ambiguous in the time zone '{timeZone}' due to Daylight Savings Time. Ignoring time zone offsets to calculate correct interval.");
+
             public static void ScheduleAndTimeZone(ILogger logger, string functionName, TimerSchedule schedule, string timeZone) =>
                 _scheduleAndTimeZone(logger, functionName, schedule, timeZone, null);
 
@@ -51,6 +55,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
 
             public static void TimerStarted(ILogger logger, string functionName, TimeSpan interval) =>
                 _timerStarted(logger, functionName, interval, null);
+
+            public static void AmbiguousTimeAdjustment(ILogger logger, DateTime ambiguousTime, string timeZone) =>
+                _ambiguousTimeAdjustment(logger, ambiguousTime, timeZone, null);
         }
     }
 }

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.Logger.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.Logger.cs
@@ -34,10 +34,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 LoggerMessage.Define<string, TimeSpan>(LogLevel.Debug, new EventId(6, nameof(TimerStarted)),
                     "Timer for '{functionName}' started with interval '{interval}'.");
 
-            private static readonly Action<ILogger, DateTime, string, Exception> _ambiguousTimeAdjustment =
-                LoggerMessage.Define<DateTime, string>(LogLevel.Debug, new EventId(7, nameof(AmbiguousTimeAdjustment)),
-                    "The time '{ambiguousTime}' is ambiguous in the time zone '{timeZone}' due to Daylight Savings Time. Ignoring time zone offsets to calculate correct interval.");
-
             public static void ScheduleAndTimeZone(ILogger logger, string functionName, TimerSchedule schedule, string timeZone) =>
                 _scheduleAndTimeZone(logger, functionName, schedule, timeZone, null);
 
@@ -55,9 +51,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
 
             public static void TimerStarted(ILogger logger, string functionName, TimeSpan interval) =>
                 _timerStarted(logger, functionName, interval, null);
-
-            public static void AmbiguousTimeAdjustment(ILogger logger, DateTime ambiguousTime, string timeZone) =>
-                _ambiguousTimeAdjustment(logger, ambiguousTime, timeZone, null);
         }
     }
 }

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -114,9 +114,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 // no schedule status has been stored yet, so initialize
                 ScheduleStatus = new ScheduleStatus
                 {
-                    Last = default(DateTime),
+                    Last = default(DateTime).ToLocalTime(),
                     Next = _schedule.GetNextOccurrence(now.LocalDateTime),
-                    LastUpdated = default(DateTime)
+                    LastUpdated = default(DateTime).ToLocalTime()
                 };
             }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             // the current schedule status
             bool isPastDue = false;
 
-            // we use DateTime.Now rather than DateTime.UtcNow to allow the local machine to set the time zone. In Azure this will be
+            // we use DateTimeOffset.Now rather than DateTimeOffset.UtcNow to allow the local machine to set the time zone. In Azure this will be
             // UTC by default, but can be configured to use any time zone if it makes scheduling easier.                        
             DateTimeOffset now = DateTimeOffset.Now;
 
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
         /// <summary>
         /// Invokes the job function.
         /// </summary>
-        /// <param name="invocationTime">The time of the invocation, likely DateTime.Now.</param>
+        /// <param name="invocationTime">The time of the invocation, likely DateTimeOffset.Now.</param>
         /// <param name="isPastDue">True if the invocation is because the invocation is due to a past due timer.</param>
         /// <param name="runOnStartup">True if the invocation is because the timer is configured to run on startup.</param>
         internal async Task InvokeJobFunction(DateTimeOffset invocationTime, bool isPastDue = false, bool runOnStartup = false, DateTimeOffset? originalSchedule = null)

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         // based on whether the next time falls across a DST boundary.
         public override bool AdjustForDST => false;
 
+        /// <inheritdoc />
+        public override bool IsInterval => true;
+
         /// <inheritdoc/>
         public override DateTime GetNextOccurrence(DateTime now)
         {

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         public override DateTime GetNextOccurrence(DateTime now)
         {
             // Note: Tests mock TimeZoneInfo.Local
-            return GetNextOccurrence(new DateTimeOffset(now, TimeZoneInfo.Local.GetUtcOffset(now))).LocalDateTime;
+            return GetNextOccurrence(new DateTimeOffset(now)).LocalDateTime;
         }
 
         private DateTimeOffset GetNextOccurrence(DateTimeOffset now)

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
@@ -29,12 +29,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         [Obsolete("This property is obsolete and will be removed in a future version.")]
         public override bool AdjustForDST => false;
 
-        internal TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Local;
-
         /// <inheritdoc/>
         public override DateTime GetNextOccurrence(DateTime now)
         {
-            return GetNextOccurrence(new DateTimeOffset(now, TimeZone.GetUtcOffset(now))).LocalDateTime;
+            // Note: Tests mock TimeZoneInfo.Local
+            return GetNextOccurrence(new DateTimeOffset(now, TimeZoneInfo.Local.GetUtcOffset(now))).LocalDateTime;
         }
 
         private DateTimeOffset GetNextOccurrence(DateTimeOffset now)

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ConstantSchedule.cs
@@ -26,13 +26,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <inheritdoc/>
         // We always want to run these based on the configured interval. We don't want to adjust
         // based on whether the next time falls across a DST boundary.
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
         public override bool AdjustForDST => false;
 
-        /// <inheritdoc />
-        public override bool IsInterval => true;
+        internal TimeZoneInfo TimeZone { get; set; } = TimeZoneInfo.Local;
 
         /// <inheritdoc/>
         public override DateTime GetNextOccurrence(DateTime now)
+        {
+            return GetNextOccurrence(new DateTimeOffset(now, TimeZone.GetUtcOffset(now))).LocalDateTime;
+        }
+
+        private DateTimeOffset GetNextOccurrence(DateTimeOffset now)
         {
             TimeSpan nextInterval = _interval;
             if (_intervalOverride != null)

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/CronSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/CronSchedule.cs
@@ -113,6 +113,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
             return next;
         }
 
+        /// <summary>
+        /// Uses the 'now' and 'next' values to determine if either is ambiguous. If they are, adjusts the times
+        /// so that they are unambiguous, depending on the time of schedule it is (interval or point-in-time).
+        /// Uses TimeZoneInfo.Local to make the determination.
+        /// </summary>
+        /// <param name="now">The DateTimeOffset that represents the current time.</param>
+        /// <param name="next">The DateTimeOffset that represents the next occurrence.</param>
+        /// <param name="adjusted">The adjusted DateTimeOffset, if "next" is invalid.</param>
+        /// <returns>True if the 'next' time was adjusted. Otherwise, false.</returns>        
         internal bool TryAdjustAmbiguousTime(DateTimeOffset now, DateTimeOffset next, out DateTimeOffset? adjusted)
         {
             adjusted = null;

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/CronSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/CronSchedule.cs
@@ -120,11 +120,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         internal bool TryAdjustInvalidTime(DateTimeOffset next, out DateTimeOffset? adjusted)
         {
             adjusted = null;
-            DateTimeOffset converted = TimeZoneInfo.ConvertTime(next, TimeZoneInfo.Local);
 
-            if (converted.Offset != next.Offset)
+            if (TimeZoneInfo.Local.IsInvalidTime(next.DateTime))
             {
-                adjusted = converted;
+                // This forces the offset to be recalculated for the local time zone. It will also signal that we don't need to do the
+                // ambiguous time calculations as this cannot happen during ambiguous times.
+                adjusted = next.ToLocalTime();
                 _logger.LogDebug(new EventId(900, "DstInvalidTime"), $"The calculated next occurrence for the schedule '{_cronSchedule}' of '{next}' was determined to be an invalid time in the time zone '{TimeZoneInfo.Local.DisplayName}' due to Daylight Saving Time. The adjusted next occurrence is '{adjusted}'.");
                 return true;
             }

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
@@ -43,10 +43,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         }
 
         /// <inheritdoc/>
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
         public override bool AdjustForDST => true;
-
-        /// <inheritdoc />
-        public override bool IsInterval => true;
 
         /// <inheritdoc/>
         public override DateTime GetNextOccurrence(DateTime now)

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/DailySchedule.cs
@@ -45,6 +45,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <inheritdoc/>
         public override bool AdjustForDST => true;
 
+        /// <inheritdoc />
+        public override bool IsInterval => true;
+
         /// <inheritdoc/>
         public override DateTime GetNextOccurrence(DateTime now)
         {

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
-using NCrontab;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Timers
 {
@@ -20,6 +19,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// Gets a value indicating whether intervals between invocations should account for DST.        
         /// </summary>
         public abstract bool AdjustForDST { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the schedule is an interval schedule as opposed to a point-in-time schedule.
+        /// For example, a schedule that fires every 5 minutes is an interval schedule, while a schedule that fires at
+        /// 5pm every day is a point-in-time schedule.
+        /// </summary>
+        public abstract bool IsInterval { get; }
 
         /// <summary>
         /// Gets the next occurrence of the schedule based on the specified

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
             if (!string.IsNullOrEmpty(attribute.ScheduleExpression))
             {
                 string resolvedExpression = nameResolver.ResolveWholeString(attribute.ScheduleExpression);
-                if (CronSchedule.TryCreate(resolvedExpression, out CronSchedule cronSchedule))
+                if (CronSchedule.TryCreate(resolvedExpression, logger, out CronSchedule cronSchedule))
                 {
                     schedule = cronSchedule;
                     if (attribute.UseMonitor && ShouldDisableScheduleMonitor(cronSchedule, DateTime.Now))

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/TimerSchedule.cs
@@ -18,14 +18,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <summary>
         /// Gets a value indicating whether intervals between invocations should account for DST.        
         /// </summary>
+        [Obsolete("This property is obsolete and will be removed in a future version. All TimerSchedule implementations should now handle their own DST transitions.")]
         public abstract bool AdjustForDST { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the schedule is an interval schedule as opposed to a point-in-time schedule.
-        /// For example, a schedule that fires every 5 minutes is an interval schedule, while a schedule that fires at
-        /// 5pm every day is a point-in-time schedule.
-        /// </summary>
-        public abstract bool IsInterval { get; }
 
         /// <summary>
         /// Gets the next occurrence of the schedule based on the specified

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         /// <inheritdoc/>
         public override bool AdjustForDST => true;
 
+        /// <inheritdoc />
+        public override bool IsInterval => true;
+
         /// <summary>
         /// Adds the specified day/time occurrence to the schedule.
         /// </summary>

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/WeeklySchedule.cs
@@ -16,10 +16,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         private readonly List<TimeSpan>[] schedule = new List<TimeSpan>[7];
 
         /// <inheritdoc/>
+        [Obsolete("This property is obsolete and will be removed in a future version.")]
         public override bool AdjustForDST => true;
-
-        /// <inheritdoc />
-        public override bool IsInterval => true;
 
         /// <summary>
         /// Adds the specified day/time occurrence to the schedule.

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
-    <PackageReference Include="ncrontab.signed" Version="3.3.2" />
+    <PackageReference Include="ncrontab.signed" Version="3.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions</RootNamespace>
     <PackageId>Microsoft.Azure.WebJobs.Extensions</PackageId>
+    <LangVersion>Latest</LangVersion>
     <Description>This package contains Timers and File triggers. For more information, please visit https://azure.microsoft.com/en-us/documentation/articles/websites-webjobs-resources.</Description>
   </PropertyGroup>
   <Import Project="..\..\build\common.props" />

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -490,49 +490,49 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         public static IEnumerable<object[]> CronTimerSchedulesExitingDST =>
         [
             // Starts in ambiguous PDT, ends in PST. Run every hour at the 30 minute mark.
-            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-7)), "0 30 * * * *", TimeSpan.FromMinutes(59), 1],
+            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-7)), "0 30 * * * *", TimeSpan.FromMinutes(59)],
 
             // Starts in ambiguous PDT, ends in PST. Run every minute.
-            [new DateTimeOffset(2018, 11, 4, 1, 59, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1), 1],
+            [new DateTimeOffset(2018, 11, 4, 1, 59, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1)],
 
             // Starts in ambiguous PDT, ends in ambiguous PDT. Run every minute.
-            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1), 1],
+            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1)],
 
             // Starts in ambiguous PDT, ends in ambiguous PST. Run at 1:00/1:30/2:00/2:30. This is considered an interval and should
             // should run 6 times during the PDT -> PST transition.
-            [new DateTimeOffset(2018, 11, 4, 1, 45, 0, TimeSpan.FromHours(-7)), "0 0,30 1-2 * * *", TimeSpan.FromMinutes(15), 1],
+            [new DateTimeOffset(2018, 11, 4, 1, 45, 0, TimeSpan.FromHours(-7)), "0 0,30 1-2 * * *", TimeSpan.FromMinutes(15)],
 
             // Starts in ambiguous PST, ends in ambiguous PST. Run at 1:30/2:30. This is considered an interval and should
             // should run 6 times during the PDT -> PST transition. No log is expected because no adjustment is performed as the
             // offsets match in this case.
-            [new DateTimeOffset(2018, 11, 4, 1, 45, 0, TimeSpan.FromHours(-8)), "0 0,30 1-3 * * *", TimeSpan.FromMinutes(15), 0],
+            [new DateTimeOffset(2018, 11, 4, 1, 45, 0, TimeSpan.FromHours(-8)), "0 0,30 1-3 * * *", TimeSpan.FromMinutes(15)],
 
             // Starts in ambiguous PST, ends in ambiguous PDT. Run every minute for a range.
-            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 * 1-3 * * *", TimeSpan.FromMinutes(1), 1],
+            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 * 1-3 * * *", TimeSpan.FromMinutes(1)],
 
             // Starts in PDT, ends in ambiguous PDT. Run every minute.
-            [new DateTimeOffset(2018, 11, 4, 0, 59, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1), 1],
+            [new DateTimeOffset(2018, 11, 4, 0, 59, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1)],
 
             // Starts in ambiguous PST, ends in PST. Run every hour at the 30 minute mark.
-            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-8)), "0 30 * * * *", TimeSpan.FromMinutes(59), 0],
+            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-8)), "0 30 * * * *", TimeSpan.FromMinutes(59)],
 
             // Starts in PDT, ends in PST. Run every Friday at 6 PM.
-            [new DateTimeOffset(2018, 11, 2, 18, 0, 0, TimeSpan.FromHours(-7)), "0 0 18 * * 5", TimeSpan.FromHours(169), 0],
+            [new DateTimeOffset(2018, 11, 2, 18, 0, 0, TimeSpan.FromHours(-7)), "0 0 18 * * 5", TimeSpan.FromHours(169)],
 
             // Starts in ambiguous PDT, ends in PST. Run every day at 1:30 (only expect one invocation during ambiguous times).
-            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromHours(25), 0],
+            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromHours(25)],
 
             // Starts in PDT, ends in ambgiguous PDT. Run every day at 1:30 (only expect one invocation during ambiguous times).
-            [new DateTimeOffset(2018, 11, 4, 0, 30, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromHours(1), 0],
+            [new DateTimeOffset(2018, 11, 4, 0, 30, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromHours(1)],
 
             // Starts in ambiguous PDT, ends in ambgiguous PDT. Run every day at 1:30 (only expect one invocation during ambiguous times).
-            [new DateTimeOffset(2018, 11, 4, 1, 29, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromMinutes(1), 0],
+            [new DateTimeOffset(2018, 11, 4, 1, 29, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromMinutes(1)],
 
             // Starts in ambiguous PST, ends in PST. Run every day at 1:30 (only expect one invocation during ambiguous times).
-            [new DateTimeOffset(2018, 11, 4, 1, 29, 0, TimeSpan.FromHours(-8)), "0 30 1 * * *", TimeSpan.Parse("1.00:01"), 0],
+            [new DateTimeOffset(2018, 11, 4, 1, 29, 0, TimeSpan.FromHours(-8)), "0 30 1 * * *", TimeSpan.Parse("1.00:01")],
 
             // Starts in ambiguous PDT, ends in PST. Run every day at 1:30 (only expect one invocation during ambiguous times).
-            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.Parse("1.00:59"), 0],
+            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.Parse("1.00:59")],
         ];
 
         /// <summary>
@@ -550,8 +550,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             // DST doesn't transition the test might not be valid.
             // The input schedules will run after DST changes. For some (Cron), they will subtract
             // an hour to account for the shift. For others (Constant), they will not.
-            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(new DateTime(2018, 3, 9, 18, 0, 0));
-            var now = new DateTimeOffset(2018, 3, 9, 18, 0, 0, offset);
+            var start = new DateTime(2018, 3, 9, 18, 0, 0, DateTimeKind.Local);
+            var now = new DateTimeOffset(start);
 
             var next = schedule.GetNextOccurrence(now.LocalDateTime);
             var interval = TimerListener.GetNextTimerInterval(next, now);
@@ -573,9 +573,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             // Running at 1:59 AM, i.e. one minute before the DST switch at 2 AM on 3/11 (Pacific Standard Time)
             // Note: this test uses Local time, so if you're running in a timezone where
             // DST doesn't transition the test might not be valid.
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-            TimeSpan offset = pst.GetUtcOffset(new DateTime(2018, 3, 11, 1, 59, 0));
-            var now = new DateTimeOffset(2018, 3, 11, 1, 59, 0, offset);
+            var start = new DateTime(2018, 3, 11, 1, 59, 0, DateTimeKind.Local);
+            var now = new DateTimeOffset(start);
 
             var next = schedule.GetNextOccurrence(now.DateTime);
 
@@ -589,20 +588,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         /// </summary>
         [Theory]
         [MemberData(nameof(CronTimerSchedulesExitingDST))]
-        public void GetNextInterval_NextAfterDSTEnds_ReturnsExpectedValue(DateTimeOffset now, string cronSchedule, TimeSpan expectedInterval, int expectedLogCount)
+        public void GetNextInterval_NextAfterDSTEnds_ReturnsExpectedValue(DateTimeOffset now, string cronSchedule, TimeSpan expectedInterval)
         {
             SetLocalTimeZoneToPacific();
 
             var schedule = new CronSchedule(CrontabSchedule.Parse(cronSchedule, new CrontabSchedule.ParseOptions() { IncludingSeconds = true }));
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
 
             var logger = new TestLogger(null);
-
             var next = schedule.GetNextOccurrence(now.LocalDateTime);
             var interval = TimerListener.GetNextTimerInterval(next, now);
 
             Assert.Equal(expectedInterval, interval);
-            //Assert.Equal(expectedLogCount, logger.GetLogMessages().Count);
         }
 
         [Fact]
@@ -667,16 +663,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
         internal static void SetLocalTimeZoneToPacific()
         {
+            // There are so many internal benefits to using DateTimeKind.Local for us, that we're relying 
+            // on it to provide the proper roundtripping support between DateTime and DateTimeOffset. This appears
+            // to be the only way to "mock" this value as it's hard-coded inside a lot of .NET libraries when
+            // calculating offsets, time zones, etc.
             var info = typeof(TimeZoneInfo).GetField("s_cachedData", BindingFlags.NonPublic | BindingFlags.Static);
             var cachedData = info.GetValue(null);
-            var field = cachedData.GetType().GetField("_localTimeZone",
-                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            var field = cachedData.GetType().GetField("_localTimeZone", BindingFlags.NonPublic | BindingFlags.Instance);
             field.SetValue(cachedData, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
         }
 
-        public void Dispose()
-        {
-            TimeZoneInfo.ClearCachedData();
-        }
+        public void Dispose() => TimeZoneInfo.ClearCachedData();
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Listeners;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NCrontab;
 using Xunit;
@@ -642,7 +643,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 RunOnStartup = runOnStartup
             };
 
-            _schedule = TimerSchedule.Create(_attribute, new TestNameResolver(), _logger);
+            ILogger logger = (ILogger)_logger ?? NullLogger.Instance;
+            _schedule = TimerSchedule.Create(_attribute, new TestNameResolver(), logger);
             _attribute.UseMonitor = useMonitor;
             _options = new TimersOptions();
             _mockScheduleMonitor = new Mock<ScheduleMonitor>(MockBehavior.Strict);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Listeners;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NCrontab;
 using Xunit;
@@ -473,27 +474,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             await RunInitialStatusTestAsync(null, $"Function '{_functionShortName}' initial status: Last='(null)', Next='(null)', LastUpdated='(null)'");
         }
 
-        public static IEnumerable<object[]> TimerSchedulesAfterDST => new object[][]
-        {
-            new object[] { new CronSchedule(CrontabSchedule.Parse("0 0 18 * * 5", new CrontabSchedule.ParseOptions() { IncludingSeconds = true })), TimeSpan.FromHours(167) },
-            new object[] { new ConstantSchedule(TimeSpan.FromDays(7)), TimeSpan.FromDays(7) },
-        };
+        public static IEnumerable<object[]> TimerSchedulesEnteringDST =>
+        [
+            [new CronSchedule(CrontabSchedule.Parse("0 0 18 * * 5", new CrontabSchedule.ParseOptions() { IncludingSeconds = true })), TimeSpan.FromHours(167)],
+            [new ConstantSchedule(TimeSpan.FromDays(7)), TimeSpan.FromDays(7)],
+        ];
 
-        public static IEnumerable<object[]> TimerSchedulesWithinDST => new object[][]
-        {
-            new object[] { new CronSchedule(CrontabSchedule.Parse("0 59 * * * *", new CrontabSchedule.ParseOptions() { IncludingSeconds = true })), TimeSpan.FromHours(1) },
-            new object[] { new ConstantSchedule(TimeSpan.FromMinutes(5)), TimeSpan.FromMinutes(5) },
-        };
+        public static IEnumerable<object[]> TimerSchedulesWithinDST =>
+        [
+            [new CronSchedule(CrontabSchedule.Parse("0 59 * * * *", new CrontabSchedule.ParseOptions() { IncludingSeconds = true })), TimeSpan.FromHours(1)],
+            [new ConstantSchedule(TimeSpan.FromMinutes(5)), TimeSpan.FromMinutes(5)],
+        ];
+
+        // Note: In Pacific time, DST (UTC -7) ends at 2 AM on 11/4/2018. The clocks go back to 1 AM (with UTC -8).
+        public static IEnumerable<object[]> CronTimerSchedulesExitingDST =>
+        [
+            // Starts in ambiguous PDT, ends in PST. Run every hour at the 30 minute mark.
+            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-7)), "0 30 * * * *", TimeSpan.FromMinutes(59), 1],
+
+            // Starts in ambiguous PDT, ends in PST. Run every minute.
+            [new DateTimeOffset(2018, 11, 4, 1, 59, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1), 1],
+
+            // Starts in ambiguous PDT, ends in ambiguous PDT. Run every minute.
+            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1), 1],
+
+            // Starts in ambiguous PDT, ends in ambiguous PST. Run at 1:00/1:30/2:00/2:30. This is considered an interval and should
+            // should run 6 times during the PDT -> PST transition.
+            [new DateTimeOffset(2018, 11, 4, 1, 45, 0, TimeSpan.FromHours(-7)), "0 0,30 1-2 * * *", TimeSpan.FromMinutes(15), 1],
+
+            // Starts in ambiguous PST, ends in ambiguous PST. Run at 1:30/2:30. This is considered an interval and should
+            // should run 6 times during the PDT -> PST transition. No log is expected because no adjustment is performed as the
+            // offsets match in this case.
+            [new DateTimeOffset(2018, 11, 4, 1, 45, 0, TimeSpan.FromHours(-8)), "0 0,30 1-3 * * *", TimeSpan.FromMinutes(15), 0],
+
+            // Starts in ambiguous PST, ends in ambiguous PDT. Run every minute for a range.
+            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 * 1-3 * * *", TimeSpan.FromMinutes(1), 1],
+
+            // Starts in PDT, ends in ambiguous PDT. Run every minute.
+            [new DateTimeOffset(2018, 11, 4, 0, 59, 0, TimeSpan.FromHours(-7)), "0 * * * * *", TimeSpan.FromMinutes(1), 1],
+
+            // Starts in ambiguous PST, ends in PST. Run every hour at the 30 minute mark.
+            [new DateTimeOffset(2018, 11, 4, 1, 31, 0, TimeSpan.FromHours(-8)), "0 30 * * * *", TimeSpan.FromMinutes(59), 0],
+
+            // Starts in PDT, ends in PST. Run every Friday at 6 PM.
+            [new DateTimeOffset(2018, 11, 2, 18, 0, 0, TimeSpan.FromHours(-7)), "0 0 18 * * 5", TimeSpan.FromHours(169), 0],
+
+            // Starts in ambiguous PDT, ends in PST. Run every day at 1:30 (only expect one invocation during ambiguous times).
+            [new DateTimeOffset(2018, 11, 4, 1, 30, 0, TimeSpan.FromHours(-7)), "0 30 1 * * *", TimeSpan.FromHours(25), 0],
+        ];
 
         /// <summary>
         /// Situation where the DST transition happens in the middle of the schedule, with the
         /// next occurrence AFTER the DST transition.
         /// </summary>
         [Theory]
-        [MemberData(nameof(TimerSchedulesAfterDST))]
-        public void GetNextInterval_NextAfterDST_ReturnsExpectedValue(TimerSchedule schedule, TimeSpan expectedInterval)
+        [MemberData(nameof(TimerSchedulesEnteringDST))]
+        public void GetNextInterval_NextAfterDSTBegins_ReturnsExpectedValue(TimerSchedule schedule, TimeSpan expectedInterval)
         {
-            // Running on the Friday before the DST switch at 2 AM on 3/11 (Pacific Standard Time)
+            // Running on the Friday before DST *begins* at 2 AM on 3/11 (Pacific Standard Time)
             // Note: this test uses Local time, so if you're running in a timezone where
             // DST doesn't transition the test might not be valid.
             // The input schedules will run after DST changes. For some (Cron), they will subtract
@@ -503,7 +541,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             var now = new DateTimeOffset(2018, 3, 9, 18, 0, 0, offset);
 
             var next = schedule.GetNextOccurrence(now.DateTime);
-            var interval = TimerListener.GetNextTimerInterval(next, now.DateTime, schedule.AdjustForDST, pst);
+            var interval = TimerListener.GetNextTimerInterval(next, now, schedule.AdjustForDST, schedule.IsInterval, NullLogger.Instance, pst);
 
             // One week is normally 168 hours, but it's 167 hours across DST
             Assert.Equal(interval, expectedInterval);
@@ -526,17 +564,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
             var next = schedule.GetNextOccurrence(now.DateTime);
 
-            var interval = TimerListener.GetNextTimerInterval(next, now.DateTime, schedule.AdjustForDST, pst);
+            TestLogger logger = new(null);
+            var interval = TimerListener.GetNextTimerInterval(next, now, schedule.AdjustForDST, schedule.IsInterval, logger, pst);
             Assert.Equal(expectedInterval, interval);
+        }
+
+        /// <summary>
+        /// Situation where we exit DST and the next occurrence is in the hour that is repeated.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(CronTimerSchedulesExitingDST))]
+        public void GetNextInterval_NextAfterDSTEnds_ReturnsExpectedValue(DateTimeOffset now, string cronSchedule, TimeSpan expectedInterval, int expectedLogCount)
+        {
+            var schedule = new CronSchedule(CrontabSchedule.Parse(cronSchedule, new CrontabSchedule.ParseOptions() { IncludingSeconds = true }));
+            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            var logger = new TestLogger(null);
+
+            var next = schedule.GetNextOccurrence(now.LocalDateTime);
+            var interval = TimerListener.GetNextTimerInterval(next, now, schedule.AdjustForDST, schedule.IsInterval, logger, pst);
+
+            Assert.Equal(expectedInterval, interval);
+            Assert.Equal(expectedLogCount, logger.GetLogMessages().Count);
         }
 
         [Fact]
         public void GetNextInterval_NegativeInterval_ReturnsOneTick()
         {
-            var now = DateTime.Now;
-            var next = now.Subtract(TimeSpan.FromSeconds(1));
+            var now = DateTimeOffset.Now;
+            var next = now.Subtract(TimeSpan.FromSeconds(1)).LocalDateTime;
 
-            var interval = TimerListener.GetNextTimerInterval(next, now, true);
+            var interval = TimerListener.GetNextTimerInterval(next, now, true, true, NullLogger.Instance);
             Assert.Equal(1, interval.Ticks);
         }
 

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ConstantScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ConstantScheduleTests.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         {
             ConstantSchedule schedule = new ConstantSchedule(TimeSpan.FromHours(1));
 
-            DateTime now = DateTime.Now;
+            DateTimeOffset now = DateTimeOffset.Now;
 
             for (int i = 0; i < 10; i++)
             {
-                DateTime nextOccurrence = schedule.GetNextOccurrence(now);
+                DateTimeOffset nextOccurrence = schedule.GetNextOccurrence(now.LocalDateTime);
                 Assert.Equal(new TimeSpan(1, 0, 0), nextOccurrence - now);
 
                 now = nextOccurrence;
@@ -30,19 +30,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         {
             ConstantSchedule schedule = new ConstantSchedule(TimeSpan.FromSeconds(30));
 
-            DateTime now = DateTime.Now;
-            DateTime nextOccurrence = schedule.GetNextOccurrence(now);
+            DateTimeOffset now = DateTimeOffset.Now;
+            DateTimeOffset nextOccurrence = schedule.GetNextOccurrence(now.LocalDateTime);
             Assert.Equal(new TimeSpan(0, 0, 30), nextOccurrence - now);
             now = nextOccurrence;
-            
+
             // next interval is overidden
             schedule.SetNextInterval(new TimeSpan(1, 0, 0));
-            nextOccurrence = schedule.GetNextOccurrence(now);
+            nextOccurrence = schedule.GetNextOccurrence(now.LocalDateTime);
             Assert.Equal(new TimeSpan(1, 0, 0), nextOccurrence - now);
             now = nextOccurrence;
 
             // subsequent intervals are not
-            nextOccurrence = schedule.GetNextOccurrence(now);
+            nextOccurrence = schedule.GetNextOccurrence(now.LocalDateTime);
             Assert.Equal(new TimeSpan(0, 0, 30), nextOccurrence - now);
             now = nextOccurrence;
         }
@@ -53,6 +53,56 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             ConstantSchedule schedule = new ConstantSchedule(TimeSpan.FromSeconds(30));
 
             Assert.Equal("Constant: 00:00:30", schedule.ToString());
+        }
+
+        [Fact]
+        public void Interval_IntoDST_ReturnsExpectedValue()
+        {
+            var schedule = new ConstantSchedule(TimeSpan.FromHours(1));
+
+            // Standard -> Daylight occurred on 3/11/2018 at 02:00            
+            var start = new DateTime(2018, 3, 10, 23, 30, 0, DateTimeKind.Local);
+            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            TimeSpan offset = pst.GetUtcOffset(start);
+            var now = new DateTimeOffset(start, offset);
+            schedule.TimeZone = pst;
+
+            var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
+
+            // Cast DateTime to DateTimeOffset so we can see the internally-stored offset details.
+            // This is how we internally do all of our calculations.
+            Assert.Collection(nextOccurrences,
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 3, 11, 0, 30, 0), TimeSpan.FromHours(-8)), o),
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 3, 11, 1, 30, 0), TimeSpan.FromHours(-8)), o),
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 3, 11, 3, 30, 0), TimeSpan.FromHours(-7)), o), // offset changes
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 3, 11, 4, 30, 0), TimeSpan.FromHours(-7)), o),
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 3, 11, 5, 30, 0), TimeSpan.FromHours(-7)), o));
+        }
+
+        [Fact]
+        public void Interval_OutOfDST_ReturnsExpectedValue()
+        {
+            var schedule = new ConstantSchedule(TimeSpan.FromHours(1));
+
+            // Standard -> Daylight occurred on 11/04/2018 at 02:00 (time went back to 01:00)            
+            var start = new DateTime(2018, 11, 3, 23, 30, 0, DateTimeKind.Local);
+            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+
+            TimeSpan offset = pst.GetUtcOffset(start);
+            var now = new DateTimeOffset(start, offset);
+            schedule.TimeZone = pst;
+
+            var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
+
+            // Cast DateTime to DateTimeOffset so we can see the internally-stored offset details.
+            // This is how we internally do all of our calculations.
+            Assert.Collection(nextOccurrences,
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 0, 30, 0), TimeSpan.FromHours(-7)), o),
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 1, 30, 0), TimeSpan.FromHours(-7)), o),
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 1, 30, 0), TimeSpan.FromHours(-8)), o), // offset changes
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 2, 30, 0), TimeSpan.FromHours(-8)), o),
+                o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 3, 30, 0), TimeSpan.FromHours(-8)), o));
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Xunit;
 
@@ -54,9 +55,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         public void Interval_IntoDST_ReturnsExpectedValue()
         {
             TimerListenerTests.SetLocalTimeZoneToPacific();
+            var testLogger = new TestLogger("Test");
 
             // Every hour at the 30 min mark
-            CronSchedule.TryCreate("0 30 * * * *", out CronSchedule schedule);
+            CronSchedule.TryCreate("0 30 * * * *", testLogger, out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 3/11/2018 at 02:00 (time skipped ahead to 3:00)
             var start = new DateTime(2018, 3, 11, 0, 0, 0, DateTimeKind.Local);
@@ -132,9 +134,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         public void Interval_OutOfDST_ReturnsExpectedValue()
         {
             TimerListenerTests.SetLocalTimeZoneToPacific();
+            var logger = new TestLogger("Test");
 
             // Every hour at the 30 min mark
-            CronSchedule.TryCreate("0 30 * * * *", out CronSchedule schedule);
+            CronSchedule.TryCreate("0 30 * * * *", logger, out CronSchedule schedule);
 
             // Daylight -> Standard occurred on 11/04/2018 at 02:00 (time went back to 01:00)
             var start = new DateTime(2018, 11, 4, 0, 0, 0, DateTimeKind.Local);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
 {
-    public class CronScheduleTests
+    public class CronScheduleTests : IDisposable
     {
         [Fact]
         public void GetNextOccurrence_NowEqualToNext_ReturnsCorrectValue()
@@ -53,16 +53,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void Interval_IntoDST_ReturnsExpectedValue()
         {
+            TimerListenerTests.SetLocalTimeZoneToPacific();
+
             // Every hour at the 30 min mark
             CronSchedule.TryCreate("0 30 * * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 3/11/2018 at 02:00 (time skipped ahead to 3:00)
-            var start = new DateTime(2018, 3, 11, 0, 0, 0, DateTimeKind.Local);
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-
-            TimeSpan offset = pst.GetUtcOffset(start);
+            var start = new DateTime(2018, 3, 11, 0, 0, 0);
+            var offset = TimeZoneInfo.Local.GetUtcOffset(start);
             var now = new DateTimeOffset(start, offset);
-            schedule.TimeZone = pst;
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -79,15 +78,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void PointInTime_IntoDST_ReturnsExpectedValue()
         {
+            TimerListenerTests.SetLocalTimeZoneToPacific();
+
             // 01:30 every day
             CronSchedule.TryCreate("0 30 1 * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 3/11/2018 at 02:00 (time skipped ahead to 3:00)
             var start = new DateTime(2018, 3, 10, 0, 0, 0);
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-            TimeSpan offset = pst.GetUtcOffset(start);
+            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(start);
             var now = new DateTimeOffset(start, offset);
-            schedule.TimeZone = pst;
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -104,15 +103,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void PointInTime_WithinAmbiguousHour_ReturnsExpectedValue()
         {
+            TimerListenerTests.SetLocalTimeZoneToPacific();
+
             // every 20 minutes
             CronSchedule.TryCreate("0 */20 * * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 11/04/2018 at 02:00 (time went back to 01:00)
             // Ambigous hour is 01:00 - 01:59 as there are two instances in of these in the day.
-            var start = new DateTime(2018, 11, 4, 0, 30, 0);
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var start = new DateTime(2018, 11, 4, 0, 30, 0, DateTimeKind.Local);
             var now = new DateTimeOffset(start, TimeSpan.FromHours(-7));
-            schedule.TimeZone = pst;
 
             // just enough to go fully through the ambiguous time
             var nextOccurrences = schedule.GetNextOccurrences(9, now.LocalDateTime);
@@ -134,16 +133,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void Interval_OutOfDST_ReturnsExpectedValue()
         {
+            TimerListenerTests.SetLocalTimeZoneToPacific();
+
             // Every hour at the 30 min mark
             CronSchedule.TryCreate("0 30 * * * *", out CronSchedule schedule);
 
             // Daylight -> Standard occurred on 11/04/2018 at 02:00 (time went back to 01:00)
-            var start = new DateTime(2018, 11, 4, 0, 0, 0, DateTimeKind.Local);
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-
-            TimeSpan offset = pst.GetUtcOffset(start);
+            var start = new DateTime(2018, 11, 4, 0, 0, 0);
+            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(start);
             var now = new DateTimeOffset(start, offset);
-            schedule.TimeZone = pst;
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -160,15 +158,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void PointInTime_OutOfDST_ReturnsExpectedValue()
         {
+            TimerListenerTests.SetLocalTimeZoneToPacific();
+
             // 01:30 every day
             CronSchedule.TryCreate("0 30 1 * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 11/04/2018 at 02:00 (time went back to 01:00)
             var start = new DateTime(2018, 11, 3, 0, 0, 0);
-            TimeZoneInfo pst = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-            TimeSpan offset = pst.GetUtcOffset(start);
+            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(start);
             var now = new DateTimeOffset(start, offset);
-            schedule.TimeZone = pst;
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -225,6 +223,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             CronSchedule.TryCreate(expression, out CronSchedule cronSchedule);
 
             Assert.Equal(expected, cronSchedule.IsInterval);
+        }
+
+        public void Dispose()
+        {
+            TimeZoneInfo.ClearCachedData();
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -213,6 +213,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [InlineData("0-15 * * * *", true)]
         [InlineData("0 * * * 0", true)]
         [InlineData("0 1-3 * * 0", true)]
+        [InlineData(" 0 1 * * *", false)]
         [InlineData("0 0 * * *", false)]
         [InlineData("0 0 1 * *", false)]
         [InlineData("0 0 1 1 *", false)]

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         public void GetNextOccurrence_NowEqualToNext_ReturnsCorrectValue()
         {
             CronSchedule.TryCreate("0 * * * * *", out CronSchedule schedule);
-                
+
             var now = schedule.GetNextOccurrence(DateTime.Now);
             var next = schedule.GetNextOccurrence(now);
 
@@ -66,6 +66,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
 
             Assert.Null(schedule);
             Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("* * * * * *", true)]
+        [InlineData("0 * * * * *", true)]
+        [InlineData("0 0 * * * *", true)]
+        [InlineData("0 0-15 * * * *", true)]
+        [InlineData("0 0 * * * 0", true)]
+        [InlineData("0 0 1-3 * * 0", true)]
+        [InlineData("0 0 0 * * *", false)]
+        [InlineData("0 0 0 1 * *", false)]
+        [InlineData("0 0 0 1 1 *", false)]
+        [InlineData("0 0 0 * * 1", false)]
+        [InlineData("* * * * *", true)]
+        [InlineData("0 * * * *", true)]
+        [InlineData("0-15 * * * *", true)]
+        [InlineData("0 * * * 0", true)]
+        [InlineData("0 1-3 * * 0", true)]
+        [InlineData("0 0 * * *", false)]
+        [InlineData("0 0 1 * *", false)]
+        [InlineData("0 0 1 1 *", false)]
+        [InlineData("0 0 * * 1", false)]
+        public void IsInterval_ReturnsExpectedValue(string expression, bool expected)
+        {
+            CronSchedule.TryCreate(expression, out CronSchedule cronSchedule);
+
+            Assert.Equal(expected, cronSchedule.IsInterval);
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -59,9 +59,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             CronSchedule.TryCreate("0 30 * * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 3/11/2018 at 02:00 (time skipped ahead to 3:00)
-            var start = new DateTime(2018, 3, 11, 0, 0, 0);
-            var offset = TimeZoneInfo.Local.GetUtcOffset(start);
-            var now = new DateTimeOffset(start, offset);
+            var start = new DateTime(2018, 3, 11, 0, 0, 0, DateTimeKind.Local);
+            var now = new DateTimeOffset(start);
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -84,9 +83,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             CronSchedule.TryCreate("0 30 1 * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 3/11/2018 at 02:00 (time skipped ahead to 3:00)
-            var start = new DateTime(2018, 3, 10, 0, 0, 0);
-            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(start);
-            var now = new DateTimeOffset(start, offset);
+            var start = new DateTime(2018, 3, 10, 0, 0, 0, DateTimeKind.Local);
+            var now = new DateTimeOffset(start);
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -111,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             // Standard -> Daylight occurred on 11/04/2018 at 02:00 (time went back to 01:00)
             // Ambigous hour is 01:00 - 01:59 as there are two instances in of these in the day.
             var start = new DateTime(2018, 11, 4, 0, 30, 0, DateTimeKind.Local);
-            var now = new DateTimeOffset(start, TimeSpan.FromHours(-7));
+            var now = new DateTimeOffset(start);
 
             // just enough to go fully through the ambiguous time
             var nextOccurrences = schedule.GetNextOccurrences(9, now.LocalDateTime);
@@ -139,9 +137,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             CronSchedule.TryCreate("0 30 * * * *", out CronSchedule schedule);
 
             // Daylight -> Standard occurred on 11/04/2018 at 02:00 (time went back to 01:00)
-            var start = new DateTime(2018, 11, 4, 0, 0, 0);
-            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(start);
-            var now = new DateTimeOffset(start, offset);
+            var start = new DateTime(2018, 11, 4, 0, 0, 0, DateTimeKind.Local);
+            var now = new DateTimeOffset(start);
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -164,9 +161,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             CronSchedule.TryCreate("0 30 1 * * *", out CronSchedule schedule);
 
             // Standard -> Daylight occurred on 11/04/2018 at 02:00 (time went back to 01:00)
-            var start = new DateTime(2018, 11, 3, 0, 0, 0);
-            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(start);
-            var now = new DateTimeOffset(start, offset);
+            var start = new DateTime(2018, 11, 3, 0, 0, 0, DateTimeKind.Local);
+            var now = new DateTimeOffset(start);
 
             var nextOccurrences = schedule.GetNextOccurrences(5, now.LocalDateTime);
 
@@ -225,9 +221,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             Assert.Equal(expected, cronSchedule.IsInterval);
         }
 
-        public void Dispose()
-        {
-            TimeZoneInfo.ClearCachedData();
-        }
+        public void Dispose() => TimeZoneInfo.ClearCachedData();
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/TimerScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/TimerScheduleTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Extensions.Logging;
-using NCrontab;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
@@ -195,6 +194,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         public class CustomSchedule : TimerSchedule
         {
             public override bool AdjustForDST => true;
+
+            public override bool IsInterval => false;
 
             public override DateTime GetNextOccurrence(DateTime now)
             {

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/TimerScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/TimerScheduleTests.cs
@@ -195,8 +195,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         {
             public override bool AdjustForDST => true;
 
-            public override bool IsInterval => false;
-
             public override DateTime GetNextOccurrence(DateTime now)
             {
                 return new DateTime(2015, 5, 22, 9, 45, 00);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerInfoTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerInfoTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             string result = TimerInfo.FormatNextOccurrences(cronSchedule, 10, now: now.DateTime, pst);
 
             var expectedDates = Enumerable.Range(11, 10)
-                .Select(hour => new DateTime(2015, 09, 16, hour, 00, 00))
+                .Select(hour => new DateTime(2015, 09, 16, hour, 00, 00, DateTimeKind.Local))
                 .Select(dateTime => $"{DateFormatter(dateTime, pst)}\r\n")
                 .ToArray();
 

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
@@ -191,6 +191,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
                 public override bool AdjustForDST => true;
 
+                public override bool IsInterval => true;
+
                 public override DateTime GetNextOccurrence(DateTime now)
                 {
                     InvocationCount++;

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
@@ -191,8 +191,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
                 public override bool AdjustForDST => true;
 
-                public override bool IsInterval => true;
-
                 public override DateTime GetNextOccurrence(DateTime now)
                 {
                     InvocationCount++;


### PR DESCRIPTION
Fixes #880

This change refactors our handling of Daylight Savings Time (DST). Previously this was all done in `GetNextTimerInterval()`, but after researching and testing, I realized that there wasn't enough information available to correctly calculate Cron schedules during the transition into and out of DST. Instead, I've moved the DST handling into the `CronSchedule` (and `ConstantSchedule`, although this one was easier) itself. This has the added benefit that when we print out the next several occurrences at the beginning of the Timer startup, they'll now be correct. Previously, we'd generate the "next" value and then re-calculate it based on DST to start our internal timer.

I've tried to add comments with explanations of terms to the code itself but have called a few things out in comments as well.

Side note that this only touches `Cron` and `Constant` schedules, which are the only ones supported by Functions. I briefly tested the behavior of `Daily` and `Weekly` and they seem... fine? It's hard to know exactly how they should behave, but they're so little used that it wasn't worth the effort to re-think them.

Some other notes: 
- `DateTime` can *sometimes* store enough details internally to allow it to roundtrip to/from `DateTimeOffset`. I've changed our usage to start from `DateTimeOffset.Now` wherever possible to ensure we have all the data for offsets stored internally. 
- However, NCronTab internally does *not* return `DateTime`s with offset details. This means that in ambiguous times (times during "fall back" from DST where there are duplicate times in a time zone), we will always think that this is the Standard (later) offset because of how `GetUtcOffset()` works. I've added calculations for the `CronSchedule` to account for this.
    > Side note. `GetUtcOffset()` only returns the Standard time in ambiguous cases when it doesn't have enough internal information to choose the correct offset. Sometimes it does! Like if you use `dateTimeOffset.LocalDateTime`, or even `DateTime.Now` it [stores some details internally](https://github.com/dotnet/runtime/blob/f722e5c5b72000a06ce267a9bee222a8c3be4696/src/libraries/System.Private.CoreLib/src/System/DateTime.cs#L133-L137) that let it choose the correct offset in ambiguous cases.
- I had previously fixed an issue when "springing forward" to DST where we'd calculate the wrong interval. In my testing, I found some other incidents where we'd schedule a trigger for a nonexistent time (i.e 02:30 when springing forward from 01:00 -> 03:00). I've taken this into account now as well.
- For `CronSchedule`, the behavior is different when you have an "interval" or a "point-in-time" schedule as the behavior around the "ambiguous" times going from DST -> Standard are different. I followed similar behavior to this: https://github.com/HangfireIO/Cronos?tab=readme-ov-file#transition-from-summer-time-in-autumn.

A succinct example of what this fixes can be shown here in this log for when daylight savings exits:

before change:
```
The next 5 occurrences of the 'TimerTrigger' schedule (Cron: '0 0,30 * * * *') will be:
      11/03/2024 00:30:00-07:00 (11/03/2024 07:30:00Z)
      11/03/2024 01:00:00-08:00 (11/03/2024 09:00:00Z)
      11/03/2024 01:30:00-08:00 (11/03/2024 09:30:00Z)
      11/03/2024 02:00:00-08:00 (11/03/2024 10:00:00Z)
      11/03/2024 02:30:00-08:00 (11/03/2024 10:30:00Z)
```

after change:
```
The next 5 occurrences of the 'TimerTrigger' schedule (Cron: '0 0,30 * * * *') will be:
      11/03/2024 00:30:00-07:00 (11/03/2024 07:30:00Z)
      11/03/2024 01:00:00-07:00 (11/03/2024 08:00:00Z)
      11/03/2024 01:30:00-07:00 (11/03/2024 08:30:00Z)
      11/03/2024 01:00:00-08:00 (11/03/2024 09:00:00Z)
      11/03/2024 01:30:00-08:00 (11/03/2024 09:30:00Z)
```

