### PR TITLE
Revert "Bump WebJobs.Extensions to 5.2.0 for release"

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -2,14 +2,14 @@
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
     <Version>3.0.0$(VersionSuffix)</Version>
-    <ExtensionsVersion>5.2.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
+    <ExtensionsVersion>5.1.0$(VersionSuffix)</ExtensionsVersion> <!-- WebJobs.Extensions -->
     <CosmosDBVersion>4.8.2$(VersionSuffix)</CosmosDBVersion>
     <HttpVersion>3.2.0$(VersionSuffix)</HttpVersion>
     <MobileAppsVersion>3.0.0$(VersionSuffix)</MobileAppsVersion>
     <SendGridVersion>3.0.3$(VersionSuffix)</SendGridVersion>
     <TwilioVersion>4.0.0$(VersionSuffix)</TwilioVersion>
     <TimersStorageVersion>1.0.0$(VersionSuffix)</TimersStorageVersion>
-    <DebugType>embedded</DebugType>
+    <DebugType>embedded</DebugType>    
     <LatestCommit Condition="$(LatestCommit) == ''">$(CommitHash)</LatestCommit>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>


### PR DESCRIPTION
Reverts Azure/azure-webjobs-sdk-extensions#919

The latest version of this extension is 5.0.0, so we should be releasing v5.1.0, not 2