### PR TITLE
Rev/fix versions for packages to prepare for release

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,0 +1,4 @@
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.11.0
+
+- Update Microsoft.Azure.Cosmos to 3.53.1 (#963)
+- Update Microsoft.Azure.WebJobs to 3.0.42 (#955)

--- a/src/WebJobs.Extensions.Http/Directory.Version.props
+++ b/src/WebJobs.Extensions.Http/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>3.2.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.Http/release_notes.md
+++ b/src/WebJobs.Extensions.Http/release_notes.md
@@ -1,0 +1,3 @@
+## Microsoft.Azure.WebJobs.Extensions.Http 3.2.1
+
+- Update Microsoft.Azure.WebJobs to 3.0.42 (#955)

--- a/src/WebJobs.Extensions.SendGrid/Directory.Version.props
+++ b/src/WebJobs.Extensions.SendGrid/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
+++ b/src/WebJobs.Extensions.SendGrid/WebJobs.Extensions.SendGrid.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions.SendGrid/release_notes.md
+++ b/src/WebJobs.Extensions.SendGrid/release_notes.md
@@ -1,0 +1,3 @@
+## Microsoft.Azure.WebJobs.Extensions.SendGrid 3.1.1
+
+- Update Microsoft.Azure.WebJobs to 3.0.42 (#955)

--- a/src/WebJobs.Extensions.Timers.Storage/release_notes.md
+++ b/src/WebJobs.Extensions.Timers.Storage/release_notes.md
@@ -1,0 +1,3 @@
+## Microsoft.Azure.WebJobs.Extensions.Timers.Storage 1.1.0
+
+- Fix timers directory using incorrect path separator for Linux (#960)

--- a/src/WebJobs.Extensions.Twilio/Directory.Version.props
+++ b/src/WebJobs.Extensions.Twilio/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
+++ b/src/WebJobs.Extensions.Twilio/WebJobs.Extensions.Twilio.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
     <PackageReference Include="Twilio" Version="6.18.0" />
   </ItemGroup>

--- a/src/WebJobs.Extensions.Twilio/release_notes.md
+++ b/src/WebJobs.Extensions.Twilio/release_notes.md
@@ -1,0 +1,3 @@
+## Microsoft.Azure.WebJobs.Extensions.Twilio 4.0.1
+
+- Update Microsoft.Azure.WebJobs to 3.0.42 (#955)

--- a/src/WebJobs.Extensions/Directory.Version.props
+++ b/src/WebJobs.Extensions/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>5.2.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions/WebJobs.Extensions.csproj
+++ b/src/WebJobs.Extensions/WebJobs.Extensions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
     <PackageReference Include="ncrontab.signed" Version="3.3.3" />
   </ItemGroup>
 

--- a/src/WebJobs.Extensions/release_notes.md
+++ b/src/WebJobs.Extensions/release_notes.md
@@ -1,0 +1,3 @@
+## Microsoft.Azure.WebJobs.Extensions 5.2.1
+
+- Update Microsoft.Azure.WebJobs to 3.0.42 (#955)


### PR DESCRIPTION
Prepare to release the following packages:

Microsoft.Azure.WebJobs.Extensions -- `5.2.0` -> `5.2.1`. Found the current version in `Directory.Version.props` was wrong. Current released version is `5.2.0` in our _internal_ feed only. Nuget.org is old.
Microsoft.Azure.WebJobs.Extensions.Http -- `3.2.0` -> `3.2.1`
Microsoft.Azure.WebJobs.Extensions.SendGrid -- `3.1.0` -> `3.1.1`
Microsoft.Azure.WebJobs.Extensions.Timers.Storage -- no change. `1.0.0` -> `1.1.0` is already staged.
Microsoft.Azure.WebJobs.Extensions.Twilio -- `4.0.0` -> `4.0.1`. Nuget.org is old, we have 4.0.0 released in our internal feed.
