### PR TITLE
Update Cosmos and Extensions

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.13.0</VersionPrefix>
+    <VersionPrefix>4.14.0</VersionPrefix>
     <VersionSuffix Condition="'$(Preview)' == 'true'">preview.1</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.55.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Preview)' == 'true'">
-    <PackageReference Update="Microsoft.Azure.Cosmos" Version="3.55.0-preview.1" />
+    <PackageReference Update="Microsoft.Azure.Cosmos" Version="3.57.0-preview.0" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,5 +1,6 @@
-## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.0
 
-- Update Microsoft.Azure.Cosmos to 3.55.0 (#976)
+- Update Microsoft.Azure.Cosmos to 3.56.0 (#979)
+- Update Microsoft.Extensions.Azure to 1.13.1 (#979)
 
 **NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for CosmosDB preview service features.

--- a/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
@@ -1,5 +1,6 @@
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0-preview.1
 
 - Update Microsoft.Azure.Cosmos to 3.57.0-preview.0. (#979)
+- Update Microsoft.Extensions.Azure to 1.13.1 (#979)
 
 **NOTE**: The preview version of this package is released in parallel with the stable train. This follows Microsoft.Azure.Cosmos release model, where preview packages contain extra CosmosDB preview service features.

--- a/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes_preview.md
@@ -1,6 +1,5 @@
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.13.0-preview.1
 
-- Update Microsoft.Azure.Cosmos to 3.55.0-preview.1. (#976)
-- Fix type binding for `AllVersionsAndDelete` mode. Throw exception if type is not `ChangeFeedMode<T>`. (#976)
+- Update Microsoft.Azure.Cosmos to 3.57.0-preview.0. (#979)
 
 **NOTE**: The preview version of this package is released in parallel with the stable train. This follows Microsoft.Azure.Cosmos release model, where preview packages contain extra CosmosDB preview service features.


### PR DESCRIPTION
This pull request updates dependencies and versioning for the `WebJobs.Extensions.CosmosDB` project to ensure compatibility with the latest packages and to prepare for a new release.

Versioning updates:

* Bumped the `VersionPrefix` in `Directory.Version.props` from `4.13.0` to `4.14.0` to indicate a new release version.

Dependency updates:

* Updated `Microsoft.Azure.Cosmos` package reference from `3.55.0` to `3.56.0` for stable builds, and from `3.55.0-preview.1` to `3.57.0-preview.0` for preview builds in `WebJobs.Extensions.CosmosDB.csproj`.
* Updated `Microsoft.Extensions.Azure` package reference from `1.12.0` to `1.13.1` in `WebJobs.Extensions.CosmosDB.csproj` as [1.12.0](https://www.nuget.org/packages/Microsoft.Extensions.Azure/1.12.0) is deprecated.