### PR TITLE
Run code-mirror once a month

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -9,6 +9,15 @@ trigger:
     - cosmos-v*
     - extensions-v*
 
+schedules:
+# Run once a month to prevent disablement from inactivity.
+- cron: "0 0 1 * *"
+  displayName: Monthly sync
+  branches:
+    include:
+    - dev
+  always: true
+
 resources:
   repositories:
   - repository: eng

--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -11,7 +11,8 @@ trigger:
 
 schedules:
 # Run once a month to prevent disablement from inactivity.
-- cron: "0 0 1 * *"
+# Not using 12:00 UTC to spread out our schedules.
+- cron: "0 2 1 * *"
   displayName: Monthly sync
   branches:
     include:


### PR DESCRIPTION
Pipelines are disabled if inactive for 90 days. Since this repo gets infrequent check-ins adding a schedule to avoid code-mirror from going inactive.