### PR TITLE
[CosmosDb] Avoid swallowing exceptions when retrieving votes

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
@@ -20,20 +20,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
         private readonly int _maxAssignWorkerOnNotFoundCount = 5;
         private int _assignWorkerOnNotFoundCount = 0;
 
-        private static readonly Dictionary<string, string> KnownDocumentClientErrors = new Dictionary<string, string>()
-        {
-            { "Resource Not Found", "Please check that the CosmosDB container and leases container exist and are listed correctly in Functions config files." },
-            { "The input authorization token can't serve the request", string.Empty },
-            { "The MAC signature found in the HTTP request is not the same", string.Empty },
-            { "Service is currently unavailable.", string.Empty },
-            { "Entity with the specified id does not exist in the system.", string.Empty },
-            { "Subscription owning the database account is disabled.", string.Empty },
-            { "Request rate is large", string.Empty },
-            { "The remote name could not be resolved:", string.Empty },
-            { "Owner resource does not exist", string.Empty },
-            { "The specified document collection is invalid", string.Empty }
-        };
-
         public CosmosDBMetricsProvider(ILogger logger, Container monitoredContainer, Container leaseContainer, string processorName)
         {
             _logger = logger;
@@ -93,45 +79,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 partitionCount = 1;
                 remainingWork = 1;
             }
-            catch (Exception e) when (e is CosmosException || e is InvalidOperationException)
-            {
-                if (!TryHandleCosmosException(e))
-                {
-                    _logger.LogWarning(Events.OnScaling, "Unable to handle {0}: {1}", e.GetType().ToString(), e.Message);
-                    if (e is InvalidOperationException)
-                    {
-                        throw;
-                    }
-                }
-            }
-            catch (System.Net.Http.HttpRequestException e)
-            {
-                string errormsg;
-
-                var webException = e.InnerException as WebException;
-                if (webException != null &&
-                    webException.Status == WebExceptionStatus.ProtocolError)
-                {
-                    string statusCode = ((HttpWebResponse)webException.Response).StatusCode.ToString();
-                    string statusDesc = ((HttpWebResponse)webException.Response).StatusDescription;
-                    errormsg = string.Format("CosmosDBTrigger status {0}: {1}.", statusCode, statusDesc);
-                }
-                else if (webException != null &&
-                    webException.Status == WebExceptionStatus.NameResolutionFailure)
-                {
-                    errormsg = string.Format("CosmosDBTrigger Exception message: {0}.", webException.Message);
-                }
-                else
-                {
-                    errormsg = e.ToString();
-                }
-
-                _logger.LogWarning(Events.OnScaling, errormsg);
-            }
-            catch (Exception e)
-            {
-                _logger.LogWarning(Events.OnScaling, "Exception occurred while obtaining metrics for CosmosDB {0}: {1}.", e.GetType().ToString(), e.ToString());
-            }
 
             return new CosmosDBTriggerMetrics
             {
@@ -139,32 +86,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 PartitionCount = partitionCount,
                 RemainingWork = remainingWork
             };
-        }
-
-        // Since all exceptions in the Cosmos client are thrown as CosmosExceptions, we have to parse their error strings because we dont have access to the internal types
-        private bool TryHandleCosmosException(Exception exception)
-        {
-            string errormsg = null;
-            string exceptionMessage = exception.Message;
-
-            if (!string.IsNullOrEmpty(exceptionMessage))
-            {
-                foreach (KeyValuePair<string, string> exceptionString in KnownDocumentClientErrors)
-                {
-                    if (exceptionMessage.IndexOf(exceptionString.Key, StringComparison.OrdinalIgnoreCase) >= 0)
-                    {
-                        errormsg = !string.IsNullOrEmpty(exceptionString.Value) ? exceptionString.Value : exceptionMessage;
-                    }
-                }
-            }
-
-            if (!string.IsNullOrEmpty(errormsg))
-            {
-                _logger.LogWarning(errormsg);
-                return true;
-            }
-
-            return false;
         }
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTargetScaler.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTargetScaler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 targetWorkerCount = partitionCount;
             }
 
-            _logger.LogInformation(targetScaleMessage);
+            _logger.LogFunctionScaleVote(_functionId, targetWorkerCount, (int)remainingWork, concurrency, targetScaleMessage);
 
             return new TargetScalerResult
             {

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBMetricsProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBMetricsProviderTests.cs
@@ -149,19 +149,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             _loggerProvider.ClearAllLogMessages();
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await _cosmosDbMetricsProvider.GetMetricsAsync());
-
-            warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.Equal("Unable to handle System.InvalidOperationException: Unknown", warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
 
-            metrics = (CosmosDBTriggerMetrics)await _cosmosDbMetricsProvider.GetMetricsAsync();
-
-            Assert.Equal(0, metrics.PartitionCount);
-            Assert.Equal(0, metrics.RemainingWork);
-            Assert.NotEqual(default(DateTime), metrics.Timestamp);
-
-            warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.Equal("CosmosDBTrigger Exception message: Uh oh again.", warning.FormattedMessage);
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(async () => await _cosmosDbMetricsProvider.GetMetricsAsync());
+            Assert.Equal("Uh oh", ex.Message);
+            Assert.Equal("Uh oh again", ex.InnerException.Message);
         }
 
         [Fact]


### PR DESCRIPTION
**Proposed Improvement**
We want to emit error logs to the customer’s Application Insights whenever there are connectivity issues to the resource.

**Current Behavior**
Exceptions are swallowed in the extension code and logged only in internal logs.

**Planned Change**
- The change will allow connectivity exceptions to bubble up to the WebJobs SDK, so they can be logged in the standard WebJobs format.
- All extensions will follow the same logging format for consistency.
- In case of an exception, the trigger will be ignored for the current vote integration.

**References**
-https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L195
-https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L121

**Additional Notes**
- The ScaleManager class in WebJobs SDK is used for both regular scale and runtime-driven scale.
- We are also adding voting logs in the PR to standardize how the current vote is logged. These logs will also be provided to the customer.
- A bunch of exceptions that were previously not emitted in Scale Controller internally (client exceptions) have been removed. Exceptions are swallowed only in scaling code; the listener code already logs them. Need to follow with CosmosDb team if we need to filter out some transient CosmosDb exceptions.
