### PR TITLE
Pinning System.Text.Json in Cosmos DB test project

### DIFF
--- a/test/WebJobs.Extensions.CosmosDB.Tests/WebJobs.Extensions.CosmosDB.Tests.csproj
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/WebJobs.Extensions.CosmosDB.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.TestCommon" Version="3.0.41" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+	<PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating the test project based on a warning that I didn't see until post-merge CI for https://github.com/Azure/azure-webjobs-sdk-extensions/pull/946.

Pinning  `System.Text.Json` to the desired major version so that it is unified properly.

