### PR TITLE
fix(cosmos): worker-shim binding for ChangeFeedMode.AllVersionsAndDeletes

### DIFF
--- a/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
+++ b/src/WebJobs.Extensions.CosmosDB/Directory.Version.props
@@ -1,6 +1,10 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.16.0</VersionPrefix>
-    <VersionSuffix Condition="'$(Preview)' == 'true'">preview.1</VersionSuffix>
+    <VersionPrefix>4.16.1</VersionPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Preview)' == 'true'">
+    <VersionPrefix>4.17.0</VersionPrefix>
+    <VersionSuffix>preview.1</VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerAttributeBindingProviderGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
@@ -57,6 +58,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
             if (typeof(string).IsAssignableFrom(documentType))
             {
                 documentType = typeof(JObject);
+            }
+
+            // For out-of-process (worker) functions in AllVersionsAndDeletes mode, the parameter
+            // type surfaced to the host is the raw payload (JObject - after the JArray/string
+            // collapse above) rather than the worker's actual ChangeFeedItem<T> binding. Wrap so
+            // downstream type contracts (TriggerValueType, value binder, listener) all agree on
+            // ChangeFeedItem<JObject>. Intentionally NOT shimming arbitrary user POCOs: those are
+            // in-proc bindings where the user is expected to declare ChangeFeedItem<T> directly,
+            // and the listener's type guard will produce a clear InvalidOperationException at
+            // startup if they don't.
+            if (cosmosDBTriggerAttribute.ChangeFeedMode == CosmosDBChangeFeedMode.AllVersionsAndDeletes
+                && documentType == typeof(JObject))
+            {
+                documentType = typeof(ChangeFeedItem<JObject>);
             }
 
             Type baseType = typeof(CosmosDBTriggerAttributeBindingProvider<>);

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerBinding.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
 
         public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
         {
-            IValueProvider valueBinder = new CosmosDBTriggerValueBinder(_parameter, value);
+            IValueProvider valueBinder = new CosmosDBTriggerValueBinder(_parameter, value, _cosmosDBAttribute);
             return Task.FromResult<ITriggerData>(new TriggerData(valueBinder, _emptyBindingData));
         }
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosDBTriggerListener.cs
@@ -265,10 +265,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private ChangeFeedProcessorBuilder GetAllVersionsAndDeleteBuilder()
         {
             // We need to unwrap T from ChangeFeedItem<T> to T, and then construct a builder from that.
+            // For out-of-process functions the binding-provider generator wraps the default JObject
+            // payload into ChangeFeedItem<JObject> before reaching this listener, so by the time
+            // we're here T is always ChangeFeedItem<>. Any other T is an in-proc user mistake
+            // (e.g. IReadOnlyList<MyDocument> instead of IReadOnlyList<ChangeFeedItem<MyDocument>>);
+            // throw early with a clear error rather than silently produce malformed bindings.
             Type itemType = typeof(T);
             if (!itemType.IsGenericType || itemType.GetGenericTypeDefinition() != typeof(ChangeFeedItem<>))
             {
-                // Type does not match ChangeFeedItem<T>, this is an invalid binding for AllVersionsAndDeletes.
                 throw new InvalidOperationException($"When using ChangeFeedMode.AllVersionsAndDeletes, the trigger binding type must be Microsoft.Azure.Cosmos.ChangeFeedItem<T>. Actual type: '{itemType.FullName}'.");
             }
 

--- a/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosdbTriggerValueBinder.cs
+++ b/src/WebJobs.Extensions.CosmosDB/Trigger/CosmosdbTriggerValueBinder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,16 +18,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
         private readonly ParameterInfo _parameter;
         private readonly bool _isJArray;
         private readonly bool _isString;
+        private readonly bool _isAllVersionsAndDeletes;
 
         public CosmosDBTriggerValueBinder(
             ParameterInfo parameter, 
-            object value)
+            object value,
+            CosmosDBTriggerAttribute cosmosDBAttribute = null)
         {
             _value = value;
             _parameter = parameter;
             Type parameterType = CosmosDBTriggerAttributeBindingProviderGenerator.GetParameterType(parameter);
             _isJArray = parameterType.IsAssignableFrom(typeof(JArray));
             _isString = parameterType.IsAssignableFrom(typeof(string));
+            _isAllVersionsAndDeletes = cosmosDBAttribute?.ChangeFeedMode == CosmosDBChangeFeedMode.AllVersionsAndDeletes;
         }
 
         public Type Type
@@ -36,7 +40,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB
                 if (_isJArray 
                     || _isString)
                 {
-                    return typeof(IReadOnlyCollection<JObject>);
+                    // In AllVersionsAndDeletes mode the host receives ChangeFeedItem<JObject>
+                    // from the change feed processor rather than raw JObjects.
+                    return _isAllVersionsAndDeletes
+                        ? typeof(IReadOnlyCollection<ChangeFeedItem<JObject>>)
+                        : typeof(IReadOnlyCollection<JObject>);
                 }
 
                 return _parameter.ParameterType;

--- a/src/WebJobs.Extensions.CosmosDB/release_notes.md
+++ b/src/WebJobs.Extensions.CosmosDB/release_notes.md
@@ -1,6 +1,5 @@
-## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.16.0
+## Microsoft.Azure.WebJobs.Extensions.CosmosDB 4.16.1
 
-- feat: add support for `AllVersionsAndDelete` changefeed mode. (#999)
-- feat: update Microsoft.Azure.Cosmos to 3.60.0 (#999)
+- fix: wrap worker-default trigger type as ChangeFeedItem<JObject> for AllVersionsAndDeletes (#1000)
 
 **NOTE**: The stable version of this package does not include CosmosDB preview features. Use the `-preview` versions of this package for CosmosDB preview service features.

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBListenerTests.cs
@@ -108,6 +108,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests.Trigger
             Assert.Contains(_logDetails, logs[3].FormattedMessage);
         }
 
+        [Fact]
+        public async Task StartAsync_AllVersionsAndDeletes_NonChangeFeedItemType_Throws()
+        {
+            // The generator's AVAD shim intentionally does NOT wrap user-defined POCO bindings
+            // (only the worker-default JObject shape gets wrapped). For in-proc users who forget
+            // the ChangeFeedItem<T> wrapper, the listener's startup guard surfaces a clear
+            // InvalidOperationException rather than silently producing a malformed binding.
+            var attribute = new CosmosDBTriggerAttribute(DatabaseName, ContainerName)
+            {
+                ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes
+            };
+
+            var listener = new CosmosDBTriggerListener<MyDocument>(
+                _mockExecutor.Object,
+                _functionId,
+                ProcessorName,
+                _monitoredContainer.Object,
+                _leasesContainer.Object,
+                attribute,
+                Mock.Of<IDrainModeManager>(),
+                _loggerFactory.CreateLogger<CosmosDBTriggerListener<MyDocument>>());
+
+            InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => listener.StartAsync(CancellationToken.None));
+
+            Assert.Contains("ChangeFeedMode.AllVersionsAndDeletes", ex.Message);
+            Assert.Contains("Microsoft.Azure.Cosmos.ChangeFeedItem<T>", ex.Message);
+            Assert.Contains(typeof(MyDocument).FullName, ex.Message);
+        }
+
+        public class MyDocument
+        {
+            public string Id { get; set; }
+        }
+
         private class MockListener<T> : CosmosDBTriggerListener<T>
         {
             private int _retries = 0;

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderGeneratorTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerAttributeBindingProviderGeneratorTests.cs
@@ -1,0 +1,211 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
+using Microsoft.Azure.WebJobs.Extensions.CosmosDB.Tests;
+using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
+{
+    /// <summary>
+    /// Targets the AVAD type-shim behavior of <see cref="CosmosDBTriggerAttributeBindingProviderGenerator"/>:
+    /// when <see cref="CosmosDBTriggerAttribute.ChangeFeedMode"/> is AllVersionsAndDeletes, the resolved
+    /// document type used to construct <see cref="CosmosDBTriggerBinding{T}"/> must be wrapped in
+    /// <see cref="ChangeFeedItem{T}"/> so that the trigger value type the host advertises matches what
+    /// the change feed processor actually delivers.
+    /// </summary>
+    public class CosmosDBTriggerAttributeBindingProviderGeneratorTests
+    {
+        private readonly ILoggerFactory _loggerFactory = new LoggerFactory();
+        private readonly IDrainModeManager _drainModeManager = Mock.Of<IDrainModeManager>();
+        private readonly CosmosDBOptions _options = new CosmosDBOptions();
+        private static readonly IConfiguration _baseConfig = CosmosDBTestUtility.BuildConfiguration(
+        [
+            Tuple.Create(Constants.DefaultConnectionStringName, "AccountEndpoint=https://fromEnvironment;AccountKey=c29tZV9rZXk=;")
+        ]);
+
+        [Fact]
+        public async Task TryCreateAsync_LatestVersion_JArray_ProducesJObjectBinding()
+        {
+            // Baseline: existing behavior - JArray parameter resolves to CosmosDBTriggerBinding<JObject>.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.JArrayLatestVersion));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.IsType<CosmosDBTriggerBinding<JObject>>(binding);
+            Assert.Equal(typeof(IReadOnlyCollection<JObject>), binding.TriggerValueType);
+        }
+
+        [Fact]
+        public async Task TryCreateAsync_LatestVersion_StronglyTyped_ProducesUserTypeBinding()
+        {
+            // Baseline: existing behavior - typed parameter resolves to CosmosDBTriggerBinding<MyDocument>.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.TypedLatestVersion));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.IsType<CosmosDBTriggerBinding<MyDocument>>(binding);
+            Assert.Equal(typeof(IReadOnlyCollection<MyDocument>), binding.TriggerValueType);
+        }
+
+        [Fact]
+        public async Task TryCreateAsync_AllVersionsAndDeletes_JArray_WrapsInChangeFeedItem()
+        {
+            // The AVAD shim: a JArray-bound parameter under AllVersionsAndDeletes mode must produce
+            // CosmosDBTriggerBinding<ChangeFeedItem<JObject>> so the value flowing through the host
+            // matches what GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes emits.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.JArrayAllVersionsAndDeletes));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.IsType<CosmosDBTriggerBinding<ChangeFeedItem<JObject>>>(binding);
+            Assert.Equal(typeof(IReadOnlyCollection<ChangeFeedItem<JObject>>), binding.TriggerValueType);
+        }
+
+        [Fact]
+        public async Task TryCreateAsync_AllVersionsAndDeletes_String_WrapsInChangeFeedItem()
+        {
+            // String-bound parameter under AllVersionsAndDeletes mode follows the same shimming
+            // path as JArray (the generator collapses string -> JObject before the AVAD wrap).
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.StringAllVersionsAndDeletes));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.IsType<CosmosDBTriggerBinding<ChangeFeedItem<JObject>>>(binding);
+            Assert.Equal(typeof(IReadOnlyCollection<ChangeFeedItem<JObject>>), binding.TriggerValueType);
+        }
+
+        [Fact]
+        public async Task TryCreateAsync_AllVersionsAndDeletes_AlreadyChangeFeedItem_DoesNotDoubleWrap()
+        {
+            // If the user already binds to IReadOnlyList<ChangeFeedItem<MyDocument>>, the shim must
+            // detect the existing wrapper and produce CosmosDBTriggerBinding<ChangeFeedItem<MyDocument>>
+            // - NOT CosmosDBTriggerBinding<ChangeFeedItem<ChangeFeedItem<MyDocument>>>.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.TypedChangeFeedItemAllVersionsAndDeletes));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.IsType<CosmosDBTriggerBinding<ChangeFeedItem<MyDocument>>>(binding);
+            Assert.Equal(typeof(IReadOnlyCollection<ChangeFeedItem<MyDocument>>), binding.TriggerValueType);
+        }
+
+        [Fact]
+        public async Task TryCreateAsync_AllVersionsAndDeletes_StronglyTyped_DoesNotWrap()
+        {
+            // A user-defined POCO (e.g. IReadOnlyList<MyDocument>) under AVAD mode is treated as
+            // an in-proc user binding and is intentionally NOT wrapped. T flows through to the
+            // listener as MyDocument, where the listener's type guard surfaces a clear
+            // InvalidOperationException ("must be ChangeFeedItem<T>") - see
+            // CosmosDBListenerTests.StartAsync_AllVersionsAndDeletes_NonChangeFeedItemType_Throws.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.TypedAllVersionsAndDeletes));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.IsType<CosmosDBTriggerBinding<MyDocument>>(binding);
+            Assert.Equal(typeof(IReadOnlyCollection<MyDocument>), binding.TriggerValueType);
+        }
+
+        [Fact]
+        public async Task TryCreateAsync_NoAttribute_ReturnsNull()
+        {
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.NoTriggerAttribute));
+
+            ITriggerBinding binding = await CreateGenerator().TryCreateAsync(
+                new TriggerBindingProviderContext(parameter, CancellationToken.None));
+
+            Assert.Null(binding);
+        }
+
+        private CosmosDBTriggerAttributeBindingProviderGenerator CreateGenerator()
+        {
+            return new CosmosDBTriggerAttributeBindingProviderGenerator(
+                new TestNameResolver(),
+                _options,
+                CreateExtensionConfigProvider(_options, _baseConfig),
+                _drainModeManager,
+                _loggerFactory);
+        }
+
+        private static CosmosDBExtensionConfigProvider CreateExtensionConfigProvider(CosmosDBOptions options, IConfiguration config)
+        {
+            return new CosmosDBExtensionConfigProvider(
+                new OptionsWrapper<CosmosDBOptions>(options),
+                new DefaultCosmosDBServiceFactory(config, Mock.Of<AzureComponentFactory>()),
+                new DefaultCosmosDBSerializerFactory(),
+                new TestNameResolver(),
+                Mock.Of<IDrainModeManager>(),
+                NullLoggerFactory.Instance);
+        }
+
+        private static ParameterInfo GetFirstParameter(string methodName)
+        {
+            MethodInfo method = typeof(SampleFunctions).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            return method.GetParameters().First();
+        }
+
+        public class MyDocument
+        {
+            public string Id { get; set; }
+        }
+
+        private static class SampleFunctions
+        {
+            public static void JArrayLatestVersion(
+                [CosmosDBTrigger("aDatabase", "aCollection")] JArray docs)
+            {
+            }
+
+            public static void JArrayAllVersionsAndDeletes(
+                [CosmosDBTrigger("aDatabase", "aCollection", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] JArray docs)
+            {
+            }
+
+            public static void StringAllVersionsAndDeletes(
+                [CosmosDBTrigger("aDatabase", "aCollection", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] string docs)
+            {
+            }
+
+            public static void TypedLatestVersion(
+                [CosmosDBTrigger("aDatabase", "aCollection")] IReadOnlyList<MyDocument> docs)
+            {
+            }
+
+            public static void TypedAllVersionsAndDeletes(
+                [CosmosDBTrigger("aDatabase", "aCollection", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] IReadOnlyList<MyDocument> docs)
+            {
+            }
+
+            public static void TypedChangeFeedItemAllVersionsAndDeletes(
+                [CosmosDBTrigger("aDatabase", "aCollection", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] IReadOnlyList<ChangeFeedItem<MyDocument>> docs)
+            {
+            }
+
+            public static void NoTriggerAttribute(string docs)
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerValueBinderTests.cs
+++ b/test/WebJobs.Extensions.CosmosDB.Tests/Trigger/CosmosDBTriggerValueBinderTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.CosmosDBTrigger.Tests
+{
+    /// <summary>
+    /// Targets the AVAD type-shim behavior of <see cref="CosmosDBTriggerValueBinder"/>.
+    /// </summary>
+    public class CosmosDBTriggerValueBinderTests
+    {
+        [Fact]
+        public void Type_JArrayParameter_LatestVersion_ReturnsReadOnlyCollectionOfJObject()
+        {
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.JArrayLatestVersion));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll");
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: new JArray(), cosmosDBAttribute: attribute);
+
+            Assert.Equal(typeof(IReadOnlyCollection<JObject>), binder.Type);
+        }
+
+        [Fact]
+        public void Type_StringParameter_LatestVersion_ReturnsReadOnlyCollectionOfJObject()
+        {
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.StringLatestVersion));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll");
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: "[]", cosmosDBAttribute: attribute);
+
+            Assert.Equal(typeof(IReadOnlyCollection<JObject>), binder.Type);
+        }
+
+        [Fact]
+        public void Type_JArrayParameter_AllVersionsAndDeletes_ReturnsReadOnlyCollectionOfChangeFeedItem()
+        {
+            // The AVAD shim: when the function uses an untyped JArray binding but the trigger is
+            // in AllVersionsAndDeletes mode, the host's change feed processor delivers
+            // IReadOnlyCollection<ChangeFeedItem<JObject>>; the binder must surface that wrapped
+            // type so the runtime can flow the value through to the worker without a cast failure.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.JArrayAllVersionsAndDeletes));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll")
+            {
+                ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes
+            };
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: new JArray(), cosmosDBAttribute: attribute);
+
+            Assert.Equal(typeof(IReadOnlyCollection<ChangeFeedItem<JObject>>), binder.Type);
+        }
+
+        [Fact]
+        public void Type_StringParameter_AllVersionsAndDeletes_ReturnsReadOnlyCollectionOfChangeFeedItem()
+        {
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.StringAllVersionsAndDeletes));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll")
+            {
+                ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes
+            };
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: "[]", cosmosDBAttribute: attribute);
+
+            Assert.Equal(typeof(IReadOnlyCollection<ChangeFeedItem<JObject>>), binder.Type);
+        }
+
+        [Fact]
+        public void Type_TypedParameter_LatestVersion_ReturnsParameterType()
+        {
+            // Strongly-typed parameters bypass the JArray/string shim entirely; Type
+            // should reflect the user's declared parameter type as-is.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.TypedLatestVersion));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll");
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: new List<MyDocument>(), cosmosDBAttribute: attribute);
+
+            Assert.Equal(typeof(IReadOnlyList<MyDocument>), binder.Type);
+        }
+
+        [Fact]
+        public void Type_TypedParameter_AllVersionsAndDeletes_ReturnsParameterType()
+        {
+            // When the user already binds to IReadOnlyList<ChangeFeedItem<T>>, the AVAD shim
+            // should not interfere - the parameter type is already correct and the binder must
+            // not double-wrap into IReadOnlyCollection<ChangeFeedItem<...>>.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.TypedAllVersionsAndDeletes));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll")
+            {
+                ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes
+            };
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: new List<ChangeFeedItem<MyDocument>>(), cosmosDBAttribute: attribute);
+
+            Assert.Equal(typeof(IReadOnlyList<ChangeFeedItem<MyDocument>>), binder.Type);
+        }
+
+        [Fact]
+        public void Type_NullAttribute_Defaults_To_LatestVersion()
+        {
+            // The cosmosDBAttribute parameter is optional for backwards compatibility; a null
+            // attribute must not crash the Type getter and must behave as LatestVersion.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.JArrayLatestVersion));
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: new JArray());
+
+            Assert.Equal(typeof(IReadOnlyCollection<JObject>), binder.Type);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_AllVersionsAndDeletes_ReturnsJArrayValueUnchanged()
+        {
+            // GetValueAsync is unaffected by the AVAD shim - it still produces a JArray for
+            // JArray-bound parameters. Only the declared Type changes.
+            ParameterInfo parameter = GetFirstParameter(nameof(SampleFunctions.JArrayAllVersionsAndDeletes));
+            var attribute = new CosmosDBTriggerAttribute("db", "coll")
+            {
+                ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes
+            };
+            var payload = new JArray(new JObject { ["id"] = "1" });
+
+            var binder = new CosmosDBTriggerValueBinder(parameter, value: payload, cosmosDBAttribute: attribute);
+            object value = await binder.GetValueAsync();
+
+            var jArray = Assert.IsType<JArray>(value);
+            Assert.Single(jArray);
+            Assert.Equal("1", (string)jArray[0]["id"]);
+        }
+
+        private static ParameterInfo GetFirstParameter(string methodName)
+        {
+            MethodInfo method = typeof(SampleFunctions).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            return method.GetParameters().First();
+        }
+
+        public class MyDocument
+        {
+            public string Id { get; set; }
+        }
+
+        private static class SampleFunctions
+        {
+            public static void JArrayLatestVersion([CosmosDBTrigger("db", "coll")] JArray docs)
+            {
+            }
+
+            public static void JArrayAllVersionsAndDeletes(
+                [CosmosDBTrigger("db", "coll", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] JArray docs)
+            {
+            }
+
+            public static void StringLatestVersion([CosmosDBTrigger("db", "coll")] string docs)
+            {
+            }
+
+            public static void StringAllVersionsAndDeletes(
+                [CosmosDBTrigger("db", "coll", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] string docs)
+            {
+            }
+
+            public static void TypedLatestVersion([CosmosDBTrigger("db", "coll")] IReadOnlyList<MyDocument> docs)
+            {
+            }
+
+            public static void TypedAllVersionsAndDeletes(
+                [CosmosDBTrigger("db", "coll", ChangeFeedMode = CosmosDBChangeFeedMode.AllVersionsAndDeletes)] IReadOnlyList<ChangeFeedItem<MyDocument>> docs)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes `AllVersionsAndDeletes` support for out-of-proc workers. Previously the type-shimming checks (unwrapping from `ChangeFeedItem<T>` to `T` when creating the changefeed processor) would fail with out of proc. This is because OOP the binding comes in as type `JObject`, and the safeguard we have would fail that binding. The fix (hacky) is to check if the binding type is `JObject` (or some other known out-of-proc types) and the trigger is `AllVersionsAndDeletes`. If those are true, we wrap the type with `ChangeFeedItem<>`.

### Additional Changes

- Revs CosmosDB to `4.16.1`.
- Revs _preview_ CosmosDB to `4.17.0-preview.1`. We will be following what CosmosDB team themselves do: preview train is always 1 minor version ahead of stable. This conveys that preview is a superset of stable.

## AI Summary

### Worker-shim fix

Discovered while wiring the equivalent E2E flow on the dotnet-worker side: out-of-process functions surface their trigger payload to the host as `JObject` (the gRPC default), which did not match the `IReadOnlyCollection<ChangeFeedItem<JObject>>` that `GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes` actually delivers. The host hit a runtime cast failure on every invocation in that mode and the lease never advanced.

Changes:

- **`CosmosDBTriggerAttributeBindingProviderGenerator`** – when `ChangeFeedMode == AllVersionsAndDeletes` and the resolved `documentType` collapses to `JObject`, wrap it in `ChangeFeedItem<JObject>`. JObject is the only resolved shape worker functions can produce (after the existing `JArray`/`string` -> `JObject` collapse); strongly-typed in-proc parameters are left untouched.
- **`CosmosDBTriggerBinding<T>` + `CosmosDBTriggerValueBinder`** – plumb the `CosmosDBTriggerAttribute` through to the value binder so its `Type` getter can advertise `IReadOnlyCollection<ChangeFeedItem<JObject>>` in AVAD mode for the `JArray`/`string` parameter shapes. The new `cosmosDBAttribute` ctor parameter is optional (null = LatestVersion) for backwards compatibility.
- **`CosmosDBTriggerListener.GetAllVersionsAndDeleteBuilder`** – kept the original `InvalidOperationException` (`"must be Microsoft.Azure.Cosmos.ChangeFeedItem<T>"`) so in-proc users who forget the wrapper still get a clear fail-fast at host startup rather than a silent malformed binding. The generator's shim only handles the worker case; everything else flows through the existing guard.

Verified end-to-end against a real Cosmos account (continuous backup) using the dotnet-worker E2EApp – Create and Delete change feed events are delivered to the isolated function in 6 seconds.

### Tests

Added unit tests for the new behavior:

- `Trigger/CosmosDBTriggerAttributeBindingProviderGeneratorTests` (7 tests): all combinations of LatestVersion/AVAD x JArray/string/POCO/already-ChangeFeedItem, plus no-attribute fallthrough.
- `Trigger/CosmosDBTriggerValueBinderTests` (8 tests): the Type getter under each AVAD/non-AVAD x JArray/string/typed combination, null-attribute backwards compat, and a smoke test confirming `GetValueAsync` still returns the underlying JArray.
- `Trigger/CosmosDBListenerTests.StartAsync_AllVersionsAndDeletes_NonChangeFeedItemType_Throws` – asserts the in-proc enforcement still surfaces the original clear error.

All 163 non-E2E unit tests pass.
