### PR TITLE
fix: use Path.Combine for timers directory to support Linux paths

### DIFF
--- a/src/WebJobs.Extensions/Extensions/Timers/Scheduling/FileSystemScheduleMonitor.cs
+++ b/src/WebJobs.Extensions/Extensions/Timers/Scheduling/FileSystemScheduleMonitor.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
 
             if (string.IsNullOrEmpty(_statusFilePath) || !Directory.Exists(_statusFilePath))
             {
-                _statusFilePath = Path.Combine(rootPath, @"webjobs\timers");
+                _statusFilePath = Path.Combine(rootPath, "webjobs", "timers");
             }
             Directory.CreateDirectory(_statusFilePath);
 


### PR DESCRIPTION
Just clicked the Copilot button in my [issue](https://github.com/Azure/azure-webjobs-sdk-extensions/issues/959) and it created this, no idea if you guys accept contibutions and I haven't tested it. LGTM though.