### PR TITLE
Honor CancellationToken in StorageScheduleMonitor

### DIFF
--- a/src/WebJobs.Extensions.Timers.Storage/Directory.Version.props
+++ b/src/WebJobs.Extensions.Timers.Storage/Directory.Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.Timers.Storage/StorageScheduleMonitor.cs
+++ b/src/WebJobs.Extensions.Timers.Storage/StorageScheduleMonitor.cs
@@ -89,14 +89,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         }
 
         /// <inheritdoc/>
-        public override async Task<ScheduleStatus> GetStatusAsync(string timerName)
+        public override Task<ScheduleStatus> GetStatusAsync(string timerName)
+            => GetStatusAsync(timerName, CancellationToken.None);
+
+        /// <inheritdoc/>
+        public override async Task<ScheduleStatus> GetStatusAsync(string timerName, CancellationToken cancellationToken)
         {
-            BlobClient statusBlobClient = await GetStatusBlobClient(timerName, createContainerIfNotExists: false);
+            BlobClient statusBlobClient = await GetStatusBlobClient(timerName, createContainerIfNotExists: false, cancellationToken);
 
             try
             {
                 string statusLine;
-                var downloadResponse = await statusBlobClient.DownloadAsync();
+                var downloadResponse = await statusBlobClient.DownloadAsync(cancellationToken);
                 using (StreamReader reader = new StreamReader(downloadResponse.Value.Content))
                 {
                     statusLine = reader.ReadToEnd();
@@ -121,7 +125,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
         }
 
         /// <inheritdoc/>
-        public override async Task UpdateStatusAsync(string timerName, ScheduleStatus status)
+        public override Task UpdateStatusAsync(string timerName, ScheduleStatus status)
+            => UpdateStatusAsync(timerName, status, CancellationToken.None);
+
+        /// <inheritdoc/>
+        public override async Task UpdateStatusAsync(string timerName, ScheduleStatus status, CancellationToken cancellationToken)
         {
             string statusLine;
             using (StringWriter stringWriter = new StringWriter())
@@ -132,10 +140,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
 
             try
             {
-                BlobClient statusBlobClient = await GetStatusBlobClient(timerName, createContainerIfNotExists: true);
+                BlobClient statusBlobClient = await GetStatusBlobClient(timerName, createContainerIfNotExists: true, cancellationToken);
                 using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(statusLine)))
                 {
-                    await statusBlobClient.UploadAsync(stream, overwrite: true);
+                    await statusBlobClient.UploadAsync(stream, overwrite: true, cancellationToken);
                 }
             }
             catch (Exception ex)
@@ -145,14 +153,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
             }
         }
 
-        private async Task<BlobClient> GetStatusBlobClient(string timerName, bool createContainerIfNotExists = false)
+        private async Task<BlobClient> GetStatusBlobClient(string timerName, bool createContainerIfNotExists, CancellationToken cancellationToken)
         {
             // Path to the status blob is:
             // timers/{hostId}/{timerName}/status
             string blobName = string.Format("{0}/{1}/status", TimerStatusPath, timerName);
             if (createContainerIfNotExists)
             {
-                await ContainerClient.CreateIfNotExistsAsync();
+                await ContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
             }
 
             return ContainerClient.GetBlobClient(blobName);

--- a/src/WebJobs.Extensions.Timers.Storage/WebJobs.Extensions.Timers.Storage.csproj
+++ b/src/WebJobs.Extensions.Timers.Storage/WebJobs.Extensions.Timers.Storage.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.3.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/WebJobs.Extensions.Timers.Storage/release_notes.md
+++ b/src/WebJobs.Extensions.Timers.Storage/release_notes.md
@@ -1,1 +1,4 @@
 ## Microsoft.Azure.WebJobs.Extensions.Timers.Storage <version>
+
+- Updated `StorageScheduleMonitor` to honor the `CancellationToken` flowed from `TimerListener` through the new `ScheduleMonitor` overloads in `Microsoft.Azure.WebJobs.Extensions` 5.3.0. Blob `DownloadAsync`, `UploadAsync`, and `CreateIfNotExistsAsync` calls now observe the token, preventing host startup from hanging indefinitely (for example, on AAD token acquisition stalls) and holding the singleton listener lock.
+- Bumped the `Microsoft.Azure.WebJobs.Extensions` dependency from 5.0.0 to 5.3.0.


### PR DESCRIPTION
🚫 **Blocked on #991** — depends on `Microsoft.Azure.WebJobs.Extensions` 5.3.0 being published to NuGet (the Storage package consumes Extensions as a `PackageReference`, so CI restore will fail until then).

## Bug

In production (ICM IN_50069), an instance acquired the timer's singleton listener lock at 01:06:40 but never started the timer listener. It held the lock for ~1.5 hours, blocking every other instance from running the timer, until the instance was recycled.

Root cause: `StorageScheduleMonitor.GetStatusAsync` calls `BlobClient.DownloadAsync` without a `CancellationToken`. When AAD token acquisition (`BearerTokenAuthenticationPolicy.GetHeaderValueAsync`) hung, there was nothing to cancel it. `SingletonListener` (in WebJobs SDK) holds its lock around the inner listener's `StartAsync`, so the hang held the singleton lock until process exit.

## Fix

This is the second of two PRs. The first (#991) added `CancellationToken` overloads to `ScheduleMonitor` and made `TimerListener` flow its own token through them. This PR overrides the new overloads in `StorageScheduleMonitor` so the token reaches the underlying blob calls.

- `GetStatusAsync(string, CancellationToken)`: passes the token to `BlobClient.DownloadAsync`.
- `UpdateStatusAsync(string, ScheduleStatus, CancellationToken)`: passes the token to `BlobClient.UploadAsync` and `BlobContainerClient.CreateIfNotExistsAsync`.
- The original no-token overrides now delegate to the new overloads with `CancellationToken.None` so direct callers continue to work.

## Versioning

- `Microsoft.Azure.WebJobs.Extensions.Timers.Storage`: 1.1.0 → 1.2.0
- `Microsoft.Azure.WebJobs.Extensions` dependency bumped from 5.0.0 to 5.3.0

## Merging

Merge after `Microsoft.Azure.WebJobs.Extensions` 5.3.0 (#991) is published to NuGet.