### PR TITLE
fixing datetimeoffset minvalue implicit conversion when in time zone that is ahead of UTC

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     /// </summary>
     public abstract class ScheduleMonitor
     {
-        private static DateTimeOffset defaultDateTime = default(DateTimeOffset).ToLocalTime();
+        private static DateTime defaultDateTime = new DateTime(0, DateTimeKind.Local);
 
         /// <summary>
         /// Gets the last recorded schedule status for the specified timer.
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 DateTimeOffset nextOccurrence = schedule.GetNextOccurrence(now.LocalDateTime);
                 lastStatus = new ScheduleStatus
                 {
-                    Last = defaultDateTime.LocalDateTime,
+                    Last = defaultDateTime,
                     Next = nextOccurrence.LocalDateTime,
                     LastUpdated = now.LocalDateTime
                 };
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                         lastUpdated = now;
                     }
 
-                    lastStatus.Last = defaultDateTime.LocalDateTime;
+                    lastStatus.Last = defaultDateTime;
                     lastStatus.Next = expectedNextOccurrence.LocalDateTime;
                     lastStatus.LastUpdated = lastUpdated.LocalDateTime;
                     await UpdateStatusAsync(timerName, lastStatus);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Listeners;
 using Microsoft.Azure.WebJobs.Host;
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 {
-    public class TimerListenerTests : IDisposable
+    public class TimerListenerTests
     {
         private readonly string _testTimerName = "Program.TestTimerJob";
         private readonly string _functionShortName = "TimerFunctionShortName";
@@ -574,7 +574,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         [MemberData(nameof(TimerSchedulesEnteringDST))]
         public void GetNextInterval_NextAfterDSTBegins_ReturnsExpectedValue(TimerSchedule schedule, TimeSpan expectedInterval)
         {
-            SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             // Running on the Friday before DST *begins* at 2 AM on 3/11 (Pacific Standard Time)
             // Note: this test uses Local time, so if you're running in a timezone where
@@ -599,7 +599,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         [MemberData(nameof(TimerSchedulesWithinDST))]
         public void GetNextInterval_NextWithinDST_ReturnsExpectedValue(TimerSchedule schedule, TimeSpan expectedInterval)
         {
-            SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             // Running at 1:59 AM, i.e. one minute before the DST switch at 2 AM on 3/11 (Pacific Standard Time)
             // Note: this test uses Local time, so if you're running in a timezone where
@@ -621,7 +621,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         [MemberData(nameof(CronTimerSchedulesExitingDST))]
         public void GetNextInterval_NextAfterDSTEnds_ReturnsExpectedValue(DateTimeOffset now, string cronSchedule, TimeSpan expectedInterval)
         {
-            SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             var schedule = new CronSchedule(CrontabSchedule.Parse(cronSchedule, new CrontabSchedule.ParseOptions() { IncludingSeconds = true }));
 
@@ -693,19 +693,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             var drainModeManager = drainManager ?? new Mock<IDrainModeManager>().Object;
             _listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, drainModeManager);
         }
-
-        internal static void SetLocalTimeZoneToPacific()
-        {
-            // There are so many internal benefits to using DateTimeKind.Local for us, that we're relying 
-            // on it to provide the proper roundtripping support between DateTime and DateTimeOffset. This appears
-            // to be the only way to "mock" this value as it's hard-coded inside a lot of .NET libraries when
-            // calculating offsets, time zones, etc.
-            var info = typeof(TimeZoneInfo).GetField("s_cachedData", BindingFlags.NonPublic | BindingFlags.Static);
-            var cachedData = info.GetValue(null);
-            var field = cachedData.GetType().GetField("_localTimeZone", BindingFlags.NonPublic | BindingFlags.Instance);
-            field.SetValue(cachedData, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
-        }
-
-        public void Dispose() => TimeZoneInfo.ClearCachedData();
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ConstantScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ConstantScheduleTests.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
 {
-    public class ConstantScheduleTests : IDisposable
+    public class ConstantScheduleTests
     {
         [Fact]
         public void GetNextOccurrence_ReturnsExpected()
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void Interval_IntoDST_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             var schedule = new ConstantSchedule(TimeSpan.FromHours(1));
 
@@ -81,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void Interval_OutOfDST_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             var schedule = new ConstantSchedule(TimeSpan.FromHours(1));
 
@@ -99,11 +100,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
                 o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 1, 30, 0), TimeSpan.FromHours(-8)), o), // offset changes
                 o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 2, 30, 0), TimeSpan.FromHours(-8)), o),
                 o => Assert.Equal(new DateTimeOffset(new DateTime(2018, 11, 4, 3, 30, 0), TimeSpan.FromHours(-8)), o));
-        }
-
-        public void Dispose()
-        {
-            TimeZoneInfo.ClearCachedData();
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/CronScheduleTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Xunit;
 
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void Interval_IntoDST_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
             var testLogger = new TestLogger("Test");
 
             // Every hour at the 30 min mark
@@ -79,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void PointInTime_IntoDST_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             // 01:30 every day
             CronSchedule.TryCreate("0 30 1 * * *", out CronSchedule schedule);
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void PointInTime_WithinAmbiguousHour_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             // every 20 minutes
             CronSchedule.TryCreate("0 */20 * * * *", out CronSchedule schedule);
@@ -133,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void Interval_OutOfDST_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
             var logger = new TestLogger("Test");
 
             // Every hour at the 30 min mark
@@ -158,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
         [Fact]
         public void PointInTime_OutOfDST_ReturnsExpectedValue()
         {
-            TimerListenerTests.SetLocalTimeZoneToPacific();
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
 
             // 01:30 every day
             CronSchedule.TryCreate("0 30 1 * * *", out CronSchedule schedule);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using NCrontab;
@@ -69,6 +67,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
+
+        public Task CheckPastDue_PlusTimeZone(bool lastSet, bool lastUpdatedSet)
+        {
+            // tokyo is +9 hours from utc
+            using var timeZoneSetter = TimeZoneSetter.TokyoStandard;
+            return CheckPastDue(lastSet, lastUpdatedSet);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+
+        public Task CheckPastDue_MinusTimeZone(bool lastSet, bool lastUpdatedSet)
+        {
+            // pacific is -8 hours from utc
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
+            return CheckPastDue(lastSet, lastUpdatedSet);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
         public async Task CheckPastDue_NowPastNext(bool lastSet, bool lastUpdatedSet)
         {
             // Move the time 1 second ahead of 'Next'. We should catch this as past due.
@@ -108,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
-        private async Task CheckPastDue_ScheduleChange_Longer(bool lastSet, bool lastUpdatedSet)
+        public async Task CheckPastDue_ScheduleChange_Longer(bool lastSet, bool lastUpdatedSet)
         {
             DateTime now = DateTime.Parse("1/1/2017 9:35");
 
@@ -147,7 +171,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
-        private async Task CheckPastDue_ScheduleChange_Shorter(bool lastSet, bool lastUpdatedSet)
+        public async Task CheckPastDue_ScheduleChange_Shorter(bool lastSet, bool lastUpdatedSet)
         {
             DateTime now = new DateTime(2017, 1, 1, 9, 35, 0);
 

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -42,7 +42,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
-        public async Task CheckPastDue(bool lastSet, bool lastUpdatedSet)
+        public Task CheckPastDue_UTC(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.Utc;
+            return CheckPastDue(lastSet, lastUpdatedSet);
+        }
+
+        private async Task CheckPastDue(bool lastSet, bool lastUpdatedSet)
         {
             DateTime now = DateTime.Parse("1/1/2017 9:35");
 
@@ -67,7 +73,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
-
         public Task CheckPastDue_PlusTimeZone(bool lastSet, bool lastUpdatedSet)
         {
             // tokyo is +9 hours from utc

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
@@ -17,6 +17,8 @@ internal class TimeZoneSetter : IDisposable
         field.SetValue(cachedData, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
     }
 
+    public static TimeZoneSetter Utc => new("UTC");
+
     public static TimeZoneSetter PacificStandard => new("Pacific Standard Time");
 
     public static TimeZoneSetter TokyoStandard => new("Tokyo Standard Time");

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
+
+internal class TimeZoneSetter : IDisposable
+{
+    // There are so many internal benefits to using DateTimeKind.Local for us, that we're relying 
+    // on it to provide the proper roundtripping support between DateTime and DateTimeOffset. This appears
+    // to be the only way to "mock" this value as it's hard-coded inside a lot of .NET libraries when
+    // calculating offsets, time zones, etc.
+    public TimeZoneSetter(string timeZoneId)
+    {
+        var info = typeof(TimeZoneInfo).GetField("s_cachedData", BindingFlags.NonPublic | BindingFlags.Static);
+        var cachedData = info.GetValue(null);
+        var field = cachedData.GetType().GetField("_localTimeZone", BindingFlags.NonPublic | BindingFlags.Instance);
+        field.SetValue(cachedData, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId));
+    }
+
+    public static TimeZoneSetter PacificStandard => new("Pacific Standard Time");
+
+    public static TimeZoneSetter TokyoStandard => new("Tokyo Standard Time");
+
+    public void Dispose()
+    {
+        TimeZoneInfo.ClearCachedData();
+    }
+}


### PR DESCRIPTION
fixes #928 

this bug was introduced with #908 as several places moved toward `DateTimeOffset`

Ultimately, this throws an exception:
```csharp
// tokyo is +9 hours from utc
using var timeZoneSetter = TimeZoneSetter.TokyoStandard;
if (default(DateTime) == default(DateTimeOffset)) // this throws due to implicit conversion
{
}
```

So we were doing a comparison between `DateTime.MinValue` and `DateTimeOffset.Now`... which performed an implicit conversion and threw an exception when that MinValue converted to an out-of-range value. This only happened when in a + time zone from UTC.

The fix is to remove that implicit conversion by only comparing to DateTimes in this situation.