### PR TITLE
Bump CosmosDB extension to 4.14.1 with release notes

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.14.0</VersionPrefix>
+    <VersionPrefix>4.14.1</VersionPrefix>
     <VersionSuffix Condition="'$(Preview)' == 'true'">preview.1</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,6 +1,6 @@
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.1
 
-- Fix CosmosClient memory leak in CosmosDbScalerProvider by implementing IDisposable (#981)
+- Fix CosmosClient memory leak in CosmosDbScalerProvider by implementing IDisposable (#988)
 
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.0
 

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,3 +1,7 @@
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.1
+
+- Fix CosmosClient memory leak in CosmosDbScalerProvider by implementing IDisposable (#981)
+
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.0
 
 - Update Microsoft.Azure.Cosmos to 3.56.0 (#979)


### PR DESCRIPTION
Version bump for the CosmosClient memory leak fix in CosmosDbScalerProvider.