### PR TITLE
Route dependency restores through Central Feed Service

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -32,6 +32,9 @@ jobs:
   steps:
     - template: /eng/ci/templates/steps/install-dotnet.yml@self
 
+    - task: NuGetAuthenticate@1
+      displayName: Authenticate NuGet
+
     - task: DotNetCoreCLI@2
       displayName: Restore
       inputs:

--- a/eng/ci/templates/steps/start-emulators.yml
+++ b/eng/ci/templates/steps/start-emulators.yml
@@ -1,10 +1,17 @@
 steps:
 
+- task: npmAuthenticate@0
+  displayName: Authenticate npm
+  inputs:
+    workingFile: $(Build.SourcesDirectory)/.npmrc
+
 - pwsh: |
     npm install -g azurite
     Start-Process azurite.cmd -ArgumentList "--silent --inMemoryPersistence"
     Write-Host "##vso[task.setvariable variable=Storage]UseDevelopmentStorage=true"
   displayName: Start azurite
+  env:
+    NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/.npmrc
 
 - pwsh: |
     Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"


### PR DESCRIPTION
## Summary
- route all NuGet restores through the `azfunc/public/upstream-public` CFS proxy and authenticate Azure Pipelines before restore
- route the pipeline Azurite install through an authenticated CFS npm configuration, including its consumed package scopes
- preserve customer-facing NuGet publishing references while removing direct public dependency sources from repository build paths

## Validation
- `dotnet restore WebJobs.Extensions.sln --force --no-cache -v minimal`
- `dotnet restore eng\sln\WebJobs.Extensions.Preview.proj --force --no-cache -v minimal`
- `dotnet build WebJobs.Extensions.sln --no-restore -v minimal`
- `dotnet build eng\sln\WebJobs.Extensions.Preview.proj --no-restore -v minimal`
- resolved Azurite metadata and its production dependency graph through the CFS npm registry