### PR TITLE
Update Microsoft.Extensions.Azure to 1.12.0

### DIFF
--- a/sample/ExtensionsSample/ExtensionsSample.csproj
+++ b/sample/ExtensionsSample/ExtensionsSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
+	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.9.0</VersionPrefix>
+    <VersionPrefix>4.10.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions.Timers.Storage/Directory.Version.props
+++ b/src/WebJobs.Extensions.Timers.Storage/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.Timers.Storage/WebJobs.Extensions.Timers.Storage.csproj
+++ b/src/WebJobs.Extensions.Timers.Storage/WebJobs.Extensions.Timers.Storage.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
-    <PackageReference Include="System.Text.Json" Version="6.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+++ b/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.5" />
+	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
resolves #945

Updating `Microsoft.Extensions.Azure` to 1.12.0 across `WebJobs.Extensions.CosmosDB` and in `WebJobs.Extensions.Timers.Storage`, as well as supporting samples and tests.

This includes a major version update to `System.Text.Json` in `WebJobs.Extensions.Timers.Storage` to avoid a package downgrade.