### PR TITLE
Updates to remove IApplicationLifetime dependency

### DIFF
--- a/src/WebJobs.Extensions.Http/Directory.Version.props
+++ b/src/WebJobs.Extensions.Http/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.2.1</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.Http/HttpBindingApplicationBuilderExtension.cs
+++ b/src/WebJobs.Extensions.Http/HttpBindingApplicationBuilderExtension.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         /// <param name="applicationLifetime">The application lifetime instance.</param>
         /// <param name="routes">A route configuration handler.</param>
         /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
+        [Obsolete("This method is obsolete. Use UseHttpBindingRouting instead.")]
         public static IApplicationBuilder UseHttpBinding(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
-            => UseHttpBindingRouting(builder, applicationLifetime, routes);
+            => UseHttpBindingRouting(builder, routes);
 
         /// <summary>
         /// Adds the WebJobs HTTP Binding routing feature to the <seealso cref="IApplicationBuilder"/> execution pipeline.
@@ -29,11 +30,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         /// <param name="applicationLifetime">The application lifetime instance.</param>
         /// <param name="routes">A route configuration handler.</param>
         /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
+        [Obsolete("This overload of UseHttpBindingRouting is obsolete.")]
         public static IApplicationBuilder UseHttpBindingRouting(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
+            => UseHttpBindingRouting(builder, routes);
+
+        /// <summary>
+        /// Adds the WebJobs HTTP Binding routing feature to the <seealso cref="IApplicationBuilder"/> execution pipeline.
+        /// </summary>
+        /// <param name="builder">The application builder.</param>
+        /// <param name="routes">A route configuration handler.</param>
+        /// <returns>The updated <see cref="IApplicationBuilder"/>.</returns>
+        public static IApplicationBuilder UseHttpBindingRouting(this IApplicationBuilder builder, Action<WebJobsRouteBuilder> routes)
         {
             var router = builder.ApplicationServices.GetRequiredService<IWebJobsRouter>();
 
-            if (routes != null)
+            if (routes is not null)
             {
                 var routeHandler = builder.ApplicationServices.GetRequiredService<IWebJobsRouteHandler>();
 

--- a/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
+++ b/src/WebJobs.Extensions.Http/WebJobs.Extensions.Http.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.44" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Extensions.Http/release_notes.md
+++ b/src/WebJobs.Extensions.Http/release_notes.md
@@ -1,1 +1,3 @@
-## Microsoft.Azure.WebJobs.Extensions.Http <version>
+## Microsoft.Azure.WebJobs.Extensions.Http 3.3.0
+
+- Obsoleted `HttpBindingApplicationBuilderExtension.UseHttpBinding` and the `HttpBindingApplicationBuilderExtension.UseHttpBindingRouting` with a dependency on `Microsoft.AspNetCore.Hosting.IApplicationLifetime`


### PR DESCRIPTION
This pull request updates the `WebJobs.Extensions.Http` package to version 3.3.0 and introduces changes to the HTTP binding extension methods, primarily by deprecating overloads that depend on `IApplicationLifetime`. It also updates several package dependencies to newer versions for improved compatibility and maintenance.

### API Changes (Obsoleting Overloads)
* Marked `UseHttpBinding` and the overload of `UseHttpBindingRouting` that accepts `IApplicationLifetime` as obsolete, signaling developers to migrate to the new overloads that do not require `IApplicationLifetime`. [[1]](diffhunk://#diff-1e8cc4b1bafa0ae1708eeb0ab617f3f6865d8b46d0541e6007c2e1457c34fbedR22-R24) [[2]](diffhunk://#diff-1e8cc4b1bafa0ae1708eeb0ab617f3f6865d8b46d0541e6007c2e1457c34fbedR33-R47)
* Added a new overload for `UseHttpBindingRouting` that does not require `IApplicationLifetime`, simplifying the API surface.

### Dependency Updates
* Updated NuGet package dependencies in `WebJobs.Extensions.Http.csproj` to newer versions for ASP.NET Core and Azure WebJobs libraries, improving security and compatibility.

### Versioning and Documentation
* Bumped the package version to 3.3.0 in `Directory.Version.props` and updated the release notes to reflect the API deprecations. [[1]](diffhunk://#diff-4fd42fd00892a843c851818f537e98e753b3f4eadcc5b0adf03f03e1919eff88L3-R3) [[2]](diffhunk://#diff-4bded74f70a8017b27b84a10a41dd8e7afd9a1e55631c42e69130cef2a4e47d1L1-R3)