### PR TITLE
Refactor releases to be individual pipelines

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,9 +1,3 @@
-parameters:
-- name: sign
-  displayName: Sign Files (release/* always signed)
-  type: boolean
-  default: false
-
 trigger:
   batch: true
   branches:
@@ -43,12 +37,6 @@ resources:
 variables:
   - template: /eng/ci/templates/variables/build.yml@self
   - template: /ci/variables/cfs.yml@eng
-  - name: sign
-    readonly: true
-    ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
-      value: true
-    ${{ else }}:
-      value: ${{ parameters.sign }}
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -68,5 +56,5 @@ extends:
       jobs:
       - template: /eng/ci/templates/jobs/build.yml@self
         parameters:
-          sign: ${{ variables.sign }}
-          project: $(Build.SourcesDirectory)/WebJobs.Extensions.sln
+          sign: false
+          projects: $(Build.SourcesDirectory)/WebJobs.Extensions.sln

--- a/eng/ci/official-release.cosmosdb.yml
+++ b/eng/ci/official-release.cosmosdb.yml
@@ -34,7 +34,7 @@ extends:
     - template: /eng/ci/templates/stages/release.yml@self
       parameters:
         public: ${{ parameters.public }}
-        folder: azure-webjobs-extensions
+        folder: azure-webjobs-extensions-cosmosdb
         projects: |
-          $(Build.SourcesDirectory)/src/WebJobs.Extensions/WebJobs.Extensions.csproj
-          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+          $(Build.SourcesDirectory)/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+          $(Build.SourcesDirectory)/test/WebJobs.Extensions.CosmosDB.Tests/WebJobs.Extensions.CosmosDB.Tests.csproj

--- a/eng/ci/official-release.http.yml
+++ b/eng/ci/official-release.http.yml
@@ -34,7 +34,7 @@ extends:
     - template: /eng/ci/templates/stages/release.yml@self
       parameters:
         public: ${{ parameters.public }}
-        folder: azure-webjobs-extensions
+        folder: azure-webjobs-extensions-http
         projects: |
-          $(Build.SourcesDirectory)/src/WebJobs.Extensions/WebJobs.Extensions.csproj
-          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+          $(Build.SourcesDirectory)/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Http.Tests/WebJobs.Extensions.Http.Tests.csproj

--- a/eng/ci/official-release.sendgrid.yml
+++ b/eng/ci/official-release.sendgrid.yml
@@ -34,7 +34,7 @@ extends:
     - template: /eng/ci/templates/stages/release.yml@self
       parameters:
         public: ${{ parameters.public }}
-        folder: azure-webjobs-extensions
+        folder: azure-webjobs-extensions-sendgrid
         projects: |
-          $(Build.SourcesDirectory)/src/WebJobs.Extensions/WebJobs.Extensions.csproj
-          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+          $(Build.SourcesDirectory)/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+          $(Build.SourcesDirectory)/test/WebJobs.Extensions.SendGrid.Tests/WebJobs.Extensions.SendGrid.Tests.csproj

--- a/eng/ci/official-release.timers.yml
+++ b/eng/ci/official-release.timers.yml
@@ -34,7 +34,7 @@ extends:
     - template: /eng/ci/templates/stages/release.yml@self
       parameters:
         public: ${{ parameters.public }}
-        folder: azure-webjobs-extensions
+        folder: azure-webjobs-extensions-timers
         projects: |
-          $(Build.SourcesDirectory)/src/WebJobs.Extensions/WebJobs.Extensions.csproj
-          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+          $(Build.SourcesDirectory)/src/WebJobs.Extensions.Timers/WebJobs.Extensions.Timers.csproj
+          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Timers.Tests/WebJobs.Extensions.Timers.Tests.csproj

--- a/eng/ci/official-release.twilio.yml
+++ b/eng/ci/official-release.twilio.yml
@@ -34,7 +34,7 @@ extends:
     - template: /eng/ci/templates/stages/release.yml@self
       parameters:
         public: ${{ parameters.public }}
-        folder: azure-webjobs-extensions
+        folder: azure-webjobs-extensions-twilio
         projects: |
-          $(Build.SourcesDirectory)/src/WebJobs.Extensions/WebJobs.Extensions.csproj
-          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Tests/WebJobs.Extensions.Tests.csproj
+          $(Build.SourcesDirectory)/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+          $(Build.SourcesDirectory)/test/WebJobs.Extensions.Twilio.Tests/WebJobs.Extensions.Twilio.Tests.csproj

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -2,7 +2,7 @@ parameters:
 - name: sign
   type: boolean
   default: false
-- name: project
+- name: projects
   type: string
 
 jobs:
@@ -14,10 +14,11 @@ jobs:
     value: $(Build.ArtifactStagingDirectory)/log
   - name: pack_dir
     value: $(Build.ArtifactStagingDirectory)/pkg
-  - name: buildNumber
-    value: $[ counter('constant', 12000) ]
-  - name: sign
-    value: ${{ parameters.sign }}
+  - name: extra_args
+    ${{ if eq(parameters.sign, true) }}:
+      value: -p:IsReleaseCI=true
+    ${{ else }}:
+      value: ''
 
   templateContext:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
@@ -30,31 +31,31 @@ jobs:
   steps:
     - template: /eng/ci/templates/steps/install-dotnet.yml@self
 
-    # If sign=false, verify this is not an "sign" branch
-    - ${{ if ne(parameters.sign, true) }}:
+    # If sign=true, verify this is a valid branch or tag
+    - ${{ if eq(parameters.sign, true) }}:
       - pwsh: |
           $source = "$(Build.SourceBranch)"
-          if ($source -like "refs/tags/*-v*" || $source -like "refs/tags/v*" || $source -like "refs/heads/release/*")
+          if (!($source -like "refs/tags/*-v*" || $source -like "refs/tags/v*" || $source -like "refs/heads/release/*"))
           {
-            Write-Host "##vso[task.logissue type=error]Branch/tag $source must have 'sign' set to 'true'."
+            Write-Host "##vso[task.logissue type=error]Signing is not allowed on non-release branches or tags"
             exit 1
           }
-        displayName: Verify not sign branch
+        displayName: Verify sign is allowed
 
     - task: DotNetCoreCLI@2
       displayName: Restore
       inputs:
         command: custom
         custom: restore
-        projects: ${{ parameters.project }}
+        projects: ${{ parameters.projects }}
         arguments: -v m
 
     - task: DotNetCoreCLI@2
       displayName: Build
       inputs:
         command: build
-        projects: ${{ parameters.project }}
-        arguments: -c $(configuration) -v m --no-restore -p:CommitHash=$(Build.SourceVersion)
+        projects: ${{ parameters.projects }}
+        arguments: -c $(configuration) -v m --no-restore
 
     - template: /eng/ci/templates/steps/start-emulators.yml@self
 
@@ -63,7 +64,7 @@ jobs:
       inputs:
         command: test
         arguments: -c $(configuration) --no-build
-        projects: ${{ parameters.project }}
+        projects: ${{ parameters.projects }}
       env:
         AzureWebJobsStorage: $(Storage)
         AzureWebJobsDashboard: $(Storage)
@@ -86,7 +87,7 @@ jobs:
         command: custom
         custom: pack
         arguments: -c $(configuration) -v m -o $(pack_dir) --no-build
-        projects: ${{ parameters.project }}
+        projects: ${{ parameters.projects }}
 
     - ${{ if eq(parameters.sign, true) }}:
       - template: ci/sign-files.yml@eng

--- a/eng/ci/templates/stages/release.yml
+++ b/eng/ci/templates/stages/release.yml
@@ -1,0 +1,33 @@
+parameters:
+- name: projects
+  type: string
+- name: folder
+  type: string
+- name: public
+  type: boolean
+  default: false
+
+stages:
+- stage: Build
+  jobs:
+  - template: /eng/ci/templates/jobs/build.yml@self
+    parameters:
+      sign: true
+      projects: ${{ parameters.projects}}
+
+- stage: Release
+  dependsOn: Build
+  jobs:
+  - template: /ci/release-nuget-package.yml@eng
+    parameters:
+      isProduction: true
+      approvers: '[internal]\Azure Functions Core'
+      artifact: drop_packages
+      stagingFeed: public/pre-release
+      packages: |
+        **/*.nupkg
+        !**/*.symbols.nupkg
+      ${{ if eq(parameters.public, true) }}:
+        partnerDrop:
+          serviceConnection: azure-sdk-partner-drops
+          targetFolder: azure-functions/dotnet/${{ parameters.folder }}/$(Build.BuildNumber)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <ArtifactsBinOutputName>bin/src</ArtifactsBinOutputName>
+    <UpdateBuildNumber Condition="'$(IsReleaseCI)' == 'true'">true</UpdateBuildNumber>
   </PropertyGroup>
 
 </Project>

--- a/src/WebJobs.Extensions/Directory.Version.props
+++ b/src/WebJobs.Extensions/Directory.Version.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Refactor and split up release pipeline to be an individual pipeline per package. The previous release pipeline attempted to consume the current `official-build.yml` pipeline, but this became too complex and convoluted. Instead, the new pipelines make no use of the common CI and build & test the intended projects directly when it is queued.