### PR TITLE
Update TimerListener to not signal cancellation when in drain mode

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerAttributeBindingProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
 
@@ -15,13 +16,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
         private readonly INameResolver _nameResolver;
         private readonly ILogger _logger;
         private readonly ScheduleMonitor _scheduleMonitor;
+        private readonly IDrainModeManager _drainModeManager;
 
-        public TimerTriggerAttributeBindingProvider(TimersOptions options, INameResolver nameResolver, ILogger logger, ScheduleMonitor scheduleMonitor)
+        public TimerTriggerAttributeBindingProvider(TimersOptions options, INameResolver nameResolver, ILogger logger, ScheduleMonitor scheduleMonitor, IDrainModeManager drainModeManager)
         {
             _options = options;
             _nameResolver = nameResolver;
             _logger = logger;
             _scheduleMonitor = scheduleMonitor;
+            _drainModeManager = drainModeManager;
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -46,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
 
             TimerSchedule schedule = TimerSchedule.Create(timerTriggerAttribute, _nameResolver, _logger);
 
-            return Task.FromResult<ITriggerBinding>(new TimerTriggerBinding(parameter, timerTriggerAttribute, schedule, _options, _logger, _scheduleMonitor));
+            return Task.FromResult<ITriggerBinding>(new TimerTriggerBinding(parameter, timerTriggerAttribute, schedule, _options, _logger, _scheduleMonitor, _drainModeManager));
         }
     }
 }

--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
@@ -25,10 +25,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
         private readonly ILogger _logger;
         private readonly ScheduleMonitor _scheduleMonitor;
         private readonly string _timerName;
+        private readonly IDrainModeManager _drainModeManager;
 
         private IReadOnlyDictionary<string, Type> _bindingContract;
 
-        public TimerTriggerBinding(ParameterInfo parameter, TimerTriggerAttribute attribute, TimerSchedule schedule, TimersOptions options, ILogger logger, ScheduleMonitor scheduleMonitor)
+        public TimerTriggerBinding(ParameterInfo parameter, TimerTriggerAttribute attribute, TimerSchedule schedule, TimersOptions options,
+            ILogger logger, ScheduleMonitor scheduleMonitor, IDrainModeManager drainModeManager)
         {
             _attribute = attribute;
             _schedule = schedule;
@@ -36,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
             _options = options;
             _logger = logger;
             _scheduleMonitor = scheduleMonitor;
+            _drainModeManager = drainModeManager;
             _bindingContract = CreateBindingDataContract();
 
             MethodInfo methodInfo = (MethodInfo)parameter.Member;
@@ -81,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
                 throw new ArgumentNullException("context");
             }
 
-            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor, context.Descriptor?.LogName));
+            return Task.FromResult<IListener>(new TimerListener(_attribute, _schedule, _timerName, _options, context.Executor, _logger, _scheduleMonitor, context.Descriptor?.LogName, _drainModeManager));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/WebJobs.Extensions/Extensions/Timers/Config/TimersExtensionConfigProvider.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Config/TimersExtensionConfigProvider.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Bindings;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Logging;
@@ -19,14 +20,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Extensions.Timers
         private readonly ILoggerFactory _loggerFactory;
         private readonly INameResolver _nameResolver;
         private readonly ScheduleMonitor _scheduleMonitor;
+        private readonly IDrainModeManager _drainModeManager;
 
         public TimersExtensionConfigProvider(IOptions<TimersOptions> options, ILoggerFactory loggerFactory,
-            INameResolver nameResolver, ScheduleMonitor scheduleMonitor)
+            INameResolver nameResolver, ScheduleMonitor scheduleMonitor, IDrainModeManager drainModeManager)
         {
             _options = options;
             _loggerFactory = loggerFactory;
             _nameResolver = nameResolver;
             _scheduleMonitor = scheduleMonitor;
+            _drainModeManager = drainModeManager;
         }
 
         public void Initialize(ExtensionConfigContext context)
@@ -37,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Extensions.Timers
             }
 
             ILogger logger = _loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Timer"));
-            var bindingProvider = new TimerTriggerAttributeBindingProvider(_options.Value, _nameResolver, logger, _scheduleMonitor);
+            var bindingProvider = new TimerTriggerAttributeBindingProvider(_options.Value, _nameResolver, logger, _scheduleMonitor, _drainModeManager);
 
             context.AddBindingRule<TimerTriggerAttribute>()
                 .BindToTrigger(bindingProvider);

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -164,9 +164,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 throw new InvalidOperationException("The listener has not yet been started or has already been stopped.");
             }
 
+            // If we're in drain mode, we don't want to signal cancellation for ongoing invocations
             if (!_drainModeManager.IsDrainModeEnabled)
             {
-                // if we're in drain mode, we don't want to cancel ongoing invocations
                 _cancellationTokenSource.Cancel();
             }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Extensions.Logging;
@@ -24,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
         private readonly ILogger _logger;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly SemaphoreSlim _invocationLock = new SemaphoreSlim(1, 1);
+        private readonly IDrainModeManager _drainModeManager;
 
         // _functionLogName is the [FunctionName] value and used for logging,
         // while _timerLookupName is the fully-qualified method name and used for lookups
@@ -41,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
         private TimeSpan _remainingInterval;
 
         public TimerListener(TimerTriggerAttribute attribute, TimerSchedule schedule, string timerName, TimersOptions options, ITriggeredFunctionExecutor executor,
-            ILogger logger, ScheduleMonitor scheduleMonitor, string functionLogName)
+            ILogger logger, ScheduleMonitor scheduleMonitor, string functionLogName, IDrainModeManager drainModeManager)
         {
             _attribute = attribute;
             _timerLookupName = timerName;
@@ -52,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             _schedule = schedule;
             ScheduleMonitor = _attribute.UseMonitor ? scheduleMonitor : null;
             _functionLogName = functionLogName;
+            _drainModeManager = drainModeManager;
         }
 
         internal static TimeSpan MaxTimerInterval
@@ -94,7 +97,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             bool isPastDue = false;
 
             // we use DateTimeOffset.Now rather than DateTimeOffset.UtcNow to allow the local machine to set the time zone. In Azure this will be
-            // UTC by default, but can be configured to use any time zone if it makes scheduling easier.                        
+            // UTC by default, but can be configured to use any time zone if it makes scheduling easier.
             DateTimeOffset now = DateTimeOffset.Now;
 
             Logger.ScheduleAndTimeZone(_logger, _functionLogName, _schedule, TimeZoneInfo.Local.DisplayName);
@@ -161,7 +164,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 throw new InvalidOperationException("The listener has not yet been started or has already been stopped.");
             }
 
-            _cancellationTokenSource.Cancel();
+            if (!_drainModeManager.IsDrainModeEnabled)
+            {
+                // if we're in drain mode, we don't want to cancel ongoing invocations
+                _cancellationTokenSource.Cancel();
+            }
 
             _timer.Dispose();
             _timer = null;

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -164,10 +164,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 throw new InvalidOperationException("The listener has not yet been started or has already been stopped.");
             }
 
-            // If we're in drain mode, we don't want to signal cancellation for ongoing invocations
+            // If we're in drain mode, we don't want to signal cancellation for outstanding invocations
             if (!_drainModeManager.IsDrainModeEnabled)
             {
-                _cancellationTokenSource.Cancel();
+                Cancel();
             }
 
             _timer.Dispose();
@@ -177,13 +177,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             await _invocationLock.WaitAsync();
             _invocationLock.Release();
 
+            // After outstanding invocations are complete, we can safely cancel the token to stop new invocations
+            Cancel();
+
             _logger.LogDebug($"Timer listener stopped ({_functionLogName})");
         }
 
         public void Cancel()
         {
             ThrowIfDisposed();
-            _cancellationTokenSource.Cancel();
+
+            if (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                _cancellationTokenSource.Cancel();
+            }
         }
 
         public void Dispose()

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Bindings/TimerTriggerBindingTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Bindings/TimerTriggerBindingTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Bindings;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
@@ -48,7 +49,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Bindings
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(new TestLoggerProvider());
 
-            TimerTriggerBinding binding = new TimerTriggerBinding(parameter, attribute, schedule, options, loggerFactory.CreateLogger("Test"), mockScheduleMonitor.Object);
+            Mock<IDrainModeManager> mockDrainModeManager = new Mock<IDrainModeManager>(MockBehavior.Strict);
+
+            TimerTriggerBinding binding = new TimerTriggerBinding(parameter, attribute, schedule, options, loggerFactory.CreateLogger("Test"), mockScheduleMonitor.Object, mockDrainModeManager.Object);
 
             // when we bind to a non-TimerInfo (e.g. in a Dashboard invocation) a new
             // TimerInfo is created, with the ScheduleStatus populated

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         private Mock<ITriggeredFunctionExecutor> _mockTriggerExecutor;
         private TriggeredFunctionData _triggeredFunctionData;
         private TestLogger _logger;
-        private Mock<IDrainModeManager> _drainModeManager;
 
         public TimerListenerTests()
         {
@@ -119,8 +118,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             // force an exception to occur outside of the function invocation path
             var ex = new Exception("Kaboom!");
             _mockScheduleMonitor.Setup(p => p.UpdateStatusAsync(_testTimerName, It.IsAny<ScheduleStatus>())).ThrowsAsync(ex);
+            var drainModeManager = new Mock<IDrainModeManager>().Object;
 
-            var listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, _drainModeManager.Object);
+            var listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, drainModeManager);
 
             Assert.Null(listener.Timer);
 
@@ -427,6 +427,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         }
 
         [Fact]
+        public async Task StopAsync_DrainMode_DoesNotCancelCts()
+        {
+            bool invocationStarted = false;
+            bool invocationCompleted = false;
+
+            var mockDrainModeManager = new Mock<IDrainModeManager>(MockBehavior.Strict);
+            mockDrainModeManager.Setup(p => p.IsDrainModeEnabled).Returns(true);
+
+            CreateTestListener("* * * * * *", useMonitor: false, functionAction: () =>
+            {
+                invocationStarted = true;
+                Task.Delay(3000).Wait();
+                invocationCompleted = true;
+            }, drainManager: mockDrainModeManager.Object);
+
+            var cts = new CancellationTokenSource();
+            await _listener.StartAsync(cts.Token);
+
+            await TestHelpers.Await(() => invocationStarted, pollingInterval: 500);
+
+            // after the function has started running, stop the listener
+            await _listener.StopAsync(cts.Token);
+
+
+            Assert.False(cts.IsCancellationRequested);
+        }
+
+        [Fact]
         public async Task StoppedListener_DoesNotContinueRunning()
         {
             // There was a bug where we would re-create a disposed _timer after a call to StopAsync(). This only
@@ -638,7 +666,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             Assert.Contains($"Timer for '{_functionShortName}' started with interval", verboseTraces[2].FormattedMessage);
         }
 
-        private void CreateTestListener(string expression, bool useMonitor = true, bool runOnStartup = false, Action functionAction = null)
+        private void CreateTestListener(string expression, bool useMonitor = true, bool runOnStartup = false, Action functionAction = null, IDrainModeManager drainManager = null)
         {
             _attribute = new TimerTriggerAttribute(expression)
             {
@@ -662,8 +690,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 })
                 .Returns(Task.FromResult(result));
             _logger = new TestLogger(null);
-            _drainModeManager = new Mock<IDrainModeManager>();
-            _listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, _drainModeManager.Object);
+            var drainModeManager = drainManager ?? new Mock<IDrainModeManager>().Object;
+            _listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, drainModeManager);
         }
 
         internal static void SetLocalTimeZoneToPacific()

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Listeners;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -31,6 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         private Mock<ITriggeredFunctionExecutor> _mockTriggerExecutor;
         private TriggeredFunctionData _triggeredFunctionData;
         private TestLogger _logger;
+        private Mock<IDrainModeManager> _drainModeManager;
 
         public TimerListenerTests()
         {
@@ -118,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             var ex = new Exception("Kaboom!");
             _mockScheduleMonitor.Setup(p => p.UpdateStatusAsync(_testTimerName, It.IsAny<ScheduleStatus>())).ThrowsAsync(ex);
 
-            var listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName);
+            var listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, _drainModeManager.Object);
 
             Assert.Null(listener.Timer);
 
@@ -660,7 +662,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 })
                 .Returns(Task.FromResult(result));
             _logger = new TestLogger(null);
-            _listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName);
+            _drainModeManager = new Mock<IDrainModeManager>();
+            _listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, _drainModeManager.Object);
         }
 
         internal static void SetLocalTimeZoneToPacific()

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimerTriggerEndToEndTests.cs
@@ -2,14 +2,22 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Executors.Internal;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
@@ -80,7 +88,55 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             CustomScheduleTestJobs.InvocationCount = 0;
         }
 
-        private async Task RunTimerJobTest(Type jobClassType, Func<bool> condition)
+        [Fact]
+        public async Task TimerJobCancelTest_StopHost_WithDrainMode_CancellationNotSignalled()
+        {
+            Assert.Equal(0, TimerTestJobWithCancellationNotExpected.InvocationCount);
+
+            await RunTimerJobTest(
+                typeof(TimerTestJobWithCancellationNotExpected),
+                () =>
+                {
+                    return TimerTestJobWithCancellationNotExpected.InvocationCount >= 1;
+                }, stopWithDrainMode: true);
+
+            TimerTestJobWithCancellationNotExpected.InvocationCount = 0;
+
+            var messages = _loggerProvider.GetAllLogMessages().Where(m => m.FormattedMessage is not null);
+
+            var functionExecutedSuccessfullyLog = messages.Where(m =>
+            {
+                return m.FormattedMessage.Contains("Executed 'TimerTestJobWithCancellationNotExpected.Run' (Succeeded");
+            });
+
+            Assert.True(functionExecutedSuccessfullyLog.Count() == 1, string.Join(Environment.NewLine, messages));
+        }
+
+        [Fact]
+        public async Task TimerJobCancelTest_StopHost_WithoutDrainMode_CancellationSignalled()
+        {
+            Assert.Equal(0, TimerTestJobWithCancellationExpected.InvocationCount);
+
+            await RunTimerJobTest(
+                typeof(TimerTestJobWithCancellationExpected),
+                () =>
+                {
+                    return TimerTestJobWithCancellationExpected.InvocationCount >= 1;
+                }, stopWithDrainMode: false);
+
+            TimerTestJobWithCancellationExpected.InvocationCount = 0;
+
+            var messages = _loggerProvider.GetAllLogMessages().Where(m => m.FormattedMessage is not null);
+
+            var functionSucceededLog = messages.Where(m =>
+            {
+                return m.FormattedMessage.Contains("Executed 'TimerTestJobWithCancellationExpected.Run' (Succeeded");
+            });
+
+            Assert.True(functionSucceededLog.Count() == 1, string.Join(Environment.NewLine, messages));
+        }
+
+        private async Task RunTimerJobTest(Type jobClassType, Func<bool> condition, bool stopWithDrainMode = false)
         {
             ExplicitTypeLocator locator = new ExplicitTypeLocator(jobClassType);
             var resolver = new TestNameResolver();
@@ -114,9 +170,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 return condition();
             });
 
-            await host.StopAsync();
+            if (stopWithDrainMode)
+            {
+                await StopWithDrainAsync(host);
+            }
+            else
+            {
+                await host.StopAsync();
+            }
 
             // TODO: ensure there were no errors
+        }
+
+        private static async Task StopWithDrainAsync(IHost host)
+        {
+            // Enable drain mode so checkpointing occurs when stopping
+            var drainModeManager = host.Services.GetService<IDrainModeManager>();
+            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
+            await host.StopAsync();
         }
 
         public static class CronScheduleTestJobs
@@ -195,6 +266,64 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
                 {
                     InvocationCount++;
                     return now + TimeSpan.FromSeconds(2);
+                }
+            }
+        }
+
+        public static class TimerTestJobWithCancellationNotExpected
+        {
+            static TimerTestJobWithCancellationNotExpected()
+            {
+                InvocationCount = 0;
+            }
+
+            public static int InvocationCount { get; set; }
+
+            public static async Task Run(
+                [TimerTrigger("*/3 * * *  * *")] TimerInfo timer, CancellationToken cancellationToken)
+            {
+                Assert.NotNull(timer.Schedule);
+                Assert.Null(timer.ScheduleStatus);
+                InvocationCount++;
+
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(2000, cancellationToken);
+                    Assert.False(cancellationToken.IsCancellationRequested);
+                }
+                catch (OperationCanceledException)
+                {
+                    Assert.True(false, "Cancellation token should not have been signalled.");
+                }
+            }
+        }
+
+        public static class TimerTestJobWithCancellationExpected
+        {
+            static TimerTestJobWithCancellationExpected()
+            {
+                InvocationCount = 0;
+            }
+
+            public static int InvocationCount { get; set; }
+
+            public static async Task Run(
+                [TimerTrigger("*/3 * * * * *")] TimerInfo timer, CancellationToken cancellationToken)
+            {
+                Assert.NotNull(timer.Schedule);
+                Assert.Null(timer.ScheduleStatus);
+                InvocationCount++;
+
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(2000, cancellationToken);
+                    Assert.True(false, "Cancellation token should have been signalled.");
+                }
+                catch (OperationCanceledException)
+                {
+                    Assert.True(cancellationToken.IsCancellationRequested);
                 }
             }
         }


### PR DESCRIPTION
Issue is related to: https://github.com/Azure/azure-webjobs-sdk/issues/2795

resolves #918 

We should not be signaling cancellation during drain mode. Drain mode is intended to allow on-going invocations to finish executing.

In this PR:

- a check to see if drain mode is enabled before cancelling the cts
- unit tests
- e2e tests

### Testing with latest host

Testing with the Functions host, we can see that when drain is called, the function gets to finish executing and does not hit the catch-block:

```csharp
[Function("MyTimer")]
public async Task Run([TimerTrigger("*/30 * * * * *")] TimerInfo myTimer, CancellationToken cancellationToken)
{
    _logger.LogWarning($"Timer trigger function executed at: {DateTime.Now}");

    if (myTimer.ScheduleStatus is not null)
    {
        _logger.LogWarning($"Next timer schedule at: {myTimer.ScheduleStatus.Next}");
    }

    try
    {
        cancellationToken.ThrowIfCancellationRequested();
        await Task.Delay(5000, cancellationToken);
        _logger.LogWarning($"Timer trigger completed at: {DateTime.Now}");
    }
    catch (OperationCanceledException)
    {
        _logger.LogWarning("Timer trigger function was cancelled.");
    }
}
```

#### Logs before change

```log
info: Host.General[337]
      Host lock lease acquired by instance ID '000000000000000000000000303B82C0'.
info: Function.MyTimer[1]
      Executing 'Functions.MyTimer' (Reason='Timer fired at 2024-11-26T10:43:00.0258410-08:00', Id=56dd4cf5-e9da-4ee2-9d35-32f597575746)
warn: Function.MyTimer.User[0]
      Timer trigger function executed at: 11/26/2024 10:43:00 AM
info: Microsoft.Azure.WebJobs.Host.DrainModeManager[0]
      DrainMode mode enabled
info: Microsoft.Azure.WebJobs.Host.DrainModeManager[0]
      Calling StopAsync on the registered listeners
info: Host.Startup[0]
      Stopping the listener 'Microsoft.Azure.WebJobs.Host.Listeners.SingletonListener' for function 'MyTimer'
warn: Function.MyTimer.User[0]
      Timer trigger function was cancelled. >>> Cancellation token is signaled <<<
info: Function.MyTimer[2]
      Executed 'Functions.MyTimer' (Succeeded, Id=56dd4cf5-e9da-4ee2-9d35-32f597575746, Duration=1598ms)
info: Host.Startup[0]
      Stopped the listener 'Microsoft.Azure.WebJobs.Host.Listeners.SingletonListener' for function 'MyTimer'
info: Microsoft.Azure.WebJobs.Host.DrainModeManager[0]
      Call to StopAsync complete, registered listeners are now stopped
```

#### Logs after change

```log
info: Host.General[337]
      Host lock lease acquired by instance ID '000000000000000000000000303B82C0'.
info: Function.MyTimer[1]
      Executing 'Functions.MyTimer' (Reason='Timer fired at 2024-11-26T10:38:30.0078440-08:00', Id=72f22c7c-3199-48e9-80f5-41e814bf2205)
warn: Function.MyTimer.User[0]
      Timer trigger function executed at: 11/26/2024 10:38:30 AM
info: Microsoft.Azure.WebJobs.Host.DrainModeManager[0]
      DrainMode mode enabled
info: Microsoft.Azure.WebJobs.Host.DrainModeManager[0]
      Calling StopAsync on the registered listeners
info: Host.Startup[0]
      Stopping the listener 'Microsoft.Azure.WebJobs.Host.Listeners.SingletonListener' for function 'MyTimer'
warn: Function.MyTimer.User[0]
      Timer trigger completed at: 11/26/2024 10:38:35 AM  >>> Cancellation token is NOT signaled <<<
info: Function.MyTimer[2]
      Executed 'Functions.MyTimer' (Succeeded, Id=72f22c7c-3199-48e9-80f5-41e814bf2205, Duration=5129ms)
info: Host.Startup[0]
      Stopped the listener 'Microsoft.Azure.WebJobs.Host.Listeners.SingletonListener' for function 'MyTimer'
info: Microsoft.Azure.WebJobs.Host.DrainModeManager[0]
      Call to StopAsync complete, registered listeners are now stopped
```
