### PR TITLE
Bump CosmosDB extension to 4.15.0 with release notes

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.14.1</VersionPrefix>
+    <VersionPrefix>4.15.0</VersionPrefix>
     <VersionSuffix Condition="'$(Preview)' == 'true'">preview.1</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBMetricsProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
         private readonly Container _leaseContainer;
         private readonly string _processorName;
         private readonly int _maxAssignWorkerOnNotFoundCount = 5;
+        private readonly string _functionId;
         private int _assignWorkerOnNotFoundCount = 0;
 
         private static readonly Dictionary<string, string> KnownDocumentClientErrors = new Dictionary<string, string>()
@@ -34,12 +36,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             { "The specified document collection is invalid", string.Empty }
         };
 
-        public CosmosDBMetricsProvider(ILogger logger, Container monitoredContainer, Container leaseContainer, string processorName)
+        public CosmosDBMetricsProvider(ILogger logger, Container monitoredContainer, Container leaseContainer, string processorName, string functionId)
         {
             _logger = logger;
             _monitoredContainer = monitoredContainer;
             _leaseContainer = leaseContainer;
             _processorName = processorName;
+            _functionId = functionId;
         }
 
         public async Task<CosmosDBTriggerMetrics> GetMetricsAsync()
@@ -65,7 +68,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 {
                     partitionCount = 1;
                     remainingWork = 1;
-                    _logger.LogWarning(Events.OnScaling, "PartitionCount is 0, the lease container exists but it has not been initialized, scale out to 1 and wait for the first execution.");
+                    _logger.LogFunctionScaleWarning("PartitionCount is 0, the lease container exists but it has not been initialized, scale out to 1 and wait for the first execution.",
+                        _functionId, null);
                 }
                 else
                 {
@@ -88,8 +92,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 // However, it could also signal an issue with the monitoring container configuration.
                 // As a result, we make a limited number of attempts to create the lease container.
                 _assignWorkerOnNotFoundCount++;
-                _logger.LogWarning(Events.OnScaling, $"Possible non-exiting lease container detected. Trying to create the lease container, attempt '{_assignWorkerOnNotFoundCount}'",
-                    cosmosException.GetType().ToString(), cosmosException.Message);
+                _logger.LogFunctionScaleWarning($"Possible non-exiting lease container detected. Trying to create the lease container, attempt '{_assignWorkerOnNotFoundCount}'",
+                    _functionId, cosmosException);
                 partitionCount = 1;
                 remainingWork = 1;
             }
@@ -97,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             {
                 if (!TryHandleCosmosException(e))
                 {
-                    _logger.LogWarning(Events.OnScaling, "Unable to handle {0}: {1}", e.GetType().ToString(), e.Message);
+                    _logger.LogFunctionScaleWarning("Unable to handle CosmosDB exception during scaling metrics retrieval.", _functionId, e);
                     if (e is InvalidOperationException)
                     {
                         throw;
@@ -106,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             }
             catch (System.Net.Http.HttpRequestException e)
             {
-                string errormsg;
+                string errorMessage;
 
                 var webException = e.InnerException as WebException;
                 if (webException != null &&
@@ -114,23 +118,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 {
                     string statusCode = ((HttpWebResponse)webException.Response).StatusCode.ToString();
                     string statusDesc = ((HttpWebResponse)webException.Response).StatusDescription;
-                    errormsg = string.Format("CosmosDBTrigger status {0}: {1}.", statusCode, statusDesc);
+                    errorMessage = string.Format("CosmosDBTrigger status {0}: {1}.", statusCode, statusDesc);
                 }
                 else if (webException != null &&
                     webException.Status == WebExceptionStatus.NameResolutionFailure)
                 {
-                    errormsg = string.Format("CosmosDBTrigger Exception message: {0}.", webException.Message);
+                    errorMessage = string.Format("CosmosDBTrigger Exception message: {0}.", webException.Message);
                 }
                 else
                 {
-                    errormsg = e.ToString();
+                    errorMessage = e.ToString();
                 }
 
-                _logger.LogWarning(Events.OnScaling, errormsg);
+                _logger.LogFunctionScaleWarning(errorMessage, _functionId, e);
             }
             catch (Exception e)
             {
-                _logger.LogWarning(Events.OnScaling, "Exception occurred while obtaining metrics for CosmosDB {0}: {1}.", e.GetType().ToString(), e.ToString());
+                _logger.LogFunctionScaleWarning($"Exception occurred while obtaining metrics for CosmosDB.", _functionId, e);
             }
 
             return new CosmosDBTriggerMetrics
@@ -144,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
         // Since all exceptions in the Cosmos client are thrown as CosmosExceptions, we have to parse their error strings because we dont have access to the internal types
         private bool TryHandleCosmosException(Exception exception)
         {
-            string errormsg = null;
+            string errorMessage = null;
             string exceptionMessage = exception.Message;
 
             if (!string.IsNullOrEmpty(exceptionMessage))
@@ -153,14 +157,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
                 {
                     if (exceptionMessage.IndexOf(exceptionString.Key, StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        errormsg = !string.IsNullOrEmpty(exceptionString.Value) ? exceptionString.Value : exceptionMessage;
+                        errorMessage = !string.IsNullOrEmpty(exceptionString.Value) ? exceptionString.Value : exceptionMessage;
                     }
                 }
             }
 
-            if (!string.IsNullOrEmpty(errormsg))
+            if (!string.IsNullOrEmpty(errorMessage))
             {
-                _logger.LogWarning(errormsg);
+                _logger.LogFunctionScaleWarning(errorMessage, _functionId, exception);
                 return true;
             }
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBScaleMonitor.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBScaleMonitor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             _functionId = functionId;
             _monitoredContainer = monitoredContainer;
             _scaleMonitorDescriptor = new ScaleMonitorDescriptor($"{_functionId}-CosmosDBTrigger-{_monitoredContainer.Database.Id}-{_monitoredContainer.Id}".ToLower(), _functionId);
-            _cosmosDBMetricsProvider = new CosmosDBMetricsProvider(logger, monitoredContainer, leaseContainer, processorName);
+            _cosmosDBMetricsProvider = new CosmosDBMetricsProvider(logger, monitoredContainer, leaseContainer, processorName, functionId);
         }
 
         public ScaleMonitorDescriptor Descriptor => _scaleMonitorDescriptor;

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTargetScaler.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTargetScaler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
             _functionId = functionId;
             _targetScalerDescriptor = new TargetScalerDescriptor(functionId);
             _monitoredContainer = monitoredContainer;
-            _cosmosDBMetricsProvider = new CosmosDBMetricsProvider(logger, _monitoredContainer, leaseContainer, processorName);
+            _cosmosDBMetricsProvider = new CosmosDBMetricsProvider(logger, _monitoredContainer, leaseContainer, processorName, _functionId);
             _logger = logger;
             _maxItemsPerInvocation = maxItemsPerInvocation;
         }
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Trigger
 
             if (concurrency <= 0)
             {
-                _logger.LogWarning($"Concurrency value for target based scale must be greater than 0. Using default value of {DefaultMaxItemsPerInvocation} as concurrency value.");
+                _logger.LogFunctionScaleWarning($"Concurrency value for target based scale must be greater than 0. Using default value of {DefaultMaxItemsPerInvocation} as concurrency value.", _functionId, null);
                 concurrency = DefaultMaxItemsPerInvocation;
             }
 

--- a/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
+++ b/src/WebJobs.Extensions.CosmosDB/WebJobs.Extensions.CosmosDB.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.42" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.44" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,10 +1,6 @@
-## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.1
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.15.0
 
-- Fix CosmosClient memory leak in CosmosDbScalerProvider by implementing IDisposable (#988)
-
-## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.0
-
-- Update Microsoft.Azure.Cosmos to 3.56.0 (#979)
-- Update Microsoft.Extensions.Azure to 1.13.1 (#979)
+- Replace scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics (#975)
+- Update Microsoft.Azure.WebJobs to 3.0.44 (#975)
 
 **NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for CosmosDB preview service features.

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,6 +1,6 @@
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.15.0
 
-- Replace scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics (#975)
-- Update Microsoft.Azure.WebJobs to 3.0.44 (#975)
+- Replace scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics (#994)
+- Update Microsoft.Azure.WebJobs to 3.0.44 (#994)
 
 **NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for CosmosDB preview service features.

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBMetricsProviderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBMetricsProviderTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
                 .Setup(m => m.GetChangeFeedEstimator(It.Is<string>(s => s == ProcessorName), It.Is<Container>(c => c == _leasesContainer.Object)))
                 .Returns(estimator.Object);
 
-            _cosmosDbMetricsProvider = new CosmosDBMetricsProvider(_loggerFactory.CreateLogger<CosmosDBMetricsProviderTests>(), _monitoredContainer.Object, _leasesContainer.Object, ProcessorName);
+            _cosmosDbMetricsProvider = new CosmosDBMetricsProvider(_loggerFactory.CreateLogger<CosmosDBMetricsProviderTests>(), _monitoredContainer.Object, _leasesContainer.Object, ProcessorName, "testFunctionId");
         }
 
         [Fact]
@@ -145,13 +145,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             Assert.NotEqual(default(DateTime), metrics.Timestamp);
 
             var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.StartsWith("Possible non-exiting lease container detected. Trying to create the lease container, attempt", warning.FormattedMessage);
+            Assert.StartsWith("Function 'testFunctionId' warning: Possible non-exiting lease container detected. Trying to create the lease container, attempt", warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await _cosmosDbMetricsProvider.GetMetricsAsync());
 
             warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.Equal("Unable to handle System.InvalidOperationException: Unknown", warning.FormattedMessage);
+            Assert.Equal("Function 'testFunctionId' warning: Unable to handle CosmosDB exception during scaling metrics retrieval.", warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
 
             metrics = (CosmosDBTriggerMetrics)await _cosmosDbMetricsProvider.GetMetricsAsync();
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             Assert.NotEqual(default(DateTime), metrics.Timestamp);
 
             warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.Equal("CosmosDBTrigger Exception message: Uh oh again.", warning.FormattedMessage);
+            Assert.Equal("Function 'testFunctionId' warning: CosmosDBTrigger Exception message: Uh oh again.", warning.FormattedMessage);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Bump CosmosDB extension version to **4.15.0** for release.

## Changes

- Replace scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics
- Update `Microsoft.Azure.WebJobs` to 3.0.44

## Files Changed

| File | Change |
|---|---|
| `Directory.Version.props` | 4.14.1 → 4.15.0 |
| `release_notes.md` | New 4.15.0 section |
| `WebJobs.Extensions.CosmosDB.csproj` | `Microsoft.Azure.WebJobs` 3.0.42 → 3.0.44 |
| `CosmosDBMetricsProvider.cs` | Replace `LogWarning` with `LogFunctionScaleWarning` |
| `CosmosDBScaleMonitor.cs` | Pass functionId to MetricsProvider |
| `CosmosDBTargetScaler.cs` | Same logging replacement + pass functionId |
| `CosmosDBMetricsProviderTests.cs` | Updated constructor calls |

## Testing

- Unit tests updated to match new constructor signature
- Logging behavior change is non-breaking (internal implementation only)