### PR TITLE
[CosmosDB] Fix AllVersionsAndDelete type binding

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.12.0</VersionPrefix>
+    <VersionPrefix>4.13.0</VersionPrefix>
     <VersionSuffix Condition="'$(Preview)' == 'true'">preview.1</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 parameter,
                 processorName,
                 monitoredContainer,
-                leasesContainer, 
+                leasesContainer,
                 attribute,
                 _drainModeManager,
                 _logger);

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             Type itemType = typeof(T);
             if (!IsChangeFeedItemType(itemType))
             {
-                throw new InvalidOperationException("When using ChangeFeedMode.AllVersionsAndDeletes, the trigger type must be of type System.Collections.Generic.IReadOnlyCollection<Microsoft.Azure.Cosmos.ChangeFeedItem<T>>.");
+                throw new InvalidOperationException("When using ChangeFeedMode.AllVersionsAndDeletes, the document type must be of type Microsoft.Azure.Cosmos.ChangeFeedItem<T>.");
             }
 
             itemType = itemType.GetGenericArguments()[0];

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -269,29 +269,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         private ChangeFeedProcessorBuilder GetAllVersionsAndDeleteBuilder()
         {
-            static bool IsChangeFeedItemType(Type type)
-            {
-                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ChangeFeedItem<>))
-                {
-                    return true;
-                }
-
-                return false;
-            }
-
-            // We need to unwrap T from ChangeFeedItem<T> to T, and then construct a builder from that. We will also validate the
-            // binding is of type ChangeFeedItem<T>.
+            // We need to unwrap T from ChangeFeedItem<T> to T, and then construct a builder from that.
             Type itemType = typeof(T);
-            if (!IsChangeFeedItemType(itemType))
+            if (!itemType.IsGenericType || itemType.GetGenericTypeDefinition() != typeof(ChangeFeedItem<>))
             {
-                throw new InvalidOperationException("When using ChangeFeedMode.AllVersionsAndDeletes, the document type must be of type Microsoft.Azure.Cosmos.ChangeFeedItem<T>.");
+                // Type does not match ChangeFeedItem<T>, this is an invalid binding for AllVersionsAndDeletes.
+                throw new InvalidOperationException($"When using ChangeFeedMode.AllVersionsAndDeletes, the trigger binding type must be Microsoft.Azure.Cosmos.ChangeFeedItem<T>. Actual type: '{itemType.FullName}'.");
             }
 
             itemType = itemType.GetGenericArguments()[0];
-
             MethodInfo method = typeof(CosmosDBTriggerListener<T>).GetMethod(nameof(GetAllVersionsAndDeleteBuilderCore), BindingFlags.NonPublic | BindingFlags.Instance);
             MethodInfo genericMethod = method.MakeGenericMethod(itemType);
-            return (ChangeFeedProcessorBuilder)genericMethod.Invoke(this, []);
+            return (ChangeFeedProcessorBuilder)genericMethod.Invoke(this, null);
         }
 #endif
     }

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
@@ -13,7 +14,6 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
-using static Microsoft.Azure.Cosmos.Container;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 {
@@ -253,12 +253,46 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             return _cosmosDBAttribute.ChangeFeedMode switch
             {
                 CosmosDBChangeFeedMode.LatestVersion => _monitoredContainer.GetChangeFeedProcessorBuilder<T>(_processorName, ProcessChangesAsync),
-                CosmosDBChangeFeedMode.AllVersionsAndDeletes => _monitoredContainer.GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes<T>(_processorName, ProcessChangesAsync),
+                CosmosDBChangeFeedMode.AllVersionsAndDeletes => GetAllVersionsAndDeleteBuilder(),
                 _ => throw new InvalidOperationException($"Unsupported ChangeFeedMode '{_cosmosDBAttribute.ChangeFeedMode}'"),
             };
 #else
             return _monitoredContainer.GetChangeFeedProcessorBuilder<T>(_processorName, ProcessChangesAsync);
 #endif
         }
+
+#if PREVIEW
+        private ChangeFeedProcessorBuilder GetAllVersionsAndDeleteBuilderCore<TInner>()
+        {
+            return _monitoredContainer.GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes<TInner>(_processorName, ProcessChangesAsync);
+        }
+
+        private ChangeFeedProcessorBuilder GetAllVersionsAndDeleteBuilder()
+        {
+            static bool IsChangeFeedItemType(Type type)
+            {
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ChangeFeedItem<>))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            // We need to unwrap T from ChangeFeedItem<T> to T, and then construct a builder from that. We will also validate the
+            // binding is of type ChangeFeedItem<T>.
+            Type itemType = typeof(T);
+            if (!IsChangeFeedItemType(itemType))
+            {
+                throw new InvalidOperationException("When using ChangeFeedMode.AllVersionsAndDeletes, the trigger type must be of type System.Collections.Generic.IReadOnlyCollection<Microsoft.Azure.Cosmos.ChangeFeedItem<T>>.");
+            }
+
+            itemType = itemType.GetGenericArguments()[0];
+
+            MethodInfo method = typeof(CosmosDBTriggerListener<T>).GetMethod(nameof(GetAllVersionsAndDeleteBuilderCore), BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo genericMethod = method.MakeGenericMethod(itemType);
+            return (ChangeFeedProcessorBuilder)genericMethod.Invoke(this, []);
+        }
+#endif
     }
 }

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.54.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.55.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Preview)' == 'true'">
-    <PackageReference Update="Microsoft.Azure.Cosmos" Version="3.54.0-preview.1" />
+    <PackageReference Update="Microsoft.Azure.Cosmos" Version="3.55.0-preview.1" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,5 +1,5 @@
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0
 
-- Update Microsoft.Azure.Cosmos to 3.55.0
+- Update Microsoft.Azure.Cosmos to 3.55.0 (#976)
 
-**NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for this features.
+**NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for CosmosDB preview service features.

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,3 +1,5 @@
-## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.12.0
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0
 
-- Update Microsoft.Azure.Cosmos to 3.54.0 (#969)
+- Update Microsoft.Azure.Cosmos to 3.55.0
+
+**NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for this features.

--- a/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
@@ -1,4 +1,6 @@
-## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.12.0-preview.1
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0-preview.1
 
-- Update Microsoft.Azure.Cosmos to 3.54.0-preview.1 (#969)
-- Add support for `AllVersionsAndDelete` change feed mode. (#972)
+- Update Microsoft.Azure.Cosmos to 3.55.0-preview.1
+- Fix type binding for `AllVersionsAndDelete` mode. Throw exception if type is not `ChangeFeedMode<T>`.
+
+**NOTE**: The preview version of this package is released in parallel with the stable train. This follows Microsoft.Azure.Cosmos release model, where preview packages contain extra CosmosDB preview service features.

--- a/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
@@ -1,6 +1,6 @@
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0-preview.1
 
-- Update Microsoft.Azure.Cosmos to 3.55.0-preview.1
-- Fix type binding for `AllVersionsAndDelete` mode. Throw exception if type is not `ChangeFeedMode<T>`.
+- Update Microsoft.Azure.Cosmos to 3.55.0-preview.1. (#976)
+- Fix type binding for `AllVersionsAndDelete` mode. Throw exception if type is not `ChangeFeedMode<T>`. (#976)
 
 **NOTE**: The preview version of this package is released in parallel with the stable train. This follows Microsoft.Azure.Cosmos release model, where preview packages contain extra CosmosDB preview service features.

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.Preview.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.Preview.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             catch (FunctionListenerException ex)
             {
                 InvalidOperationException inner = Assert.IsType<InvalidOperationException>(ex.InnerException);
-                Assert.Equal("When using ChangeFeedMode.AllVersionsAndDeletes, the document type must be of type Microsoft.Azure.Cosmos.ChangeFeedItem<T>.", inner.Message);
+                Assert.StartsWith($"When using ChangeFeedMode.AllVersionsAndDeletes, the trigger binding type must be Microsoft.Azure.Cosmos.ChangeFeedItem<T>.", inner.Message);
             }
         }
 

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.Preview.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.Preview.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Extensions.CosmosDB.Models;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
+{
+#if PREVIEW
+    // The EndToEnd tests require the AzureWebJobsCosmosDBConnectionString environment variable to be set.
+    public sealed partial class CosmosDBEndToEndTests
+    {
+        private const string AllVersionsDeleteCollection = "allVersionsAndDeletes";
+
+        [Fact]
+        public async Task CosmosDBEndToEndChangeFeedModeWrongType()
+        {
+            _loggerProvider.ClearAllLogMessages();
+            using var host = BuildHost(typeof(IncorrectBindingTypeTestClass));
+            using var client = await InitializeDocumentClientAsync(
+                host.Services.GetRequiredService<IConfiguration>(), DatabaseName, AllVersionsDeleteCollection, "/_partitionKey");
+
+            try
+            {
+                await host.StartAsync();
+            }
+            catch (FunctionListenerException ex)
+            {
+                InvalidOperationException inner = Assert.IsType<InvalidOperationException>(ex.InnerException);
+                Assert.Equal("When using ChangeFeedMode.AllVersionsAndDeletes, the document type must be of type Microsoft.Azure.Cosmos.ChangeFeedItem<T>.", inner.Message);
+            }
+        }
+
+        [Fact(Skip = "Emulator doesn't appear to work with AllChangesAndDelete")]
+        public async Task CosmosDBEndToEndChangeFeedMode()
+        {
+            _loggerProvider.ClearAllLogMessages();
+            using var host = BuildHost(typeof(AllVersionsAndDeleteTestClass));
+            using var client = await InitializeDocumentClientAsync(
+                host.Services.GetRequiredService<IConfiguration>(), DatabaseName, AllVersionsDeleteCollection, "/_partitionKey");
+
+            await host.StartAsync();
+            await Task.Delay(TimeSpan.FromSeconds(10)); // change feed listener takes a bit to start
+
+            Item item = new() { Id = Guid.NewGuid().ToString(), Text = "Some Text" };
+            var container = client.GetContainer(DatabaseName, AllVersionsDeleteCollection);
+            await container.CreateItemAsync(item, PartitionKey.None);
+
+            IReadOnlyCollection<ChangeFeedItem<Item>> input =
+                await AllVersionsAndDeleteTestClass.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            Assert.Single(input, i => i.Current.Id == item.Id);
+        }
+
+        private static class IncorrectBindingTypeTestClass
+        {
+
+            public static void Trigger(
+                [CosmosDBTrigger(
+                    DatabaseName,
+                    AllVersionsDeleteCollection,
+                    CreateLeaseContainerIfNotExists = true,
+                    LeaseContainerPrefix = "ciIncorrectBindingType",
+                    ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] IReadOnlyCollection<Item> documents) // Not ChangeFeedItem<Item>
+            {
+                // This method is intentionally left blank.
+            }
+        }
+
+        private static class AllVersionsAndDeleteTestClass
+        {
+            private static TaskCompletionSource<IReadOnlyCollection<ChangeFeedItem<Item>>> _triggered = new();
+
+            public static Task<IReadOnlyCollection<ChangeFeedItem<Item>>> Task => _triggered.Task;
+
+            public static void Trigger(
+                [CosmosDBTrigger(
+                    DatabaseName,
+                    AllVersionsDeleteCollection,
+                    CreateLeaseContainerIfNotExists = true,
+                    LeaseContainerPrefix = "ciAllVersionsAndDelete",
+                    ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] IReadOnlyCollection<ChangeFeedItem<Item>> documents)
+            {
+                _triggered.TrySetResult(documents);
+            }
+        }
+    }
+}
+#endif

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.Preview.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.Preview.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+#if PREVIEW
 
 using System;
 using System.Collections.Generic;
@@ -13,7 +14,6 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 {
-#if PREVIEW
     // The EndToEnd tests require the AzureWebJobsCosmosDBConnectionString environment variable to be set.
     public sealed partial class CosmosDBEndToEndTests
     {
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 
         private static class IncorrectBindingTypeTestClass
         {
-
             public static void Trigger(
                 [CosmosDBTrigger(
                     DatabaseName,

--- a/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/CosmosDBEndToEndTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
 {
     // The EndToEnd tests require the AzureWebJobsCosmosDBConnectionString environment variable to be set.
     [Trait("Category", "E2E")]
-    public sealed class CosmosDBEndToEndTests(ITestOutputHelper output) : IDisposable
+    public sealed partial class CosmosDBEndToEndTests(ITestOutputHelper output) : IDisposable
     {
         private const string DatabaseName = "E2EDb";
         private const string CollectionName = "E2ECollection";
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests
             }
 
             public static void Trigger(
-                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "ciTrigger")]IReadOnlyList<Item> documents,
+                [CosmosDBTrigger(DatabaseName, CollectionName, CreateLeaseContainerIfNotExists = true, LeaseContainerPrefix = "ciTrigger")] IReadOnlyList<Item> documents,
                 ILogger log)
             {
                 foreach (var document in documents)


### PR DESCRIPTION
`AllVersionsAndDelete` mode requires customers wrap their bound POCO in `ChangeFeedItem<>` as this is how Microsoft.Azure.Cosmos supplies these values. However, when a binding does have that type it then influences the `<T>` of the listener, which means we end up binding to `ChangeFeedItem<ChangeFeedItem<T>>` (bad!) when creating the change feed listener. To address this we need to use reflection to:

1. Validate in `AllVersionsAndDelete` mode the type is `ChangeFeedItem<T>`
2. Unwrap that generic type and create a listener with just `T`. Which then results in CosmosDB supplying `ChangeFeedItem<T>`, which is what we want.