### PR TITLE
Bump CosmosDB extension to 4.15.0 with release notes

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.14.1</VersionPrefix>
+    <VersionPrefix>4.15.0</VersionPrefix>
     <VersionSuffix Condition="'$(Preview)' == 'true'">preview.1</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,3 +1,8 @@
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.15.0
+
+- Replace scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics
+- Update Microsoft.Azure.WebJobs to 3.0.44
+
 ## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.14.1
 
 - Fix CosmosClient memory leak in CosmosDbScalerProvider by implementing IDisposable (#988)


### PR DESCRIPTION
Version bump for the scaling logs standardization change.

Changes:
- Replace scaling warning/error log calls with standardized LogFunctionScaleWarning extension method to enable Scale Controller App Insights diagnostics
- Update Microsoft.Azure.WebJobs to 3.0.44