### PR TITLE
Reduce a test dependency to avoid extra build

### DIFF
--- a/test/WebJobs.Extensions.Tests.Common/WebJobs.Extensions.Tests.Common.csproj
+++ b/test/WebJobs.Extensions.Tests.Common/WebJobs.Extensions.Tests.Common.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
@@ -17,10 +18,6 @@
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
     <PackageReference Include="System.Text.Json" Version="6.0.10" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="$(SrcRoot)WebJobs.Extensions/WebJobs.Extensions.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removing the p2p reference just to avoid building `WebJobs.Extensions` from other release pipelines when it isn't needed.