### PR TITLE
Fixing default DateTime bug with TimeZones

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
 {
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
     {
         public const string UnscheduledInvocationReasonKey = "UnscheduledInvocationReason";
         public const string OriginalScheduleKey = "OriginalSchedule";
+        public const string ScheduleStatusKey = "ScheduleStatus";
 
         private readonly TimerTriggerAttribute _attribute;
         private readonly TimersOptions _options;
@@ -31,6 +33,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
         // while _timerLookupName is the fully-qualified method name and used for lookups
         private readonly string _functionLogName;
         private readonly string _timerLookupName;
+
+        private readonly JsonSerializerSettings _serializerSsettings = new JsonSerializerSettings
+        {
+            DateFormatHandling = DateFormatHandling.IsoDateFormat
+        };
 
         // Since Timer uses an integer internally for it's interval,
         // it has a maximum interval of 24.8 days.
@@ -325,6 +332,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 if (originalSchedule.HasValue)
                 {
                     details[OriginalScheduleKey] = originalSchedule.Value.ToString("o");
+                }
+
+                try
+                {
+                    if (timerInfo?.ScheduleStatus is not null)
+                    {
+                        details[ScheduleStatusKey] = JsonConvert.SerializeObject(timerInfo.ScheduleStatus, _serializerSsettings);
+                    }
+                }
+                catch
+                {
+                    // best effort
                 }
 
                 TriggeredFunctionData input = new TriggeredFunctionData

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
         private readonly string _functionLogName;
         private readonly string _timerLookupName;
 
-        private readonly JsonSerializerSettings _serializerSsettings = new JsonSerializerSettings
+        private readonly JsonSerializerSettings _serializerSettings = new JsonSerializerSettings
         {
             DateFormatHandling = DateFormatHandling.IsoDateFormat
         };
@@ -338,7 +338,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 {
                     if (timerInfo?.ScheduleStatus is not null)
                     {
-                        details[ScheduleStatusKey] = JsonConvert.SerializeObject(timerInfo.ScheduleStatus, _serializerSsettings);
+                        details[ScheduleStatusKey] = JsonConvert.SerializeObject(timerInfo.ScheduleStatus, _serializerSettings);
                     }
                 }
                 catch

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -107,6 +107,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 // check to see if we've missed an occurrence since we last started.
                 // If we have, invoke it immediately.
                 ScheduleStatus = await ScheduleMonitor.GetStatusAsync(_timerLookupName);
+
+                // Move any 'Last' value up to the new default. This fixes any serialization issues that
+                // we may hit due to time zone conversions
+                if (ScheduleStatus?.Last < ScheduleMonitor.DefaultDateTimeThreshold)
+                {
+                    ScheduleStatus.Last = ScheduleMonitor.DefaultDateTime;
+                }
+
                 Logger.InitialStatus(_logger, _functionLogName, ScheduleStatus?.Last.ToString("o"), ScheduleStatus?.Next.ToString("o"), ScheduleStatus?.LastUpdated.ToString("o"));
                 TimeSpan pastDueDuration = await ScheduleMonitor.CheckPastDueAsync(_timerLookupName, now, _schedule, ScheduleStatus);
                 isPastDue = pastDueDuration != TimeSpan.Zero;
@@ -117,9 +125,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
                 // no schedule status has been stored yet, so initialize
                 ScheduleStatus = new ScheduleStatus
                 {
-                    Last = default(DateTime).ToLocalTime(),
+                    Last = ScheduleMonitor.DefaultDateTime,
                     Next = _schedule.GetNextOccurrence(now.LocalDateTime),
-                    LastUpdated = default(DateTime).ToLocalTime()
+                    LastUpdated = ScheduleMonitor.DefaultDateTime
                 };
             }
 

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     public abstract class ScheduleMonitor
     {
         // Avoid anything close to DateTime.MinValue as time zone conversions have caused bugs
-        internal static readonly DateTime DefaultDateTime = default(DateTime).ToLocalTime();
+        internal static readonly DateTime DefaultDateTime = DateTime.MinValue.ToLocalTime();
 
         // We consider anything below this as a "default", unset value. Refactoring to use nullable DateTime would
         // be a disruptive change.
-        internal static readonly DateTime DefaultDateTimeThreshold = default(DateTime).ToLocalTime().AddYears(1);
+        internal static readonly DateTime DefaultDateTimeThreshold = DefaultDateTime.AddYears(1);
 
         /// <summary>
         /// Gets the last recorded schedule status for the specified timer.

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     public abstract class ScheduleMonitor
     {
         // Avoid anything close to DateTime.MinValue as time zone conversions have caused bugs
-        internal static readonly DateTime DefaultDateTime = DateTime.MinValue.ToLocalTime();
+        internal static DateTime DefaultDateTime => DateTime.MinValue.ToLocalTime();
 
         // We consider anything below this as a "default", unset value. Refactoring to use nullable DateTime would
         // be a disruptive change.
-        internal static readonly DateTime DefaultDateTimeThreshold = DefaultDateTime.AddYears(1);
+        internal static DateTime DefaultDateTimeThreshold => DefaultDateTime.AddYears(1);
 
         /// <summary>
         /// Gets the last recorded schedule status for the specified timer.

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     /// </summary>
     public abstract class ScheduleMonitor
     {
-        // Avoid anything close to DateTime.MinValue as time zone conversions have caused bugs
+        // Recalculate this value every time as our time zone can change dynamically when hosted.
         internal static DateTime DefaultDateTime => DateTime.MinValue.ToLocalTime();
 
         // We consider anything below this as a "default", unset value. Refactoring to use nullable DateTime would

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -14,7 +14,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     /// </summary>
     public abstract class ScheduleMonitor
     {
-        private static DateTime defaultDateTime = new DateTime(0, DateTimeKind.Local);
+        // Avoid anything close to DateTime.MinValue as time zone conversions have caused bugs
+        internal static readonly DateTime DefaultDateTime = default(DateTime).ToLocalTime().AddYears(1);
+
+        // We consider anything below this as a "default", unset value. Refactoring to use nullable DateTime would
+        // be a disruptive change.
+        internal static readonly DateTime DefaultDateTimeThreshold = default(DateTime).ToLocalTime().AddYears(2);
 
         /// <summary>
         /// Gets the last recorded schedule status for the specified timer.
@@ -57,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 DateTimeOffset nextOccurrence = schedule.GetNextOccurrence(now.LocalDateTime);
                 lastStatus = new ScheduleStatus
                 {
-                    Last = defaultDateTime,
+                    Last = DefaultDateTime,
                     Next = nextOccurrence.LocalDateTime,
                     LastUpdated = now.LocalDateTime
                 };
@@ -71,14 +76,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                 // Track the time that was used to create 'expectedNextOccurrence'.
                 DateTimeOffset lastUpdated;
 
-                if (lastStatus.Last != defaultDateTime)
+                if (lastStatus.Last > DefaultDateTimeThreshold)
                 {
                     // If we have a 'Last' value, we know that we used this to calculate 'Next'
                     // in a previous invocation.
                     expectedNextOccurrence = schedule.GetNextOccurrence(lastStatus.Last);
                     lastUpdated = lastStatus.Last;
                 }
-                else if (lastStatus.LastUpdated != defaultDateTime)
+                else if (lastStatus.LastUpdated > DefaultDateTimeThreshold)
                 {
                     // If the trigger has never fired, we won't have 'Last', but we will have
                     // 'LastUpdated', which tells us the last time that we used to calculate 'Next'.
@@ -106,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
                         lastUpdated = now;
                     }
 
-                    lastStatus.Last = defaultDateTime;
+                    lastStatus.Last = DefaultDateTime;
                     lastStatus.Next = expectedNextOccurrence.LocalDateTime;
                     lastStatus.LastUpdated = lastUpdated.LocalDateTime;
                     await UpdateStatusAsync(timerName, lastStatus);

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
     public abstract class ScheduleMonitor
     {
         // Avoid anything close to DateTime.MinValue as time zone conversions have caused bugs
-        internal static readonly DateTime DefaultDateTime = default(DateTime).ToLocalTime().AddYears(1);
+        internal static readonly DateTime DefaultDateTime = default(DateTime).ToLocalTime();
 
         // We consider anything below this as a "default", unset value. Refactoring to use nullable DateTime would
         // be a disruptive change.
-        internal static readonly DateTime DefaultDateTimeThreshold = default(DateTime).ToLocalTime().AddYears(2);
+        internal static readonly DateTime DefaultDateTimeThreshold = default(DateTime).ToLocalTime().AddYears(1);
 
         /// <summary>
         /// Gets the last recorded schedule status for the specified timer.

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Listeners;
 using Microsoft.Azure.WebJobs.Host;
@@ -311,11 +312,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
             await _listener.StartAsync(CancellationToken.None);
 
-            // ensure that these are valid DateTimeOffsets as they need to be able to
-            // round-trip during serialization/deserialization
-            _ = (DateTimeOffset)_listener.ScheduleStatus.Last;
-            _ = (DateTimeOffset)_listener.ScheduleStatus.Next;
-            _ = (DateTimeOffset)_listener.ScheduleStatus.LastUpdated;
+            ScheduleMonitorTests.ValidateSchedule(_listener.ScheduleStatus);
 
             Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.Last);
             Assert.True(_listener.ScheduleStatus.Next > DateTime.Now);
@@ -368,11 +365,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 
             await _listener.StartAsync(CancellationToken.None);
 
-            // ensure that these are valid DateTimeOffsets as they need to be able to
-            // round-trip during serialization/deserialization
-            _ = (DateTimeOffset)_listener.ScheduleStatus.Last;
-            _ = (DateTimeOffset)_listener.ScheduleStatus.Next;
-            _ = (DateTimeOffset)_listener.ScheduleStatus.LastUpdated;
+            ScheduleMonitorTests.ValidateSchedule(_listener.ScheduleStatus);
 
             Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.Last);
             Assert.Equal(invalidStatus.Next, _listener.ScheduleStatus.Next);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -184,7 +184,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             // it shouldn't be run twice.
             _attribute.RunOnStartup = true;
 
-            ScheduleStatus status = new ScheduleStatus();
+            ScheduleStatus status = new ScheduleStatus
+            {
+                Last = ScheduleMonitor.DefaultDateTime,
+                Next = ScheduleMonitor.DefaultDateTime,
+                LastUpdated = ScheduleMonitor.DefaultDateTime
+            };
+
             _mockScheduleMonitor.Setup(p => p.GetStatusAsync(_testTimerName)).ReturnsAsync(status);
 
             DateTimeOffset lastOccurrence = default(DateTimeOffset);
@@ -302,6 +308,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         {
             using var tz = TimeZoneSetter.TokyoStandard;
 
+            DateTime testStart = DateTime.Now;
+
             _mockScheduleMonitor
                 .Setup(p => p.GetStatusAsync(_testTimerName))
                 .Returns(Task.FromResult<ScheduleStatus>(null));
@@ -315,7 +323,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             ScheduleMonitorTests.ValidateSchedule(_listener.ScheduleStatus);
 
             Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.Last);
-            Assert.True(_listener.ScheduleStatus.Next > DateTime.Now);
+            Assert.True(_listener.ScheduleStatus.Next > testStart);
             Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.LastUpdated);
         }
 
@@ -440,7 +448,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         {
             CreateTestListener("* * * * * *", useMonitor: true);
 
-            ScheduleStatus status = new ScheduleStatus();
+            ScheduleStatus status = new ScheduleStatus
+            {
+                Last = ScheduleMonitor.DefaultDateTime,
+                Next = ScheduleMonitor.DefaultDateTime,
+                LastUpdated = ScheduleMonitor.DefaultDateTime
+            };
+
             _mockScheduleMonitor.Setup(p => p.GetStatusAsync(_testTimerName)).ReturnsAsync(status);
 
             // Make sure we invoke b/c we're past due.

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
 {
-    public class TimerListenerTests
+    public class TimerListenerTests : IDisposable
     {
         private readonly string _testTimerName = "Program.TestTimerJob";
         private readonly string _functionShortName = "TimerFunctionShortName";
@@ -297,6 +297,93 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
         }
 
         [Fact]
+        public async Task StartAsync_NullStatus_DefaultsToValidDates()
+        {
+            using var tz = TimeZoneSetter.TokyoStandard;
+
+            _mockScheduleMonitor
+                .Setup(p => p.GetStatusAsync(_testTimerName))
+                .Returns(Task.FromResult<ScheduleStatus>(null));
+
+            _mockScheduleMonitor
+                .Setup(p => p.CheckPastDueAsync(_testTimerName, It.IsAny<DateTimeOffset>(), It.IsAny<TimerSchedule>(), It.IsAny<ScheduleStatus>()))
+                .Returns(Task.FromResult(TimeSpan.Zero));
+
+            await _listener.StartAsync(CancellationToken.None);
+
+            // ensure that these are valid DateTimeOffsets as they need to be able to
+            // round-trip during serialization/deserialization
+            _ = (DateTimeOffset)_listener.ScheduleStatus.Last;
+            _ = (DateTimeOffset)_listener.ScheduleStatus.Next;
+            _ = (DateTimeOffset)_listener.ScheduleStatus.LastUpdated;
+
+            var defaultDateTime = default(DateTime).ToLocalTime();
+
+            Assert.Equal(defaultDateTime, _listener.ScheduleStatus.Last);
+            Assert.True(_listener.ScheduleStatus.Next > DateTime.Now);
+            Assert.Equal(defaultDateTime, _listener.ScheduleStatus.LastUpdated);
+        }
+
+        [Fact]
+        public Task StartAsync_InvalidStatus_DefaultsToValidDates_Utc()
+        {
+            using var tz = TimeZoneSetter.Utc;
+            return StartAsync_InvalidStatus_DefaultsToValidDates();
+        }
+
+        [Fact]
+        public Task StartAsync_InvalidStatus_DefaultsToValidDates_Tokyo()
+        {
+            using var tz = TimeZoneSetter.TokyoStandard;
+            return StartAsync_InvalidStatus_DefaultsToValidDates();
+        }
+
+        [Fact]
+        public Task StartAsync_InvalidStatus_DefaultsToValidDates_Pacific()
+        {
+            using var tz = TimeZoneSetter.PacificStandard;
+            return StartAsync_InvalidStatus_DefaultsToValidDates();
+        }
+
+        private async Task StartAsync_InvalidStatus_DefaultsToValidDates()
+        {
+            var testStart = DateTime.Now;
+
+            // This is invalid in UTC + time zones like Tokyo but used to be used as a 
+            // default value in the past.
+            var invalidDateTime = new DateTime(0, DateTimeKind.Local);
+
+            var invalidStatus = new ScheduleStatus()
+            {
+                Last = invalidDateTime,
+                Next = DateTime.Now.ToLocalTime(),
+                LastUpdated = DateTime.Now.ToLocalTime()
+            };
+
+            _mockScheduleMonitor
+                .Setup(p => p.GetStatusAsync(_testTimerName))
+                .Returns(Task.FromResult(invalidStatus));
+
+            _mockScheduleMonitor
+                .Setup(p => p.CheckPastDueAsync(_testTimerName, It.IsAny<DateTimeOffset>(), It.IsAny<TimerSchedule>(), It.IsAny<ScheduleStatus>()))
+                .Returns(Task.FromResult(TimeSpan.Zero));
+
+            await _listener.StartAsync(CancellationToken.None);
+
+            // ensure that these are valid DateTimeOffsets as they need to be able to
+            // round-trip during serialization/deserialization
+            _ = (DateTimeOffset)_listener.ScheduleStatus.Last;
+            _ = (DateTimeOffset)_listener.ScheduleStatus.Next;
+            _ = (DateTimeOffset)_listener.ScheduleStatus.LastUpdated;
+
+            var defaultDateTime = default(DateTime).ToLocalTime();
+
+            Assert.Equal(defaultDateTime, _listener.ScheduleStatus.Last);
+            Assert.Equal(invalidStatus.Next, _listener.ScheduleStatus.Next);
+            Assert.Equal(invalidStatus.LastUpdated, _listener.ScheduleStatus.LastUpdated);
+        }
+
+        [Fact]
         public async Task StartAsync_ScheduleStatus_DateKindIsLocal()
         {
             _listener.ScheduleMonitor = null;
@@ -304,9 +391,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             CancellationToken cancellationToken = CancellationToken.None;
             await _listener.StartAsync(cancellationToken);
 
-            //Assert.Equal(DateTimeKind.Local, _listener.ScheduleStatus.Last.Kind);
-            //Assert.Equal(DateTimeKind.Local, _listener.ScheduleStatus.Next.Kind);
-            //Assert.Equal(DateTimeKind.Local, _listener.ScheduleStatus.LastUpdated.Kind);
+            Assert.Equal(DateTimeKind.Local, _listener.ScheduleStatus.Last.Kind);
+            Assert.Equal(DateTimeKind.Local, _listener.ScheduleStatus.Next.Kind);
+            Assert.Equal(DateTimeKind.Local, _listener.ScheduleStatus.LastUpdated.Kind);
 
             _listener.Dispose();
         }
@@ -692,6 +779,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             _logger = new TestLogger(null);
             var drainModeManager = drainManager ?? new Mock<IDrainModeManager>().Object;
             _listener = new TimerListener(_attribute, _schedule, _testTimerName, _options, _mockTriggerExecutor.Object, _logger, _mockScheduleMonitor.Object, _functionShortName, drainModeManager);
+        }
+
+        public void Dispose()
+        {
+            _listener?.Dispose();
         }
     }
 }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Listener/TimerListenerTests.cs
@@ -317,11 +317,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             _ = (DateTimeOffset)_listener.ScheduleStatus.Next;
             _ = (DateTimeOffset)_listener.ScheduleStatus.LastUpdated;
 
-            var defaultDateTime = default(DateTime).ToLocalTime();
-
-            Assert.Equal(defaultDateTime, _listener.ScheduleStatus.Last);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.Last);
             Assert.True(_listener.ScheduleStatus.Next > DateTime.Now);
-            Assert.Equal(defaultDateTime, _listener.ScheduleStatus.LastUpdated);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.LastUpdated);
         }
 
         [Fact]
@@ -376,9 +374,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers
             _ = (DateTimeOffset)_listener.ScheduleStatus.Next;
             _ = (DateTimeOffset)_listener.ScheduleStatus.LastUpdated;
 
-            var defaultDateTime = default(DateTime).ToLocalTime();
-
-            Assert.Equal(defaultDateTime, _listener.ScheduleStatus.Last);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, _listener.ScheduleStatus.Last);
             Assert.Equal(invalidStatus.Next, _listener.ScheduleStatus.Next);
             Assert.Equal(invalidStatus.LastUpdated, _listener.ScheduleStatus.LastUpdated);
         }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/FileSystemScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/FileSystemScheduleMonitorTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
 
             TimeSpan pastDueAmount = await _monitor.CheckPastDueAsync(_testTimerName, now, mockSchedule.Object, null);
             Assert.True(File.Exists(_statusFile));
-            VerifyScheduleStatus(default(DateTime), next, now);
+            VerifyScheduleStatus(ScheduleMonitor.DefaultDateTime, next, now);
             Assert.Equal(TimeSpan.Zero, pastDueAmount);
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Timers.Scheduling
             pastDueAmount = await _monitor.CheckPastDueAsync(_testTimerName, now, mockSchedule.Object, status);
             Assert.Equal(TimeSpan.Zero, pastDueAmount);
             ScheduleStatus updatedStatus = await _monitor.GetStatusAsync(_testTimerName);
-            Assert.Equal(default(DateTime), updatedStatus.Last);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, updatedStatus.Last);
             Assert.Equal(adjustedNext, updatedStatus.Next);
             Assert.Equal(now, updatedStatus.LastUpdated);
 

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -24,7 +24,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         }
 
         [Fact]
-        public async Task CheckPastDue_NullStatus()
+        public Task CheckPastDue_NullStatus_Tokyo()
+        {
+            using var timeZoneSetter = TimeZoneSetter.TokyoStandard;
+            return CheckPastDue_NullStatus();
+        }
+
+        [Fact]
+        public Task CheckPastDue_NullStatus_Utc()
+        {
+            using var timeZoneSetter = TimeZoneSetter.Utc;
+            return CheckPastDue_NullStatus();
+        }
+
+        [Fact]
+        public Task CheckPastDue_NullStatus_Pacific()
+        {
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
+            return CheckPastDue_NullStatus();
+        }
+
+        private async Task CheckPastDue_NullStatus()
         {
             DateTime now = new DateTime(2017, 1, 1, 9, 35, 0);
             MockScheduleMonitor monitor = new MockScheduleMonitor();
@@ -35,6 +55,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
             Assert.Equal(new DateTime(2017, 1, 2), monitor.CurrentStatus.Next);
             Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
+
+            // ensure that these are valid DateTimeOffsets as they need to be able to
+            // round-trip during serialization/deserialization
+            _ = (DateTimeOffset)monitor.CurrentStatus.Last;
+            _ = (DateTimeOffset)monitor.CurrentStatus.Next;
+            _ = (DateTimeOffset)monitor.CurrentStatus.LastUpdated;
         }
 
         [Theory]
@@ -212,6 +238,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
                 // Because the 'Next' times happen to line up, we don't see it as a new schedule and don't update it
                 Assert.Null(monitor.CurrentStatus);
             }
+        }
+
+        [Fact]
+        public async Task CheckPastDue_Creates_ValidDefaults()
+        {
+            DateTime now = new DateTime(2017, 1, 1, 9, 35, 0);
+
+            MockScheduleMonitor monitor = new MockScheduleMonitor();
+            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _halfHourlySchedule, null);
         }
 
         private class MockScheduleMonitor : ScheduleMonitor

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -240,15 +240,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             }
         }
 
-        [Fact]
-        public async Task CheckPastDue_Creates_ValidDefaults()
-        {
-            DateTime now = new DateTime(2017, 1, 1, 9, 35, 0);
-
-            MockScheduleMonitor monitor = new MockScheduleMonitor();
-            TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _halfHourlySchedule, null);
-        }
-
         private class MockScheduleMonitor : ScheduleMonitor
         {
             public ScheduleStatus CurrentStatus { get; private set; }

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -56,11 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             Assert.Equal(new DateTime(2017, 1, 2), monitor.CurrentStatus.Next);
             Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
 
-            // ensure that these are valid DateTimeOffsets as they need to be able to
-            // round-trip during serialization/deserialization
-            _ = (DateTimeOffset)monitor.CurrentStatus.Last;
-            _ = (DateTimeOffset)monitor.CurrentStatus.Next;
-            _ = (DateTimeOffset)monitor.CurrentStatus.LastUpdated;
+            ValidateSchedule(monitor.CurrentStatus);
         }
 
         [Theory]
@@ -99,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
-        public Task CheckPastDue_PlusTimeZone(bool lastSet, bool lastUpdatedSet)
+        public Task CheckPastDue_Tokyo(bool lastSet, bool lastUpdatedSet)
         {
             // tokyo is +9 hours from utc
             using var timeZoneSetter = TimeZoneSetter.TokyoStandard;
@@ -112,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(true, true)]
         [InlineData(false, true)]
 
-        public Task CheckPastDue_MinusTimeZone(bool lastSet, bool lastUpdatedSet)
+        public Task CheckPastDue_Pacific(bool lastSet, bool lastUpdatedSet)
         {
             // pacific is -8 hours from utc
             using var timeZoneSetter = TimeZoneSetter.PacificStandard;
@@ -163,6 +159,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
+        public Task CheckPastDue_ScheduleChange_Longer_Tokyo(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.TokyoStandard;
+            return CheckPastDue_ScheduleChange_Longer(lastSet, lastUpdatedSet);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public Task CheckPastDue_ScheduleChange_Longer_Utc(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.Utc;
+            return CheckPastDue_ScheduleChange_Longer(lastSet, lastUpdatedSet);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public Task CheckPastDue_ScheduleChange_Longer_Pacific(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
+            return CheckPastDue_ScheduleChange_Longer(lastSet, lastUpdatedSet);
+        }
+
         public async Task CheckPastDue_ScheduleChange_Longer(bool lastSet, bool lastUpdatedSet)
         {
             DateTime now = DateTime.Parse("1/1/2017 9:35");
@@ -186,6 +210,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
             Assert.Equal(expectedNext, monitor.CurrentStatus.Next);
 
+            ValidateSchedule(monitor.CurrentStatus);
+
             if (lastUpdatedSet || lastSet)
             {
                 Assert.Equal(new DateTime(2017, 1, 1, 9, 0, 0), monitor.CurrentStatus.LastUpdated);
@@ -202,7 +228,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(false, true)]
-        public async Task CheckPastDue_ScheduleChange_Shorter(bool lastSet, bool lastUpdatedSet)
+        public Task CheckPastDue_ScheduleChange_Shorter_Tokyo(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.TokyoStandard;
+            return CheckPastDue_ScheduleChange_Shorter(lastSet, lastUpdatedSet);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public Task CheckPastDue_ScheduleChange_Shorter_Pacific(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.PacificStandard;
+            return CheckPastDue_ScheduleChange_Shorter(lastSet, lastUpdatedSet);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public Task CheckPastDue_ScheduleChange_Shorter_Utc(bool lastSet, bool lastUpdatedSet)
+        {
+            using var timeZoneSetter = TimeZoneSetter.Utc;
+            return CheckPastDue_ScheduleChange_Shorter(lastSet, lastUpdatedSet);
+        }
+
+        private async Task CheckPastDue_ScheduleChange_Shorter(bool lastSet, bool lastUpdatedSet)
         {
             DateTime now = new DateTime(2017, 1, 1, 9, 35, 0);
 
@@ -227,6 +281,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
                 Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
                 Assert.Equal(new DateTime(2017, 1, 1, 10, 0, 0), monitor.CurrentStatus.Next);
                 Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
+
+                ValidateSchedule(monitor.CurrentStatus);
             }
             else
             {
@@ -238,6 +294,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
                 // Because the 'Next' times happen to line up, we don't see it as a new schedule and don't update it
                 Assert.Null(monitor.CurrentStatus);
             }
+        }
+
+        public static void ValidateSchedule(ScheduleStatus schedule)
+        {
+            // ensure that these are valid DateTimeOffsets as they need to be able to
+            // round-trip during serialization/deserialization
+            _ = (DateTimeOffset)schedule.Last;
+            _ = (DateTimeOffset)schedule.Next;
+            _ = (DateTimeOffset)schedule.LastUpdated;
         }
 
         private class MockScheduleMonitor : ScheduleMonitor

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Scheduling/ScheduleMonitorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
 
             TimeSpan pastDueAmount = await monitor.CheckPastDueAsync(_timerName, now, _dailySchedule, null);
             Assert.Equal(TimeSpan.Zero, pastDueAmount);
-            Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, monitor.CurrentStatus.Last);
             Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
             Assert.Equal(new DateTime(2017, 1, 2), monitor.CurrentStatus.Next);
             Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
                 //      but we miss it because there is no 'Last' value, which we require to calculate the 'Next'
                 //      value. It also shouldn't register as a schedule change.
                 Assert.Equal(TimeSpan.Zero, pastDueAmount);
-                Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+                Assert.Equal(ScheduleMonitor.DefaultDateTime, monitor.CurrentStatus.Last);
                 Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
                 Assert.Equal(DateTime.Parse("1/1/2017 11:00"), monitor.CurrentStatus.Next);
                 Assert.Equal(now, monitor.CurrentStatus.LastUpdated);
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             Assert.Equal(TimeSpan.Zero, pastDueAmount);
 
             DateTime expectedNext = new DateTime(2017, 1, 2);
-            Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, monitor.CurrentStatus.Last);
             Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
             Assert.Equal(expectedNext, monitor.CurrentStatus.Next);
 
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling
             {
                 // Because the new time is in the past, we re-calculate it to be the next invocation from 'now'.
                 Assert.Equal(TimeSpan.Zero, pastDueAmount);
-                Assert.Equal(default(DateTime), monitor.CurrentStatus.Last);
+                Assert.Equal(ScheduleMonitor.DefaultDateTime, monitor.CurrentStatus.Last);
                 Assert.Equal(DateTimeKind.Local, monitor.CurrentStatus.Last.Kind);
                 Assert.Equal(new DateTime(2017, 1, 1, 10, 0, 0), monitor.CurrentStatus.Next);
                 Assert.Equal(now, monitor.CurrentStatus.LastUpdated);

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
 
-internal class TimeZoneSetter : IDisposable
+public class TimeZoneSetter : IDisposable
 {
     // There are so many internal benefits to using DateTimeKind.Local for us, that we're relying 
     // on it to provide the proper roundtripping support between DateTime and DateTimeOffset. This appears

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/TimeZoneSetter.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers;
 
-public class TimeZoneSetter : IDisposable
+internal class TimeZoneSetter : IDisposable
 {
     // There are so many internal benefits to using DateTimeKind.Local for us, that we're relying 
     // on it to provide the proper roundtripping support between DateTime and DateTimeOffset. This appears


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-dotnet-worker/issues/2971 

There was an issue with us using a default `DateTime` that, when parsed by certain Json serializers would throw an exeption (notably `System.Text.Json` in .NET... although `Newtonsoft.Json` worked fine)

This is because using `new DateTime(0, DateTimeKind.Local)` results in a usable `DateTime`, but when cast or parsed as a `DateTimeOffset`, would throw.

This change fixes that and adds a bunch of tests around the scenarios we were seeing. It also adds an additional detail to the TriggerDetails collection, which would have helped us in our analysis.