### PR TITLE
Adjust output bin path to simplify sign pattern

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -76,10 +76,9 @@ jobs:
           displayName: Sign assemblies
           minimatch: true
           signType: dll-strong-name
-          folderPath: out/bin
+          folderPath: out/bin/src
           pattern: |
             **/Microsoft.Azure.WebJobs.Extensions*.dll
-            !**/*Test*.dll
 
     - task: DotNetCoreCLI@2
       displayName: Pack

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -2,9 +2,9 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
           Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''" />
-          
+
   <PropertyGroup>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)/out</ArtifactsPath>
+    <ArtifactsBinOutputName>bin/sample</ArtifactsBinOutputName>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
+    <ArtifactsBinOutputName>bin/src</ArtifactsBinOutputName>
   </PropertyGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,6 +3,10 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
           Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''" />
 
+  <PropertyGroup>
+    <ArtifactsBinOutputName>bin/test</ArtifactsBinOutputName>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
To simplify signing step, this PR adds subdirectories to `out/bin` folder. Allowing us to narrow down signing all assemblies in `out/bin/src`, easily skipping `out/bin/test` and `out/bin/sample`.