### PR TITLE
fixing issue in Timer's BindAsync with invalid dates

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Bindings/TimerTriggerBinding.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Bindings
                 ScheduleStatus status = null;
                 if (_attribute.UseMonitor && _scheduleMonitor != null)
                 {
-                    status = await _scheduleMonitor.GetStatusAsync(_timerName);
+                    status = await _scheduleMonitor.GetSafeStatusAsync(_timerName);
                 }
                 timerInfo = new TimerInfo(_schedule, status);
             }

--- a/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Listener/TimerListener.cs
@@ -113,14 +113,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers.Listeners
             {
                 // check to see if we've missed an occurrence since we last started.
                 // If we have, invoke it immediately.
-                ScheduleStatus = await ScheduleMonitor.GetStatusAsync(_timerLookupName);
-
-                // Move any 'Last' value up to the new default. This fixes any serialization issues that
-                // we may hit due to time zone conversions
-                if (ScheduleStatus?.Last < ScheduleMonitor.DefaultDateTimeThreshold)
-                {
-                    ScheduleStatus.Last = ScheduleMonitor.DefaultDateTime;
-                }
+                ScheduleStatus = await ScheduleMonitor.GetSafeStatusAsync(_timerLookupName);
 
                 Logger.InitialStatus(_logger, _functionLogName, ScheduleStatus?.Last.ToString("o"), ScheduleStatus?.Next.ToString("o"), ScheduleStatus?.LastUpdated.ToString("o"));
                 TimeSpan pastDueDuration = await ScheduleMonitor.CheckPastDueAsync(_timerLookupName, now, _schedule, ScheduleStatus);

--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/ScheduleMonitor.cs
@@ -30,6 +30,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         public abstract Task<ScheduleStatus> GetStatusAsync(string timerName);
 
         /// <summary>
+        /// Internally, calls <see cref="GetStatusAsync(string)"/> and corrects any invalid values
+        /// on the returned <see cref="ScheduleStatus"/> object before returning.
+        /// </summary>
+        /// <param name="timerName">The name of the timer to check.</param>
+        /// <returns>The schedule status.</returns>
+        public async Task<ScheduleStatus> GetSafeStatusAsync(string timerName)
+        {
+            var status = await GetStatusAsync(timerName);
+
+            if (status?.Last < DefaultDateTimeThreshold)
+            {
+                status.Last = DefaultDateTime;
+            }
+
+            if (status?.Next < DefaultDateTimeThreshold)
+            {
+                status.Next = DefaultDateTime;
+            }
+
+            if (status?.LastUpdated < DefaultDateTimeThreshold)
+            {
+                status.LastUpdated = DefaultDateTime;
+            }
+
+            return status;
+        }
+
+        /// <summary>
         /// Updates the schedule status for the specified timer.
         /// </summary>
         /// <param name="timerName">The name of the timer.</param>

--- a/test/WebJobs.Extensions.Tests/Extensions/Timers/Bindings/TimerTriggerBindingTests.cs
+++ b/test/WebJobs.Extensions.Tests/Extensions/Timers/Bindings/TimerTriggerBindingTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Scheduling;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Extensions.Timers.Bindings;
 using Microsoft.Azure.WebJobs.Host;
@@ -21,6 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Bindings
     {
         private readonly ILogger _logger;
         private readonly TestLoggerProvider _loggerProvider;
+        private readonly string _timerName;
+        private readonly Mock<ScheduleMonitor> _mockScheduleMonitor;
+        private readonly TimerTriggerBinding _binding;
+        private readonly TimerSchedule _schedule;
 
         public TimerTriggerBindingTests()
         {
@@ -28,44 +33,96 @@ namespace Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.Timers.Bindings
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
             _logger = _loggerProvider.CreateLogger("Test");
+
+            ParameterInfo parameter = GetType().GetMethod("TestTimerJob").GetParameters()[0];
+            MethodInfo methodInfo = (MethodInfo)parameter.Member;
+            _timerName = string.Format("{0}.{1}", methodInfo.DeclaringType.FullName, methodInfo.Name);
+
+            _mockScheduleMonitor = new Mock<ScheduleMonitor>(MockBehavior.Strict);
+
+            TimerTriggerAttribute attribute = parameter.GetCustomAttribute<TimerTriggerAttribute>();
+            INameResolver nameResolver = new TestNameResolver();
+            _schedule = TimerSchedule.Create(attribute, nameResolver, _logger);
+            TimersOptions options = new TimersOptions();
+
+            Mock<IDrainModeManager> mockDrainModeManager = new Mock<IDrainModeManager>(MockBehavior.Strict);
+
+            _binding = new TimerTriggerBinding(parameter, attribute, _schedule, options, loggerFactory.CreateLogger("Test"), _mockScheduleMonitor.Object, mockDrainModeManager.Object);
         }
 
         [Fact]
         public async Task BindAsync_ReturnsExpectedTriggerData()
         {
-            ParameterInfo parameter = GetType().GetMethod("TestTimerJob").GetParameters()[0];
-            MethodInfo methodInfo = (MethodInfo)parameter.Member;
-            string timerName = string.Format("{0}.{1}", methodInfo.DeclaringType.FullName, methodInfo.Name);
-
-            Mock<ScheduleMonitor> mockScheduleMonitor = new Mock<ScheduleMonitor>(MockBehavior.Strict);
             ScheduleStatus status = new ScheduleStatus();
-            mockScheduleMonitor.Setup(p => p.GetStatusAsync(timerName)).ReturnsAsync(status);
-
-            TimerTriggerAttribute attribute = parameter.GetCustomAttribute<TimerTriggerAttribute>();
-            INameResolver nameResolver = new TestNameResolver();
-            TimerSchedule schedule = TimerSchedule.Create(attribute, nameResolver, _logger);
-            TimersOptions options = new TimersOptions();
-
-            ILoggerFactory loggerFactory = new LoggerFactory();
-            loggerFactory.AddProvider(new TestLoggerProvider());
-
-            Mock<IDrainModeManager> mockDrainModeManager = new Mock<IDrainModeManager>(MockBehavior.Strict);
-
-            TimerTriggerBinding binding = new TimerTriggerBinding(parameter, attribute, schedule, options, loggerFactory.CreateLogger("Test"), mockScheduleMonitor.Object, mockDrainModeManager.Object);
+            _mockScheduleMonitor.Setup(p => p.GetStatusAsync(_timerName)).ReturnsAsync(status);
 
             // when we bind to a non-TimerInfo (e.g. in a Dashboard invocation) a new
             // TimerInfo is created, with the ScheduleStatus populated
             FunctionBindingContext functionContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None);
             ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
-            TriggerData triggerData = (TriggerData)(await binding.BindAsync(string.Empty, context));
+            TriggerData triggerData = (TriggerData)(await _binding.BindAsync(string.Empty, context));
             TimerInfo timerInfo = (TimerInfo)(await triggerData.ValueProvider.GetValueAsync());
             Assert.Same(status, timerInfo.ScheduleStatus);
 
             // when we pass in a TimerInfo that is used
-            TimerInfo expected = new TimerInfo(schedule, status);
-            triggerData = (TriggerData)(await binding.BindAsync(expected, context));
+            TimerInfo expected = new TimerInfo(_schedule, status);
+            triggerData = (TriggerData)(await _binding.BindAsync(expected, context));
             timerInfo = (TimerInfo)(await triggerData.ValueProvider.GetValueAsync());
             Assert.Same(expected, timerInfo);
+        }
+
+        [Fact]
+        public Task BindAsync_InvalidStatus_DefaultsToValidDates_Tokyo()
+        {
+            using var tz = TimeZoneSetter.TokyoStandard;
+            return BindAsync_InvalidStatus_DefaultsToValidDates();
+        }
+
+        [Fact]
+        public Task BindAsync_InvalidStatus_DefaultsToValidDates_Pacific()
+        {
+            using var tz = TimeZoneSetter.PacificStandard;
+            return BindAsync_InvalidStatus_DefaultsToValidDates();
+        }
+
+        [Fact]
+        public Task BindAsync_InvalidStatus_DefaultsToValidDates_Utc()
+        {
+            using var tz = TimeZoneSetter.Utc;
+            return BindAsync_InvalidStatus_DefaultsToValidDates();
+        }
+
+        private async Task BindAsync_InvalidStatus_DefaultsToValidDates()
+        {
+            var testStart = DateTime.Now;
+
+            // This is invalid in UTC + time zones like Tokyo but used to be used as a 
+            // default value in the past.
+            var invalidDateTime = new DateTime(0, DateTimeKind.Local);
+
+            var invalidStatus = new ScheduleStatus()
+            {
+                Last = invalidDateTime,
+                Next = ScheduleMonitor.DefaultDateTimeThreshold.AddMinutes(-1),
+                LastUpdated = DateTime.MinValue
+            };
+
+            _mockScheduleMonitor
+                .Setup(p => p.GetStatusAsync(_timerName))
+                .Returns(Task.FromResult(invalidStatus));
+
+            FunctionBindingContext functionContext = new FunctionBindingContext(Guid.NewGuid(), CancellationToken.None);
+            ValueBindingContext context = new ValueBindingContext(functionContext, CancellationToken.None);
+
+            TriggerData triggerData = (TriggerData)(await _binding.BindAsync(string.Empty, context));
+            TimerInfo timerInfo = (TimerInfo)(await triggerData.ValueProvider.GetValueAsync());
+
+            ScheduleMonitorTests.ValidateSchedule(timerInfo.ScheduleStatus);
+
+            // Validate that all were set to default
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, timerInfo.ScheduleStatus.Last);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, timerInfo.ScheduleStatus.Next);
+            Assert.Equal(ScheduleMonitor.DefaultDateTime, timerInfo.ScheduleStatus.LastUpdated);
         }
 
         public static void TestTimerJob([TimerTrigger("5:00:00")] TimerInfo timer)


### PR DESCRIPTION
During testing of #933 I realized that portal invocations were still susceptible to "invalid" dates coming from the status blob. I had been correcting them in one place, but not all (turns out there were only two).

This change wraps the call to `GetStatusAsync()` with a `GetSafeStatusAsync()` that ensures the returned status is moved to our Default value to correct any issues with time zones. Doing it this way means that all derived `ScheduleMonitor` classes also get the safe API.

A test was added for the `BindAsync()` call where this was happening, and it failed in the Tokyo time zone before the fix.